### PR TITLE
fix: correct interrogate badge filename and branch

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: update docstring coverage badge"
-          file_pattern: "interrogate_badge_output.svg"
+          file_pattern: "interrogate_badge.svg"

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Download Crypto-Currency Data
     :target: https://download-crypto-currencies-data.readthedocs.io/en/latest/
     :alt: Documentation Status
 
-.. image:: https://raw.githubusercontent.com/ArthurBernard/Download_Crypto_Currencies_Data/master/interrogate_badge_output.svg
+.. image:: https://raw.githubusercontent.com/ArthurBernard/Download_Crypto_Currencies_Data/develop/interrogate_badge.svg
     :target: https://github.com/ArthurBernard/Download_Crypto_Currencies_Data
     :alt: Docstring Coverage
 


### PR DESCRIPTION
## Summary

- `--generate-badge .` produces `interrogate_badge.svg`, not `interrogate_badge_output.svg`
- `file_pattern` in `git-auto-commit-action` was watching the wrong name → badge was generated but never committed
- README was referencing the wrong filename and `master` branch (badge only commits to `develop` on each PR merge, not just at release)

## Changes

- `.github/workflows/badges.yml` — `file_pattern: interrogate_badge_output.svg` → `interrogate_badge.svg`
- `README.rst` — badge URL: `master/interrogate_badge_output.svg` → `develop/interrogate_badge.svg`

## Test plan

- [ ] CI green; Badges workflow commits `interrogate_badge.svg` to `develop` after merge
- [ ] Badge displays correctly in README