### PR TITLE
fix: install io extras in CI to provide pyarrow for parquet tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,io]"
 
       - name: Run tests
         run: pytest --cov=dccd --cov-report=term-missing --cov-report=xml


### PR DESCRIPTION
## Summary

- CI was installing `.[dev]` only, missing `pyarrow` from the `[io]` optional extras
- `test_get_last_date_parquet` was failing on all Python versions with `ImportError: Unable to find a usable engine`

## Fix

Change `pip install -e ".[dev]"` → `pip install -e ".[dev,io]"` so `pyarrow>=13` is present in the test environment.

## Test plan

- [x] Local `pytest` passes (parquet test verified locally with pyarrow)
- [ ] CI green