### PR TITLE
fix: remove untracked badge svg before switching to badges branch

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Push badge to badges branch
         run: |
           cp interrogate_badge.svg /tmp/interrogate_badge.svg
+          rm -f interrogate_badge.svg
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git ls-remote --exit-code origin badges; then


### PR DESCRIPTION
## Summary
- Adds `rm -f interrogate_badge.svg` after copying it to `/tmp`, so the subsequent `git checkout -b badges origin/badges` can succeed without being blocked by an untracked file

## Test plan
- [ ] Badges workflow completes without error
- [ ] `badges` branch updated with new `interrogate_badge.svg`