### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-15
+
 ### Added
 
 - `dccd/tests/test_binance.py`, `test_kraken.py`, `test_bybit.py`, `test_okx.py`, `test_coinbase.py` — REST error-scenario tests: HTTP 500 and malformed response for every exchange (#22)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "2.0.2"
+version = "2.1.0"
 description = "Download Crypto Currency Data from different exchanges."
 readme = "README.rst"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Bump `version` in `pyproject.toml`: `2.0.2` → `2.1.0`
- Close `[Unreleased]` section in `CHANGELOG.md` as `[2.1.0] - 2026-05-15`

Minor bump justified by new public API: `DownloadBinanceData`, `DownloadKrakenData`, `DownloadOKXData` WebSocket modules added in #20.

## Test plan

- [x] No logic changes — version string and CHANGELOG only
- [ ] CI green