### PR TITLE
chore: add Codecov test coverage badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,10 @@ Download Crypto-Currency Data
     :target: https://download-crypto-currencies-data.readthedocs.io/en/latest/
     :alt: Documentation Status
 
+.. image:: https://codecov.io/gh/ArthurBernard/Download_Crypto_Currencies_Data/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/ArthurBernard/Download_Crypto_Currencies_Data
+    :alt: Coverage
+
 .. image:: https://raw.githubusercontent.com/ArthurBernard/Download_Crypto_Currencies_Data/badges/interrogate_badge.svg
     :target: https://github.com/ArthurBernard/Download_Crypto_Currencies_Data
     :alt: Docstring Coverage


### PR DESCRIPTION
## Summary
- Adds Codecov test coverage badge to README, consistent with Fynance

## Test plan
- [ ] CI green
- [ ] Badge renders on PyPI / GitHub README