### PR TITLE
fix: badge back on develop, rulesets replace classic branch protection

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install interrogate
-      - name: Generate badge
-        run: >
+      - run: >
           interrogate dccd/
           --generate-badge .
           --ignore-init-method
@@ -26,19 +25,7 @@ jobs:
           --ignore-private
           --exclude dccd/tests
           --fail-under 0
-      - name: Push badge to badges branch
-        run: |
-          cp interrogate_badge.svg /tmp/interrogate_badge.svg
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code origin badges; then
-            git fetch origin badges
-            git checkout -b badges origin/badges
-          else
-            git checkout --orphan badges
-            git rm -rf .
-          fi
-          cp /tmp/interrogate_badge.svg interrogate_badge.svg
-          git add interrogate_badge.svg
-          git diff --cached --quiet || git commit -m "chore: update docstring coverage badge [skip ci]"
-          git push origin badges
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update docstring coverage badge [skip ci]"
+          file_pattern: "interrogate_badge.svg"

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Download Crypto-Currency Data
     :target: https://download-crypto-currencies-data.readthedocs.io/en/latest/
     :alt: Documentation Status
 
-.. image:: https://raw.githubusercontent.com/ArthurBernard/Download_Crypto_Currencies_Data/badges/interrogate_badge.svg
+.. image:: https://raw.githubusercontent.com/ArthurBernard/Download_Crypto_Currencies_Data/develop/interrogate_badge.svg
     :target: https://github.com/ArthurBernard/Download_Crypto_Currencies_Data
     :alt: Docstring Coverage
 


### PR DESCRIPTION
## Summary

- Classic branch protection → GitHub Rulesets (support direct pushes for bots)
- Badge workflow simplified back to committing directly on `develop`/`master`
- README badge URL: `badges/` branch → `develop`
- `badges` orphan branch to be deleted post-merge

## Why this works now

Rulesets' `required_status_checks` rule only blocks merging a PR whose CI hasn't passed — it does **not** block direct pushes. So `github-actions[bot]` can still push the badge SVG directly to `develop`.

Classic branch protection blocked both direct pushes and PR merges without passing CI.