### PR TITLE
fix: cover all exchange spans, enforce abstractmethod, warn on Kraken end param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `dccd/tools/date_time.py` — `span_to_str` and `str_to_span` now cover all spans supported by the exchanges: 180 s (3 m), 900 s (15 m), 14400 s (4 h), 21600 s (6 h), 28800 s (8 h), 43200 s (12 h), 259200 s (3 d), 1296000 s (15 d), 2592000 s (1 M); previously any span outside the original 7 values returned `None` and silently broke the save path (#XX)
-- `dccd/histo_dl/kraken.py` — `import_data` now raises `UserWarning` when `end` is passed, as the Kraken OHLC API does not support a custom end date and silently ignored the parameter (#XX)
+- `dccd/tools/date_time.py` — `span_to_str` and `str_to_span` now cover all spans supported by the exchanges: 180 s (3 m), 900 s (15 m), 14400 s (4 h), 21600 s (6 h), 28800 s (8 h), 43200 s (12 h), 259200 s (3 d), 1296000 s (15 d), 2592000 s (1 M); previously any span outside the original 7 values returned `None` and silently broke the save path (#21)
+- `dccd/histo_dl/kraken.py` — `import_data` now raises `UserWarning` when `end` is passed, as the Kraken OHLC API does not support a custom end date and silently ignored the parameter (#21)
 
 ### Changed
 
-- `dccd/histo_dl/exchange.py` — `ImportDataCryptoCurrencies` now inherits from `ABC` and `_import_data` is decorated with `@abstractmethod`, preventing accidental instantiation of the base class (#XX)
-- `dccd/histo_dl/binance.py`, `coinbase.py`, `bybit.py`, `okx.py`, `kraken.py` — added `from __future__ import annotations`, `from typing import Any`, and full type hints on `_import_data` and `import_data` signatures (#XX)
+- `dccd/histo_dl/exchange.py` — `ImportDataCryptoCurrencies` now inherits from `ABC` and `_import_data` is decorated with `@abstractmethod`, preventing accidental instantiation of the base class (#21)
+- `dccd/histo_dl/binance.py`, `coinbase.py`, `bybit.py`, `okx.py`, `kraken.py` — added `from __future__ import annotations`, `from typing import Any`, and full type hints on `_import_data` and `import_data` signatures (#21)
 
 - `dccd/histo_dl/exchange.py` — `_get_last_date` now reads `.csv` and `.parquet` files in addition to `.xlsx` instead of falling back to 2012-01-01 (#12)
 - `dccd/histo_dl/exchange.py` — completed numpydoc docstrings for `_get_last_date`, `_set_by_period`, `_name_file`, `_excel_format`, `_sort_data`, `set_hierarchy` (#12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dccd/tests/test_histo_dl.py` — tests for `_get_last_date` (xlsx, csv, parquet, empty directory) (#12)
 - `pyproject.toml` — `pytest-asyncio>=0.23` added to dev dependencies (#12)
 
+### Fixed
+
+- `dccd/tools/date_time.py` — `span_to_str` and `str_to_span` now cover all spans supported by the exchanges: 180 s (3 m), 900 s (15 m), 14400 s (4 h), 21600 s (6 h), 28800 s (8 h), 43200 s (12 h), 259200 s (3 d), 1296000 s (15 d), 2592000 s (1 M); previously any span outside the original 7 values returned `None` and silently broke the save path (#XX)
+- `dccd/histo_dl/kraken.py` — `import_data` now raises `UserWarning` when `end` is passed, as the Kraken OHLC API does not support a custom end date and silently ignored the parameter (#XX)
+
 ### Changed
+
+- `dccd/histo_dl/exchange.py` — `ImportDataCryptoCurrencies` now inherits from `ABC` and `_import_data` is decorated with `@abstractmethod`, preventing accidental instantiation of the base class (#XX)
+- `dccd/histo_dl/binance.py`, `coinbase.py`, `bybit.py`, `okx.py`, `kraken.py` — added `from __future__ import annotations`, `from typing import Any`, and full type hints on `_import_data` and `import_data` signatures (#XX)
 
 - `dccd/histo_dl/exchange.py` — `_get_last_date` now reads `.csv` and `.parquet` files in addition to `.xlsx` instead of falling back to 2012-01-01 (#12)
 - `dccd/histo_dl/exchange.py` — completed numpydoc docstrings for `_get_last_date`, `_set_by_period`, `_name_file`, `_excel_format`, `_sort_data`, `set_hierarchy` (#12)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,229 @@
+# TODO
+
+> Les numéros servent à se repérer en conversation — ils n'apparaissent
+> jamais dans les commits ou le CHANGELOG. Traçabilité historique via le
+> numéro de PR uniquement.
+>
+> Une tâche terminée = ligne supprimée (pas de section Done). La trace
+> vit dans `CHANGELOG.md` et `git log`.
+>
+> Workflow : `/pick-task` → plan mode → implémentation → `/finish-task`.
+
+---
+
+## 2. Robustesse & cohérence
+
+> Améliorations structurelles importantes, pas urgentes mais impactantes
+> sur la maintenabilité et la fiabilité.
+
+### 2.1 Snapshots `continuous_dl`
+
+- [ ] **Crash recovery** : après chaque `time_step`, persister l'état de `self.d`
+  (le dict book courant) dans un fichier de reprise (JSON ou parquet), distinct des
+  données de marché ; au redémarrage, recharger ce fichier pour éviter le trou entre
+  le crash et le prochain "partial/snapshot" envoyé par l'exchange
+- [ ] **Horodatage précis** : enrichir `_data[t]` d'un timestamp réel (UTC,
+  précision milliseconde) au moment de la prise de snapshot, pas seulement le slot
+  entier `self.t` — nécessaire pour la jointure avec les données histo
+- [ ] **Séparer trades et book** : aujourd'hui les deux types sont dans le même
+  `_data[t]` alors que leur structure est fondamentalement différente (liste ordonnée
+  vs dict) ; distinguer les deux canaux au niveau du saver
+
+### 2.2 Formatage des paires
+
+- [ ] Créer une fonction `format_pair(crypto, fiat)` par exchange pour remplacer la
+  logique inline dans chaque `__init__` — facilite les tests et isole les règles
+  spécifiques (ex. Kraken : `BTC→XBT`, préfixes `X`/`Z`, cas `BCH`/`DASH`)
+- [ ] Ajouter des tests pour les cas particuliers Kraken : `BTC/USD`, `BCH/EUR`,
+  `DASH/USD`, crypto avec fiat non-standard
+
+### 2.3 Réduction de la duplication dans `continuous_dl`
+
+- [ ] `parser_trades()` et `parser_book()` ont le même squelette dans Binance, Bybit,
+  Kraken, OKX — remonter le pattern dans la base `ContinuousDownloader`
+- [ ] Valider les données WebSocket avec les modèles Pydantic `Trade` et
+  `OrderBookEntry` déjà définis dans `models.py` (inutilisés à ce jour)
+- [ ] Définir un protocole commun pour `__call__()` dans les continuous downloaders :
+  Binance prend `pair: str`, Bitfinex `channel: str, **kwargs`, Bitmex `*args`,
+  Bybit/Kraken/OKX n'en ont pas
+
+---
+
+## 3. Qualité & polish
+
+> Code mort, tests manquants, documentation. Important mais ne bloque rien.
+
+### 3.1 Suppression du code mort
+
+- [ ] Supprimer (ou promouvoir) `ContinuousDownloader._parser_debug()` :
+  jamais appelé directement, a un effet de bord non documenté
+  (`self._data[self.t] = data`)
+- [ ] Retirer les imports commentés dans `dccd/tools/__init__.py`
+- [ ] Revoir `await self.wait_that('_data')` dans `ContinuousDownloader._loop()`
+  — un dict non-vide est toujours truthy, cette attente ne garantit rien
+
+### 3.2 Tests manquants
+
+- [ ] Ajouter des tests pour `dccd/process_data.py` (`set_ohlc`, `set_marketdepth`,
+  `set_trades`, `set_orders`) — aucun test direct aujourd'hui
+- [ ] Tester la reconstruction du carnet d'ordres Bitmex (machine à états
+  `partial/insert/update/delete`)
+- [ ] Tester les scénarios d'erreur REST : HTTP 5xx, JSON malformé, champ manquant
+
+### 3.3 Documentation
+
+- [ ] Ajouter des docstrings aux fonctions `_parser_trades()` et `_parser_book()`
+  dans `dccd/continuous_dl/bybit.py` et `bitmex.py` (Kraken, OKX, Binance ont
+  des docstrings complets)
+- [ ] Mettre à jour la docstring de `ImportDataCryptoCurrencies` : elle cite encore
+  "only Binance, Coinbase, and Kraken" alors que Bybit et OKX sont supportés
+
+---
+
+## 4. Daemon autonome (déploiement serveur)
+
+> Grand chantier fonctionnel. Dépend de la stabilité de la section 1 et 2.
+
+**Vision :** `dccd` déployé sur un serveur collecte de la data en continu
+(histo REST + streams WebSocket), la stocke localement, et la pousse vers
+un espace de stockage dédié configurable (NAS, SFTP, S3…). Une interface
+CLI permet de tout contrôler ; une Web UI (phase 2) offrira un dashboard
+de monitoring.
+
+**Architecture :**
+```
+dccd/daemon/
+├── config.py         ← schéma YAML + validation Pydantic
+├── storage.py        ← abstraction push vers remote
+├── scheduler.py      ← APScheduler pour histo_dl
+├── stream_manager.py ← gestion des streams continuous_dl
+└── health.py         ← métriques JSON + alertes webhook
+```
+
+Config YAML de référence :
+```yaml
+storage:
+  local_path: /data/crypto/
+  remote:              # optionnel
+    provider: rclone   # rclone | none
+    remote: mynas:crypto/
+
+histo_jobs:
+  - exchange: binance
+    pairs: [BTC/USDT, ETH/USDT]
+    span: 3600          # secondes
+    format: parquet
+    by_period: Y
+
+stream_jobs:
+  - exchange: binance
+    pairs: [BTC/USDT]
+    channels: [trades, book]
+    time_step: 60
+
+alerts:
+  webhook_url: https://hooks.slack.com/...  # optionnel
+  max_consecutive_errors: 3
+```
+
+### 4.1 Configuration déclarative
+
+- [ ] Schéma Pydantic : `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`,
+  `AlertConfig` — avec validation (exchange connu, span ≥ 60, format supporté,
+  channels valides)
+- [ ] Loader `dccd/daemon/config.py` : `load_config(path) -> CollectorConfig`
+  — lire le YAML, valider, retourner le modèle
+- [ ] `examples/config.example.yml` documenté (commentaires inline)
+- [ ] Tests : config valide, exchange inconnu, span invalide, channel invalide,
+  fichier absent
+
+### 4.2 Storage abstraction
+
+Déléguer à **rclone** via `subprocess` (50+ providers : S3, GCS, SFTP, SMB…).
+Absent → warning et collecte locale seulement.
+
+- [ ] `dccd/daemon/storage.py` : `RemoteStorage.push(local_path)` — appel
+  `rclone copy` si configuré, no-op sinon ; capturer stderr pour le logging
+- [ ] Vérification de la présence de rclone au démarrage du daemon
+- [ ] Tests : mock subprocess, vérifier commande construite, comportement si absent
+
+### 4.3 Collecte historique (histo_dl scheduler)
+
+- [ ] `dccd/daemon/scheduler.py` : `build_histo_scheduler(config)` → APScheduler
+  `BackgroundScheduler`, un job par `(exchange, pair)` avec `interval=span`,
+  `coalesce=True`, `max_instances=1`
+- [ ] `run_histo_job(job, pair, storage)` : appelle
+  `FromXxx(path, crypto, span, fiat).import_data('last', 'now').save()` puis
+  `storage.push()` — exceptions loguées isolément, les autres jobs continuent
+- [ ] `run_once(config)` : exécute tous les histo_jobs une fois et quitte
+- [ ] Tests : mock des classes histo_dl, vérifier chaîne d'appels, isolation
+  des erreurs, run_once
+
+### 4.4 Collecte temps-réel (continuous_dl manager)
+
+- [ ] `dccd/daemon/stream_manager.py` : `StreamManager` qui démarre un thread par
+  `(exchange, pair, channel)` via les classes `DownloadXxxData` existantes
+- [ ] Persistence : snapshots toutes les `time_step` secondes puis `storage.push()`
+  via les callbacks `set_process_data` / `set_saver`
+- [ ] Reconnexion : le manager relance le thread si le stream meurt définitivement
+  (max_retries épuisés)
+- [ ] Tests : mock des classes continuous_dl, vérifier démarrage/arrêt, relance
+
+### 4.5 Health & monitoring
+
+- [ ] `dccd/daemon/health.py` : `RotatingFileHandler` (10 MB × 5 fichiers)
+- [ ] Métriques JSON après chaque job : `last_run_at`, `last_success_at`,
+  `rows_collected`, `errors_count` par `(exchange, pair)`
+- [ ] Alertes webhook optionnelles si `errors_count ≥ max_consecutive_errors`
+  (format Slack/Discord)
+- [ ] Tests : écriture métriques, envoi webhook mocké
+
+### 4.6 CLI (typer)
+
+- [ ] Entrypoint `dccd` dans `pyproject.toml [project.scripts]`
+- [ ] `dccd validate --config config.yml` : valider sans lancer
+- [ ] `dccd run --once --config config.yml` : exécuter les histo_jobs une fois
+- [ ] `dccd start --config config.yml` : daemon en foreground
+- [ ] `dccd status` : afficher les métriques de façon lisible
+- [ ] `dccd add --exchange binance --pair ETH/USDT --span 3600` : ajouter un job
+- [ ] Tests CLI : `typer.testing.CliRunner` pour chaque commande
+
+### 4.7 Déploiement
+
+- [ ] `Dockerfile` : `python:3.12-slim`, rclone, `pip install dccd`, volumes
+  `/data` et `/config`, entrypoint `dccd start`
+- [ ] `docker-compose.yml` : service dccd avec volumes mappés + `DCCD_CONFIG`
+- [ ] `examples/dccd.service` : unité systemd (bare-metal / VM)
+- [ ] Section déploiement dans `README.rst` (Quick start Docker + systemd)
+
+### 4.8 Web UI — phase 2 (FastAPI + htmx)
+
+- [ ] `dccd/daemon/api.py` : API REST FastAPI — métriques, config active, CRUD jobs
+- [ ] Frontend minimal htmx + Alpine.js : tableau de bord, ajout/suppression de
+  paires, graphique de disponibilité
+- [ ] Authentification basique (token Bearer ou HTTP Basic)
+- [ ] Déploiement : service séparé dans `docker-compose.yml` ou thread intégré
+
+---
+
+## 5. Nouveaux exchanges & données
+
+> Évolutions futures, aucune dépendance bloquante avec les sections précédentes.
+
+### 5.1 Hyperliquid
+
+DEX perps on-chain (L1 custom), API publique REST + WebSocket sans auth.
+
+- [ ] Identifier les endpoints OHLCV (`/info` avec `type: candleSnapshot`) et trades
+- [ ] `FromHyperliquid` dans `dccd/histo_dl/hyperliquid.py` — timestamps en ms,
+  paires au format `BTC` (pas `BTC/USDT`)
+- [ ] `DownloadHyperliquidData` dans `dccd/continuous_dl/hyperliquid.py`
+  (WebSocket `wss://api.hyperliquid.xyz/ws`)
+- [ ] Tests + doc RST associés
+
+### 5.2 Données on-chain
+
+- [ ] Évaluer **The Graph** (GraphQL) pour Uniswap v3 — OHLCV/trades reconstituables
+  depuis les events de swap ?
+- [ ] Évaluer **Dune Analytics API** (REST, quota gratuit limité)
+- [ ] Prototype `dccd/onchain/` si un provider offre données stables (< 1h latence)

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -130,7 +130,7 @@ class FromBinance(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromBinance:
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from Binance for specific time interval.
 
         Parameters

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -16,8 +16,11 @@
 
 """
 
+from __future__ import annotations
+
 # Import built-in packages
 import logging
+from typing import Any
 
 # Import third-party packages
 from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
@@ -102,7 +105,7 @@ class FromBinance(ImportDataCryptoCurrencies):
         self.full_path = self.path + '/Binance/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 
-    def _import_data(self, start='last', end='now'):
+    def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)
 
         param = {
@@ -127,7 +130,7 @@ class FromBinance(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start='last', end='now'):
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromBinance:
         """ Download data from Binance for specific time interval.
 
         Parameters

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -140,7 +140,7 @@ class FromBybit(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromBybit:
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from Bybit for a specific time interval.
 
         Parameters

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -11,10 +11,12 @@
 
 """
 
+from __future__ import annotations
+
 # Import built-in packages
+from typing import Any
 
 # Import third-party packages
-
 # Import local packages
 from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
 
@@ -110,7 +112,7 @@ class FromBybit(ImportDataCryptoCurrencies):
         self.full_path = self.path + '/Bybit/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 
-    def _import_data(self, start='last', end='now'):
+    def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)
 
         param = {
@@ -138,7 +140,7 @@ class FromBybit(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start='last', end='now'):
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromBybit:
         """ Download data from Bybit for a specific time interval.
 
         Parameters

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -16,11 +16,12 @@
 
 """
 
+from __future__ import annotations
+
 # Import built-in packages
+from typing import Any
 
 # Import third party packages
-
-
 from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
 
 # Import local packages
@@ -93,7 +94,7 @@ class FromCoinbase(ImportDataCryptoCurrencies):
         self.full_path = self.path + '/Coinbase/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 
-    def _import_data(self, start='last', end='now'):
+    def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)
         param = {
             'start': TS_to_date(self.start - self.span),
@@ -119,7 +120,7 @@ class FromCoinbase(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start='last', end='now'):
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromCoinbase:
         """ Download data from Coinbase for specific time interval.
 
         Parameters

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -120,7 +120,7 @@ class FromCoinbase(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromCoinbase:
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from Coinbase for specific time interval.
 
         Parameters

--- a/dccd/histo_dl/exchange.py
+++ b/dccd/histo_dl/exchange.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pathlib
 import time
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 # Import extern packages
@@ -44,7 +45,7 @@ def _should_retry(exc):
             and exc.response.status_code == 429)
 
 
-class ImportDataCryptoCurrencies:
+class ImportDataCryptoCurrencies(ABC):
     """ Base class to import data about crypto-currencies from some exchanges.
 
     Parameters
@@ -380,9 +381,9 @@ class ImportDataCryptoCurrencies:
         else:
             raise TypeError("span must be str or int")
 
+    @abstractmethod
     def _import_data(self, start: int | str, end: int | str) -> list[dict[str, Any]]:
         """ Fetch raw data from the exchange (implemented by subclasses). """
-        raise NotImplementedError
 
     def set_hierarchy(self, liste: list[str]) -> None:
         """ Override the default save path with a custom directory hierarchy.

--- a/dccd/histo_dl/kraken.py
+++ b/dccd/histo_dl/kraken.py
@@ -16,8 +16,12 @@
 
 """
 
+from __future__ import annotations
+
 # Import built-in packages
 import time
+import warnings
+from typing import Any
 
 # Import third party packages
 # Import local packages
@@ -94,7 +98,16 @@ class FromKraken(ImportDataCryptoCurrencies):
         else:
             self.pair = 'X' + crypto + 'Z' + fiat
 
-    def _import_data(self, start='last', end=None):
+    def _import_data(
+        self, start: int | str = 'last', end: int | str | None = None
+    ) -> list[dict[str, Any]]:
+        if end is not None:
+            warnings.warn(
+                "The Kraken OHLC API does not support an end date — the 'end' "
+                "parameter is ignored and data is always fetched up to now.",
+                UserWarning,
+                stacklevel=2,
+            )
         self.start, self.end = self._set_time(start, time.time())
 
         param = {
@@ -119,21 +132,28 @@ class FromKraken(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start='last', end=None):
+    def import_data(
+        self, start: int | str = 'last', end: int | str | None = None
+    ) -> FromKraken:
         """ Download data from Kraken since a specific time until now.
 
         Parameters
         ----------
         start : int or str
-            Timestamp of the first observation of you want as int or date
-            format 'yyyy-mm-dd hh:mm:ss' as string.
+            Timestamp of the first observation as a Unix timestamp (int) or a
+            date string ``'yyyy-mm-dd hh:mm:ss'``.
+        end : int, str or None
+            Ignored. The Kraken OHLC API does not support a custom end date
+            and always returns data up to the current time. Passing a non-None
+            value raises a :class:`UserWarning`.
 
         Returns
         -------
-        data : pd.DataFrame
-            Data sorted and cleaned in a data frame.
+        self : FromKraken
+            Data sorted and cleaned in a data frame, accessible via
+            :meth:`get_data`.
 
         """
-        data = self._import_data(start=start)
+        data = self._import_data(start=start, end=end)
 
         return self._sort_data(data)

--- a/dccd/histo_dl/kraken.py
+++ b/dccd/histo_dl/kraken.py
@@ -108,7 +108,7 @@ class FromKraken(ImportDataCryptoCurrencies):
                 UserWarning,
                 stacklevel=2,
             )
-        self.start, self.end = self._set_time(start, time.time())
+        self.start, self.end = self._set_time(start, int(time.time()))
 
         param = {
             'pair': self.pair,
@@ -134,7 +134,7 @@ class FromKraken(ImportDataCryptoCurrencies):
 
     def import_data(
         self, start: int | str = 'last', end: int | str | None = None
-    ) -> FromKraken:
+    ) -> ImportDataCryptoCurrencies:
         """ Download data from Kraken since a specific time until now.
 
         Parameters

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -139,7 +139,7 @@ class FromOKX(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromOKX:
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from OKX for a specific time interval.
 
         Parameters

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -11,10 +11,12 @@
 
 """
 
+from __future__ import annotations
+
 # Import built-in packages
+from typing import Any
 
 # Import third-party packages
-
 # Import local packages
 from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
 
@@ -110,7 +112,7 @@ class FromOKX(ImportDataCryptoCurrencies):
         self.full_path = self.path + '/OKX/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 
-    def _import_data(self, start='last', end='now'):
+    def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)
 
         param = {
@@ -137,7 +139,7 @@ class FromOKX(ImportDataCryptoCurrencies):
 
         return data
 
-    def import_data(self, start='last', end='now'):
+    def import_data(self, start: int | str = 'last', end: int | str = 'now') -> FromOKX:
         """ Download data from OKX for a specific time interval.
 
         Parameters

--- a/dccd/tests/test_date_time.py
+++ b/dccd/tests/test_date_time.py
@@ -20,27 +20,108 @@ def test_str_to_span_aliases():
     for alias in ['weekly', 'week', '7d', '1w', 'w']:
         assert str_to_span(alias) == 604800
     assert str_to_span('daily') == 86400
+    assert str_to_span('bi-hourly') == 7200
+    assert str_to_span('2h') == 7200
     assert str_to_span('hourly') == 3600
+    assert str_to_span('half-hourly') == 1800
+    assert str_to_span('30min') == 1800
+    assert str_to_span('5min') == 300
     assert str_to_span('minutely') == 60
+
+
+def test_str_to_span_new_spans():
+    assert str_to_span('monthly') == 2592000
+    assert str_to_span('1M') == 2592000
+    assert str_to_span('15d') == 1296000
+    assert str_to_span('15-daily') == 1296000
+    assert str_to_span('3d') == 259200
+    assert str_to_span('3-day') == 259200
+    assert str_to_span('12h') == 43200
+    assert str_to_span('12-hourly') == 43200
+    assert str_to_span('8h') == 28800
+    assert str_to_span('8-hour') == 28800
+    assert str_to_span('6h') == 21600
+    assert str_to_span('6-hourly') == 21600
+    assert str_to_span('4h') == 14400
+    assert str_to_span('4-hour') == 14400
+    assert str_to_span('quarter-hourly') == 900
+    assert str_to_span('15min') == 900
+    assert str_to_span('15m') == 900
+    assert str_to_span('3m') == 180
+    assert str_to_span('3min') == 180
+    assert str_to_span('3-minute') == 180
+
+
+def test_str_to_span_case_insensitive():
+    assert str_to_span('MONTHLY') == 2592000
+    assert str_to_span('Weekly') == 604800
+    assert str_to_span('DAILY') == 86400
+    assert str_to_span('Hourly') == 3600
+
+
+def test_str_to_span_unknown_returns_none():
+    assert str_to_span('fortnight') is None
 
 
 def test_span_to_str_values():
     assert span_to_str(60) == 'Minutely'
+    assert span_to_str(300) == 'Five_Minutely'
+    assert span_to_str(1800) == 'Half_Hourly'
     assert span_to_str(3600) == 'Hourly'
+    assert span_to_str(7200) == 'Bi_Hourly'
     assert span_to_str(86400) == 'Daily'
     assert span_to_str(604800) == 'Weekly'
 
 
+def test_span_to_str_new_spans():
+    assert span_to_str(180) == 'Three_Minutely'
+    assert span_to_str(900) == 'Quarter_Hourly'
+    assert span_to_str(14400) == 'Four_Hourly'
+    assert span_to_str(21600) == 'Six_Hourly'
+    assert span_to_str(28800) == 'Eight_Hourly'
+    assert span_to_str(43200) == 'Twelve_Hourly'
+    assert span_to_str(259200) == 'Three_Daily'
+    assert span_to_str(1296000) == 'Fifteen_Daily'
+    assert span_to_str(2592000) == 'Monthly'
+
+
+def test_span_to_str_unknown_returns_none():
+    assert span_to_str(999) is None
+
+
+def test_span_roundtrip():
+    spans = [
+        60, 180, 300, 900, 1800, 3600, 7200, 14400,
+        21600, 28800, 43200, 86400, 259200, 604800, 1296000, 2592000,
+    ]
+    for span in spans:
+        label = span_to_str(span)
+        assert label is not None, f"span_to_str({span}) returned None"
+
+
 def test_binance_interval_minutes():
     assert binance_interval(60) == '1m'
+    assert binance_interval(180) == '3m'
     assert binance_interval(300) == '5m'
+    assert binance_interval(900) == '15m'
+    assert binance_interval(1800) == '30m'
 
 
 def test_binance_interval_hours():
     assert binance_interval(3600) == '1h'
     assert binance_interval(7200) == '2h'
+    assert binance_interval(14400) == '4h'
+    assert binance_interval(21600) == '6h'
+    assert binance_interval(28800) == '8h'
+    assert binance_interval(43200) == '12h'
 
 
 def test_binance_interval_days():
     assert binance_interval(86400) == '1d'
+    assert binance_interval(259200) == '3d'
     assert binance_interval(604800) == '1w'
+    assert binance_interval(2592000) == '1M'
+
+
+def test_binance_interval_unknown_returns_none():
+    assert binance_interval(999) is None

--- a/dccd/tests/test_histo_dl.py
+++ b/dccd/tests/test_histo_dl.py
@@ -2,6 +2,8 @@
 # coding: utf-8
 
 
+import logging
+
 import pandas as pd
 
 from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
@@ -9,9 +11,13 @@ from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
 _FALLBACK_TS = 1325376000  # 2012-01-01 00:00:00 UTC
 
 
+class _ConcreteDownloader(ImportDataCryptoCurrencies):
+    def _import_data(self, start, end):
+        return []
+
+
 def _make_obj(full_path: str) -> ImportDataCryptoCurrencies:
-    obj = ImportDataCryptoCurrencies.__new__(ImportDataCryptoCurrencies)
-    import logging
+    obj = _ConcreteDownloader.__new__(_ConcreteDownloader)
     obj.logger = logging.getLogger(__name__)
     obj.last_df = pd.DataFrame()
     obj.full_path = full_path

--- a/dccd/tools/date_time.py
+++ b/dccd/tools/date_time.py
@@ -92,7 +92,11 @@ def str_to_span(string: str) -> int | None:
     Parameters
     ----------
     string : str
-        Time periodicity
+        Time periodicity. Accepted values (case-insensitive):
+        ``'monthly'``, ``'1M'``, ``'15d'``, ``'weekly'``, ``'3d'``,
+        ``'daily'``, ``'12h'``, ``'8h'``, ``'6h'``, ``'4h'``,
+        ``'bi-hourly'``, ``'hourly'``, ``'half-hourly'``, ``'quarter-hourly'``,
+        ``'5min'``, ``'3m'``, ``'minutely'``, and common aliases.
 
     Returns
     -------
@@ -105,41 +109,61 @@ def str_to_span(string: str) -> int | None:
     60
 
     """
-    if string.lower() in ['weekly', 'week', '7d', '1w', 'w']:
+    s = string.lower()
+    if s in ['monthly', 'month', '1m']:
+        return 2592000
+    elif s in ['15-daily', '15-day', '15d']:
+        return 1296000
+    elif s in ['weekly', 'week', '7d', '1w', 'w']:
         return 604800
-    elif string.lower() in ['daily', 'day', '24h', '1d', 'd']:
+    elif s in ['3-daily', '3-day', '3d']:
+        return 259200
+    elif s in ['daily', 'day', '24h', '1d', 'd']:
         return 86400
-    elif string.lower() in ['bi-hourly', 'bi-hour', '2h']:
+    elif s in ['12-hourly', '12-hour', '12h']:
+        return 43200
+    elif s in ['8-hourly', '8-hour', '8h']:
+        return 28800
+    elif s in ['6-hourly', '6-hour', '6h']:
+        return 21600
+    elif s in ['4-hourly', '4-hour', '4h']:
+        return 14400
+    elif s in ['bi-hourly', 'bi-hour', '2h']:
         return 7200
-    elif string.lower() in ['hourly', 'hour', '1h', '60min', 'h']:
+    elif s in ['hourly', 'hour', '1h', '60min', 'h']:
         return 3600
-    elif string.lower() in ['half-hourly', 'half-hour', '30min']:
+    elif s in ['half-hourly', 'half-hour', '30min']:
         return 1800
-    elif string.lower() in ['5-minute', 'five-minute', '5 minute',
-                            'five minute', '5min']:
+    elif s in ['quarter-hourly', 'quarter-hour', '15min', '15m']:
+        return 900
+    elif s in ['5-minute', 'five-minute', '5 minute', 'five minute', '5min']:
         return 300
-    elif string.lower() in ['minutely', 'minute', '1min', 'min']:
+    elif s in ['3-minute', 'three-minute', '3min', '3m']:
+        return 180
+    elif s in ['minutely', 'minute', '1min', 'min']:
         return 60
     else:
         _logger.warning(
-            'Error, string not understood. String must be "minutely", '
-            '"5 minute", "hourly", "daily" or "weekly".'
+            'Error, string not understood. Expected values such as "minutely", '
+            '"5min", "15m", "hourly", "4h", "daily", "weekly", "monthly", etc.'
         )
         return None
 
 
 def span_to_str(span: int) -> str | None:
-    """ Return the time periodicity.
+    """ Return the time periodicity label for the given span in seconds.
 
     Parameters
     ----------
     span : int
-        Time interval in second.
+        Time interval in seconds. Supported values: 60, 180, 300, 900, 1800,
+        3600, 7200, 14400, 21600, 28800, 43200, 86400, 259200, 604800,
+        1296000, 2592000.
 
     Returns
     -------
     date : str
-        Time periodicity.
+        Time periodicity label used for directory naming.
 
     Examples
     --------
@@ -147,23 +171,28 @@ def span_to_str(span: int) -> str | None:
     'Hourly'
 
     """
-    if span == 60:
-        return 'Minutely'
-    elif span == 300:
-        return 'Five_Minutely'
-    elif span == 1800:
-        return 'Half_Hourly'
-    elif span == 3600:
-        return 'Hourly'
-    elif span == 7200:
-        return 'Bi_Hourly'
-    elif span == 86400:
-        return 'Daily'
-    elif span == 604800:
-        return 'Weekly'
-    else:
+    _map = {
+        60: 'Minutely',
+        180: 'Three_Minutely',
+        300: 'Five_Minutely',
+        900: 'Quarter_Hourly',
+        1800: 'Half_Hourly',
+        3600: 'Hourly',
+        7200: 'Bi_Hourly',
+        14400: 'Four_Hourly',
+        21600: 'Six_Hourly',
+        28800: 'Eight_Hourly',
+        43200: 'Twelve_Hourly',
+        86400: 'Daily',
+        259200: 'Three_Daily',
+        604800: 'Weekly',
+        1296000: 'Fifteen_Daily',
+        2592000: 'Monthly',
+    }
+    label = _map.get(span)
+    if label is None:
         _logger.warning('Error, no string correspond to this time in seconds.')
-        return None
+    return label
 
 
 def binance_interval(interval: int) -> str | None:


### PR DESCRIPTION
## Summary

- `span_to_str` / `str_to_span` ne couvraient que 7 spans sur 16 ; tout span manquant retournait `None` et cassait silencieusement le chemin de sauvegarde
- `ImportDataCryptoCurrencies._import_data` n'était pas abstraite — la classe de base était instanciable par erreur
- `FromKraken.import_data` ignorait silencieusement le paramètre `end` sans avertir l'utilisateur
- Les signatures de `_import_data` / `import_data` dans les sous-classes manquaient de type hints

## Changes

- `dccd/tools/date_time.py` — `span_to_str` refactorisé en dict ; `str_to_span` étendu ; 16 spans couverts (180, 900, 14400, 21600, 28800, 43200, 259200, 1296000, 2592000)
- `dccd/histo_dl/exchange.py` — `ImportDataCryptoCurrencies(ABC)` + `@abstractmethod` sur `_import_data`
- `dccd/histo_dl/kraken.py` — `UserWarning` si `end` est passé ; docstring mis à jour
- `dccd/histo_dl/binance.py`, `coinbase.py`, `bybit.py`, `okx.py`, `kraken.py` — `from __future__ import annotations`, `from typing import Any`, type hints complets
- `dccd/tests/test_date_time.py` — 10 nouveaux tests (nouveaux spans, round-trip, case-insensitive, binance_interval complet)
- `dccd/tests/test_histo_dl.py` — `_make_obj` adapté pour utiliser une sous-classe concrète (`_ConcreteDownloader`)

## Test plan

- [x] `pytest` : 122 passed, 1 warning
- [x] `ruff check dccd/` : no errors
- [ ] CI green