### PR TITLE
feat: add daemon config, rclone storage, and histo scheduler (tasks 4.1-4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#XX)
-- `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#XX)
-- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#XX)
-- `examples/config.example.yml` — annotated reference config for the daemon (#XX)
-- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#XX)
+- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)
+- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#25)
+- `examples/config.example.yml` — annotated reference config for the daemon (#25)
+- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#25)
 
 ## [2.1.0] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#XX)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#XX)
+- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#XX)
+- `examples/config.example.yml` — annotated reference config for the daemon (#XX)
+- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#XX)
+
 ## [2.1.0] - 2026-05-15
 
 ### Added

--- a/dccd/daemon/__init__.py
+++ b/dccd/daemon/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Daemon module for autonomous data collection.
+
+.. currentmodule:: dccd.daemon
+
+Submodules
+----------
+
+.. autosummary::
+
+   config
+   storage
+   scheduler
+
+"""
+
+from dccd.daemon.config import CollectorConfig, load_config
+from dccd.daemon.scheduler import build_histo_scheduler, run_once
+from dccd.daemon.storage import RemoteStorage
+
+__all__ = [
+    'CollectorConfig',
+    'load_config',
+    'RemoteStorage',
+    'build_histo_scheduler',
+    'run_once',
+]

--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Declarative configuration for the dccd daemon.
+
+Loads a YAML file and validates it with Pydantic v2 models.
+
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+__all__ = [
+    'CollectorConfig',
+    'AlertConfig',
+    'HistoJob',
+    'RemoteConfig',
+    'StorageConfig',
+    'StreamJob',
+    'load_config',
+]
+
+SUPPORTED_HISTO_EXCHANGES: frozenset[str] = frozenset(
+    {'binance', 'kraken', 'bybit', 'okx', 'coinbase'}
+)
+SUPPORTED_STREAM_EXCHANGES: frozenset[str] = frozenset(
+    {'binance', 'kraken', 'bybit', 'okx', 'bitfinex', 'bitmex'}
+)
+SUPPORTED_FORMATS: frozenset[str] = frozenset({'xlsx', 'csv', 'parquet'})
+SUPPORTED_BY_PERIOD: frozenset[str] = frozenset({'Y', 'M', 'D'})
+
+
+class RemoteConfig(BaseModel):
+    """ Remote storage configuration for rclone.
+
+    Parameters
+    ----------
+    provider : str
+        Remote provider, default is ``'rclone'``.
+    remote : str
+        rclone remote destination, e.g. ``'mynas:crypto/'``.
+
+    """
+
+    provider: str = 'rclone'
+    remote: str
+
+
+class StorageConfig(BaseModel):
+    """ Local and optional remote storage configuration.
+
+    Parameters
+    ----------
+    local_path : str
+        Absolute path where data is stored on the daemon host.
+    remote : RemoteConfig or None
+        Remote push configuration. If ``None``, data is kept locally only.
+
+    """
+
+    local_path: str
+    remote: RemoteConfig | None = None
+
+
+class HistoJob(BaseModel):
+    """ Historical (REST) data collection job.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name. Must be one of ``SUPPORTED_HISTO_EXCHANGES``.
+    pairs : list of str
+        Trading pairs in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
+    span : int
+        Candle interval in seconds. Must be >= 60.
+    format : str
+        Output format: ``'xlsx'``, ``'csv'``, or ``'parquet'``.
+    by_period : str
+        File grouping period: ``'Y'`` (year), ``'M'`` (month), ``'D'`` (day).
+
+    """
+
+    exchange: str
+    pairs: list[str]
+    span: int
+    format: str = 'parquet'
+    by_period: str = 'Y'
+
+    @field_validator('exchange')
+    @classmethod
+    def _validate_exchange(cls, v: str) -> str:
+        if v not in SUPPORTED_HISTO_EXCHANGES:
+            raise ValueError(
+                f"Unknown exchange {v!r}. "
+                f"Supported: {sorted(SUPPORTED_HISTO_EXCHANGES)}"
+            )
+        return v
+
+    @field_validator('pairs')
+    @classmethod
+    def _validate_pairs(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("'pairs' must not be empty")
+        for pair in v:
+            if '/' not in pair:
+                raise ValueError(
+                    f"Pair {pair!r} must be in 'CRYPTO/FIAT' format (e.g. 'BTC/USDT')"
+                )
+        return v
+
+    @field_validator('span')
+    @classmethod
+    def _validate_span(cls, v: int) -> int:
+        if v < 60:
+            raise ValueError(f"span must be >= 60 seconds, got {v}")
+        return v
+
+    @field_validator('format')
+    @classmethod
+    def _validate_format(cls, v: str) -> str:
+        if v not in SUPPORTED_FORMATS:
+            raise ValueError(
+                f"Unknown format {v!r}. Supported: {sorted(SUPPORTED_FORMATS)}"
+            )
+        return v
+
+    @field_validator('by_period')
+    @classmethod
+    def _validate_by_period(cls, v: str) -> str:
+        if v not in SUPPORTED_BY_PERIOD:
+            raise ValueError(
+                f"Unknown by_period {v!r}. Supported: {sorted(SUPPORTED_BY_PERIOD)}"
+            )
+        return v
+
+
+class StreamJob(BaseModel):
+    """ Real-time (WebSocket) data collection job.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name. Must be one of ``SUPPORTED_STREAM_EXCHANGES``.
+    pairs : list of str
+        Trading pairs (format depends on exchange).
+    channels : list of str
+        WebSocket channels to subscribe to (e.g. ``['trades', 'book']``).
+    time_step : int
+        Snapshot interval in seconds, default is 60.
+
+    """
+
+    exchange: str
+    pairs: list[str]
+    channels: list[str]
+    time_step: int = 60
+
+    @field_validator('exchange')
+    @classmethod
+    def _validate_exchange(cls, v: str) -> str:
+        if v not in SUPPORTED_STREAM_EXCHANGES:
+            raise ValueError(
+                f"Unknown exchange {v!r}. "
+                f"Supported: {sorted(SUPPORTED_STREAM_EXCHANGES)}"
+            )
+        return v
+
+    @field_validator('pairs', 'channels')
+    @classmethod
+    def _validate_nonempty(cls, v: list[str], info: Any) -> list[str]:
+        if not v:
+            raise ValueError(f"'{info.field_name}' must not be empty")
+        return v
+
+
+class AlertConfig(BaseModel):
+    """ Optional alerting configuration.
+
+    Parameters
+    ----------
+    webhook_url : str or None
+        Slack/Discord webhook URL for error notifications. ``None`` disables alerts.
+    max_consecutive_errors : int
+        Number of consecutive job failures before sending an alert, default 3.
+
+    """
+
+    webhook_url: str | None = None
+    max_consecutive_errors: int = 3
+
+
+class CollectorConfig(BaseModel):
+    """ Root configuration model for the dccd daemon.
+
+    Parameters
+    ----------
+    storage : StorageConfig
+        Local (and optional remote) storage settings.
+    histo_jobs : list of HistoJob
+        REST API polling jobs.
+    stream_jobs : list of StreamJob
+        WebSocket streaming jobs.
+    alerts : AlertConfig
+        Alerting settings.
+
+    """
+
+    storage: StorageConfig
+    histo_jobs: list[HistoJob] = Field(default_factory=list)
+    stream_jobs: list[StreamJob] = Field(default_factory=list)
+    alerts: AlertConfig = Field(default_factory=AlertConfig)
+
+    @model_validator(mode='after')
+    def _at_least_one_job(self) -> 'CollectorConfig':
+        if not self.histo_jobs and not self.stream_jobs:
+            raise ValueError(
+                "Configuration must define at least one job "
+                "(histo_jobs or stream_jobs)"
+            )
+        return self
+
+
+def load_config(path: str | pathlib.Path) -> CollectorConfig:
+    """ Load and validate a YAML daemon configuration file.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the YAML configuration file.
+
+    Returns
+    -------
+    CollectorConfig
+        Validated configuration object.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* does not exist.
+    yaml.YAMLError
+        If the file contains invalid YAML.
+    pydantic.ValidationError
+        If the configuration fails validation.
+
+    """
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return CollectorConfig.model_validate(data)

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Historical data scheduler for the dccd daemon.
+
+Wraps APScheduler 3.x BackgroundScheduler to run periodic REST API
+collection jobs defined in a :class:`~dccd.daemon.config.CollectorConfig`.
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from dccd.daemon.storage import RemoteStorage
+from dccd.histo_dl.binance import FromBinance
+from dccd.histo_dl.bybit import FromBybit
+from dccd.histo_dl.coinbase import FromCoinbase
+from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
+from dccd.histo_dl.kraken import FromKraken
+from dccd.histo_dl.okx import FromOKX
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import CollectorConfig, HistoJob
+
+__all__ = ['build_histo_scheduler', 'run_histo_job', 'run_once']
+
+logger = logging.getLogger(__name__)
+
+_HISTO_CLASSES: dict[str, type[ImportDataCryptoCurrencies]] = {
+    'binance': FromBinance,
+    'kraken': FromKraken,
+    'bybit': FromBybit,
+    'okx': FromOKX,
+    'coinbase': FromCoinbase,
+}
+
+
+def run_histo_job(
+    job: HistoJob,
+    pair: str,
+    base_path: str,
+    storage: RemoteStorage,
+) -> None:
+    """ Download and save one (exchange, pair) candle job, then push to remote.
+
+    Parameters
+    ----------
+    job : HistoJob
+        Job configuration (exchange, span, format, by_period).
+    pair : str
+        Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
+    base_path : str
+        Root directory for local storage (``CollectorConfig.storage.local_path``).
+    storage : RemoteStorage
+        Remote storage handler.  :meth:`~RemoteStorage.push` is called after
+        each successful save.
+
+    """
+    crypto, fiat = pair.split('/', 1)
+    cls = _HISTO_CLASSES[job.exchange]
+    obj = cls(base_path, crypto, job.span, fiat, form=job.format)
+    obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
+    storage.push(obj.full_path)
+    logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
+
+
+def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
+    """ Build an APScheduler BackgroundScheduler from a CollectorConfig.
+
+    One interval job is registered per ``(exchange, pair)`` combination in
+    ``config.histo_jobs``.  Each job runs with ``coalesce=True`` and
+    ``max_instances=1`` to prevent overlapping executions.
+
+    Parameters
+    ----------
+    config : CollectorConfig
+        Daemon configuration.
+
+    Returns
+    -------
+    apscheduler.schedulers.background.BackgroundScheduler
+        Configured scheduler, not yet started.
+
+    Examples
+    --------
+    >>> from dccd.daemon.config import load_config
+    >>> from dccd.daemon.scheduler import build_histo_scheduler
+    >>> # config = load_config('config.yml')
+    >>> # scheduler = build_histo_scheduler(config)
+    >>> # scheduler.start()
+
+    """
+    scheduler = BackgroundScheduler()
+    storage = RemoteStorage(config.storage)
+
+    for job in config.histo_jobs:
+        for pair in job.pairs:
+            job_id = f'{job.exchange}_{pair.replace("/", "_")}_{job.span}'
+            scheduler.add_job(
+                run_histo_job,
+                trigger='interval',
+                seconds=job.span,
+                args=[job, pair, config.storage.local_path, storage],
+                id=job_id,
+                name=f'{job.exchange} {pair} {job.span}s',
+                coalesce=True,
+                max_instances=1,
+            )
+            logger.debug('registered job %s', job_id)
+
+    return scheduler
+
+
+def run_once(config: CollectorConfig) -> None:
+    """ Execute all histo_jobs once and return.
+
+    Each ``(exchange, pair)`` combination is run sequentially.  A job
+    failure is logged and skipped — other jobs continue regardless.
+
+    Parameters
+    ----------
+    config : CollectorConfig
+        Daemon configuration.
+
+    """
+    storage = RemoteStorage(config.storage)
+
+    for job in config.histo_jobs:
+        for pair in job.pairs:
+            try:
+                run_histo_job(job, pair, config.storage.local_path, storage)
+            except Exception:
+                logger.exception(
+                    'histo job failed: %s %s', job.exchange, pair
+                )

--- a/dccd/daemon/storage.py
+++ b/dccd/daemon/storage.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Remote storage abstraction for the dccd daemon.
+
+Wraps rclone to push local data directories to any rclone-supported
+destination (NAS, SFTP, S3, Google Drive, …).
+
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import StorageConfig
+
+__all__ = ['RemoteStorage']
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteStorage:
+    """ Push local data directories to a remote destination via rclone.
+
+    If no remote is configured, :meth:`push` is a silent no-op and data
+    is kept on the daemon host only.
+
+    Parameters
+    ----------
+    config : StorageConfig
+        Storage configuration (local path + optional rclone remote).
+
+    """
+
+    def __init__(self, config: StorageConfig) -> None:
+        self.config = config
+        self._rclone_available: bool | None = None
+
+    def check_rclone(self) -> bool:
+        """ Check whether rclone is available in PATH (result is cached).
+
+        Returns
+        -------
+        bool
+            ``True`` if rclone is found, ``False`` otherwise.
+
+        """
+        if self._rclone_available is None:
+            self._rclone_available = shutil.which('rclone') is not None
+            if not self._rclone_available and self.config.remote is not None:
+                logger.warning(
+                    'rclone not found in PATH — remote sync disabled. '
+                    'Install rclone and ensure it is on your PATH.'
+                )
+        return self._rclone_available
+
+    def push(self, local_path: str | pathlib.Path) -> None:
+        """ Copy *local_path* to the configured remote destination.
+
+        The remote target mirrors the relative directory structure under
+        ``config.local_path``.  For example, if ``local_path`` is
+        ``/data/crypto/Binance/Data/Clean_Data/Hourly/BTCUSDT`` and
+        ``config.local_path`` is ``/data/crypto``, the remote target will
+        be ``<remote>/Binance/Data/Clean_Data/Hourly/BTCUSDT``.
+
+        Parameters
+        ----------
+        local_path : str or pathlib.Path
+            Absolute path of the directory to synchronise.
+
+        Notes
+        -----
+        This method never raises — failures are logged as errors so that
+        a remote-push failure does not interrupt the local collection loop.
+
+        """
+        if self.config.remote is None:
+            return
+
+        if not self.check_rclone():
+            return
+
+        local_abs = pathlib.Path(local_path).resolve()
+        base_abs = pathlib.Path(self.config.local_path).resolve()
+
+        try:
+            rel = local_abs.relative_to(base_abs)
+        except ValueError:
+            logger.error(
+                'push() called with path %s that is not under base %s',
+                local_abs, base_abs,
+            )
+            return
+
+        remote_target = self.config.remote.remote.rstrip('/') + '/' + str(rel)
+
+        result = subprocess.run(
+            ['rclone', 'copy', str(local_abs), remote_target],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        if result.returncode != 0:
+            logger.error(
+                'rclone copy failed (%s → %s): %s',
+                local_abs, remote_target, result.stderr.strip(),
+            )

--- a/dccd/tests/test_daemon_config.py
+++ b/dccd/tests/test_daemon_config.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import pathlib
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from dccd.daemon.config import (
+    CollectorConfig,
+    load_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_STORAGE = {'local_path': '/data/crypto/'}
+
+_VALID_HISTO_JOB = {
+    'exchange': 'binance',
+    'pairs': ['BTC/USDT', 'ETH/USDT'],
+    'span': 3600,
+    'format': 'parquet',
+    'by_period': 'Y',
+}
+
+_VALID_CONFIG = {
+    'storage': _VALID_STORAGE,
+    'histo_jobs': [_VALID_HISTO_JOB],
+}
+
+
+def _make_config_file(tmp_path: pathlib.Path, data: dict) -> pathlib.Path:
+    p = tmp_path / 'config.yml'
+    p.write_text(yaml.dump(data))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# CollectorConfig — valid cases
+# ---------------------------------------------------------------------------
+
+def test_valid_full_config():
+    cfg = CollectorConfig.model_validate(_VALID_CONFIG)
+    assert cfg.storage.local_path == '/data/crypto/'
+    assert len(cfg.histo_jobs) == 1
+    assert cfg.histo_jobs[0].exchange == 'binance'
+    assert cfg.histo_jobs[0].pairs == ['BTC/USDT', 'ETH/USDT']
+    assert cfg.histo_jobs[0].span == 3600
+
+
+def test_default_values_applied():
+    cfg = CollectorConfig.model_validate(_VALID_CONFIG)
+    assert cfg.stream_jobs == []
+    assert cfg.alerts.webhook_url is None
+    assert cfg.alerts.max_consecutive_errors == 3
+    assert cfg.histo_jobs[0].format == 'parquet'
+    assert cfg.histo_jobs[0].by_period == 'Y'
+
+
+def test_remote_config_parsed():
+    data = {
+        **_VALID_CONFIG,
+        'storage': {
+            'local_path': '/data/',
+            'remote': {'provider': 'rclone', 'remote': 'mynas:crypto/'},
+        },
+    }
+    cfg = CollectorConfig.model_validate(data)
+    assert cfg.storage.remote is not None
+    assert cfg.storage.remote.remote == 'mynas:crypto/'
+
+
+# ---------------------------------------------------------------------------
+# HistoJob — validation errors
+# ---------------------------------------------------------------------------
+
+def test_unknown_exchange_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'exchange': 'poloniex'}]}
+    with pytest.raises(ValidationError, match='Unknown exchange'):
+        CollectorConfig.model_validate(data)
+
+
+def test_span_too_small_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'span': 30}]}
+    with pytest.raises(ValidationError, match='span must be >= 60'):
+        CollectorConfig.model_validate(data)
+
+
+def test_unsupported_format_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'format': 'json'}]}
+    with pytest.raises(ValidationError, match='Unknown format'):
+        CollectorConfig.model_validate(data)
+
+
+def test_pair_missing_slash_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'pairs': ['BTCUSDT']}]}
+    with pytest.raises(ValidationError, match="CRYPTO/FIAT"):
+        CollectorConfig.model_validate(data)
+
+
+def test_empty_pairs_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'pairs': []}]}
+    with pytest.raises(ValidationError, match="must not be empty"):
+        CollectorConfig.model_validate(data)
+
+
+def test_invalid_by_period_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'by_period': 'W'}]}
+    with pytest.raises(ValidationError, match='Unknown by_period'):
+        CollectorConfig.model_validate(data)
+
+
+def test_no_jobs_raises():
+    data = {'storage': _VALID_STORAGE}
+    with pytest.raises(ValidationError, match='at least one job'):
+        CollectorConfig.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+def test_load_config_valid(tmp_path):
+    p = _make_config_file(tmp_path, _VALID_CONFIG)
+    cfg = load_config(p)
+    assert isinstance(cfg, CollectorConfig)
+    assert cfg.histo_jobs[0].exchange == 'binance'
+
+
+def test_load_config_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_config(tmp_path / 'nonexistent.yml')
+
+
+def test_load_config_invalid_yaml(tmp_path):
+    p = tmp_path / 'bad.yml'
+    p.write_text(': invalid: yaml: {')
+    with pytest.raises(yaml.YAMLError):
+        load_config(p)
+
+
+def test_load_config_validation_error(tmp_path):
+    bad = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'span': 10}]}
+    p = _make_config_file(tmp_path, bad)
+    with pytest.raises(ValidationError):
+        load_config(p)

--- a/dccd/tests/test_daemon_scheduler.py
+++ b/dccd/tests/test_daemon_scheduler.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from unittest.mock import MagicMock, patch
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from dccd.daemon.config import CollectorConfig, HistoJob, StorageConfig
+from dccd.daemon.scheduler import build_histo_scheduler, run_histo_job, run_once
+from dccd.daemon.storage import RemoteStorage
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_config(histo_jobs=None, tmp_path=None):
+    path = str(tmp_path) if tmp_path else '/data/crypto/'
+    return CollectorConfig(
+        storage=StorageConfig(local_path=path),
+        histo_jobs=histo_jobs or [
+            HistoJob(exchange='binance', pairs=['BTC/USDT', 'ETH/USDT'], span=3600),
+            HistoJob(exchange='kraken', pairs=['BTC/USD'], span=86400),
+        ],
+    )
+
+
+def _make_storage(tmp_path):
+    return RemoteStorage(StorageConfig(local_path=str(tmp_path)))
+
+
+# ---------------------------------------------------------------------------
+# build_histo_scheduler
+# ---------------------------------------------------------------------------
+
+def test_scheduler_type(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    scheduler = build_histo_scheduler(cfg)
+    assert isinstance(scheduler, BackgroundScheduler)
+
+
+def test_scheduler_job_count(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    scheduler = build_histo_scheduler(cfg)
+    jobs = scheduler.get_jobs()
+    # 2 pairs (binance) + 1 pair (kraken) = 3 jobs
+    assert len(jobs) == 3
+
+
+def test_scheduler_job_ids(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    scheduler = build_histo_scheduler(cfg)
+    ids = {j.id for j in scheduler.get_jobs()}
+    assert 'binance_BTC_USDT_3600' in ids
+    assert 'binance_ETH_USDT_3600' in ids
+    assert 'kraken_BTC_USD_86400' in ids
+
+
+def test_scheduler_interval_seconds(tmp_path):
+    cfg = _make_config(
+        histo_jobs=[HistoJob(exchange='bybit', pairs=['BTC/USDT'], span=900)],
+        tmp_path=tmp_path,
+    )
+    scheduler = build_histo_scheduler(cfg)
+    job = scheduler.get_jobs()[0]
+    assert job.trigger.interval.total_seconds() == 900
+
+
+# ---------------------------------------------------------------------------
+# run_histo_job
+# ---------------------------------------------------------------------------
+
+def _mock_exchange_cls(tmp_path_str):
+    """Return a mock exchange class and instance pair."""
+    mock_obj = MagicMock()
+    mock_obj.import_data.return_value = mock_obj
+    mock_obj.save.return_value = mock_obj
+    mock_obj.full_path = tmp_path_str
+    mock_cls = MagicMock(return_value=mock_obj)
+    return mock_cls, mock_obj
+
+
+def test_run_histo_job_calls_chain(tmp_path):
+    import dccd.daemon.scheduler as sched_mod
+
+    job = HistoJob(exchange='binance', pairs=['BTC/USDT'], span=3600)
+    storage = MagicMock(spec=RemoteStorage)
+    mock_cls, mock_obj = _mock_exchange_cls(str(tmp_path / 'Binance'))
+
+    original = sched_mod._HISTO_CLASSES.copy()
+    sched_mod._HISTO_CLASSES['binance'] = mock_cls
+    try:
+        run_histo_job(job, 'BTC/USDT', str(tmp_path), storage)
+    finally:
+        sched_mod._HISTO_CLASSES.update(original)
+
+    mock_cls.assert_called_once_with(str(tmp_path), 'BTC', 3600, 'USDT', form='parquet')
+    mock_obj.import_data.assert_called_once_with('last', 'now')
+    mock_obj.save.assert_called_once_with(form='parquet', by_period='Y')
+    storage.push.assert_called_once_with(str(tmp_path / 'Binance'))
+
+
+def test_run_histo_job_splits_pair_correctly(tmp_path):
+    import dccd.daemon.scheduler as sched_mod
+
+    job = HistoJob(exchange='okx', pairs=['ETH/USDT'], span=3600)
+    storage = MagicMock(spec=RemoteStorage)
+    mock_cls, mock_obj = _mock_exchange_cls('/tmp')
+    mock_obj.full_path = '/tmp'
+
+    original = sched_mod._HISTO_CLASSES.copy()
+    sched_mod._HISTO_CLASSES['okx'] = mock_cls
+    try:
+        run_histo_job(job, 'ETH/USDT', str(tmp_path), storage)
+    finally:
+        sched_mod._HISTO_CLASSES.update(original)
+
+    mock_cls.assert_called_once_with(str(tmp_path), 'ETH', 3600, 'USDT', form='parquet')
+
+
+# ---------------------------------------------------------------------------
+# run_once
+# ---------------------------------------------------------------------------
+
+def test_run_once_executes_all_jobs(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+
+    with patch('dccd.daemon.scheduler.run_histo_job') as mock_job:
+        run_once(cfg)
+
+    assert mock_job.call_count == 3  # BTC/USDT, ETH/USDT (binance) + BTC/USD (kraken)
+
+
+def test_run_once_job_failure_does_not_stop_others(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    call_log = []
+
+    def _side_effect(job, pair, *args, **kwargs):
+        call_log.append(pair)
+        if pair == 'BTC/USDT' and job.exchange == 'binance':
+            raise RuntimeError('network error')
+
+    with patch('dccd.daemon.scheduler.run_histo_job', side_effect=_side_effect):
+        run_once(cfg)  # must not raise
+
+    assert 'ETH/USDT' in call_log
+    assert 'BTC/USD' in call_log
+
+
+def test_run_once_logs_exception_on_failure(tmp_path, caplog):
+    cfg = _make_config(
+        histo_jobs=[HistoJob(exchange='binance', pairs=['BTC/USDT'], span=3600)],
+        tmp_path=tmp_path,
+    )
+
+    import logging
+    with patch('dccd.daemon.scheduler.run_histo_job', side_effect=ValueError('boom')):
+        with caplog.at_level(logging.ERROR, logger='dccd.daemon.scheduler'):
+            run_once(cfg)
+
+    assert 'histo job failed' in caplog.text

--- a/dccd/tests/test_daemon_storage.py
+++ b/dccd/tests/test_daemon_storage.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from unittest.mock import MagicMock, patch
+
+from dccd.daemon.config import RemoteConfig, StorageConfig
+from dccd.daemon.storage import RemoteStorage
+
+
+def _storage(tmp_path, remote=None):
+    cfg = StorageConfig(local_path=str(tmp_path), remote=remote)
+    return RemoteStorage(cfg)
+
+
+def _remote():
+    return RemoteConfig(provider='rclone', remote='mynas:crypto/')
+
+
+# ---------------------------------------------------------------------------
+# push() without remote — no-op
+# ---------------------------------------------------------------------------
+
+def test_push_no_remote_never_calls_subprocess(tmp_path):
+    s = _storage(tmp_path)
+    sub_dir = tmp_path / 'Binance'
+    sub_dir.mkdir()
+    with patch('subprocess.run') as mock_run:
+        s.push(sub_dir)
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# check_rclone()
+# ---------------------------------------------------------------------------
+
+def test_check_rclone_found(tmp_path):
+    s = _storage(tmp_path, _remote())
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        assert s.check_rclone() is True
+
+
+def test_check_rclone_not_found_logs_warning(tmp_path, caplog):
+    s = _storage(tmp_path, _remote())
+    import logging
+    with patch('shutil.which', return_value=None):
+        with caplog.at_level(logging.WARNING, logger='dccd.daemon.storage'):
+            result = s.check_rclone()
+    assert result is False
+    assert 'rclone not found' in caplog.text
+
+
+def test_check_rclone_cached(tmp_path):
+    s = _storage(tmp_path, _remote())
+    with patch('shutil.which', return_value='/usr/bin/rclone') as mock_which:
+        s.check_rclone()
+        s.check_rclone()
+    mock_which.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# push() with remote + rclone present
+# ---------------------------------------------------------------------------
+
+def test_push_calls_rclone_with_correct_args(tmp_path):
+    s = _storage(tmp_path, _remote())
+    sub_dir = tmp_path / 'Binance' / 'Data'
+    sub_dir.mkdir(parents=True)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(sub_dir)
+
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args[0] == 'rclone'
+    assert args[1] == 'copy'
+    assert args[2] == str(sub_dir.resolve())
+    assert args[3] == 'mynas:crypto/Binance/Data'
+
+
+def test_push_remote_no_trailing_slash(tmp_path):
+    remote = RemoteConfig(provider='rclone', remote='mynas:crypto')  # no trailing /
+    s = _storage(tmp_path, remote)
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(sub_dir)
+
+    dest = mock_run.call_args[0][0][3]
+    assert dest == 'mynas:crypto/sub'
+
+
+# ---------------------------------------------------------------------------
+# push() with rclone not found
+# ---------------------------------------------------------------------------
+
+def test_push_rclone_absent_does_not_call_subprocess(tmp_path):
+    s = _storage(tmp_path, _remote())
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    with patch('shutil.which', return_value=None):
+        with patch('subprocess.run') as mock_run:
+            s.push(sub_dir)
+
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# push() when rclone returns non-zero exit code
+# ---------------------------------------------------------------------------
+
+def test_push_rclone_failure_logs_error_no_exception(tmp_path, caplog):
+    s = _storage(tmp_path, _remote())
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stderr = 'connection refused'
+
+    import logging
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result):
+            with caplog.at_level(logging.ERROR, logger='dccd.daemon.storage'):
+                s.push(sub_dir)  # must NOT raise
+
+    assert 'rclone copy failed' in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# push() with path outside base
+# ---------------------------------------------------------------------------
+
+def test_push_path_outside_base_logs_error(tmp_path, caplog):
+    s = _storage(tmp_path, _remote())
+    outside = tmp_path.parent / 'other'
+    outside.mkdir(exist_ok=True)
+
+    import logging
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run') as mock_run:
+            with caplog.at_level(logging.ERROR, logger='dccd.daemon.storage'):
+                s.push(outside)
+
+    mock_run.assert_not_called()
+    assert 'not under base' in caplog.text

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -1,0 +1,81 @@
+# dccd daemon — example configuration
+#
+# Copy this file, adapt it to your setup, and pass it to the daemon:
+#   dccd validate --config config.yml    # check without running
+#   dccd run --once --config config.yml  # run all jobs once and exit
+#   dccd start --config config.yml       # run as a daemon
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+storage:
+  # Root directory on the daemon host where data files are written.
+  local_path: /data/crypto/
+
+  # Optional: push data to a remote after each save.
+  # Requires rclone (https://rclone.org) installed on the daemon host and
+  # a named remote configured with `rclone config`.
+  #
+  # Examples:
+  #   mynas:crypto/         → NAS / Freebox via SMB or SFTP
+  #   mypc:data/crypto/     → local PC via SFTP (OpenSSH)
+  #   s3:mybucket/crypto/   → Amazon S3
+  #   gdrive:crypto/        → Google Drive
+  #
+  # Remove this block to keep data on the daemon host only.
+  remote:
+    provider: rclone
+    remote: "mynas:crypto/"   # rclone remote name + path
+
+
+# ---------------------------------------------------------------------------
+# Historical (REST API) jobs
+# ---------------------------------------------------------------------------
+# Each job polls one exchange at a fixed interval and saves OHLCV candles.
+# One file per period (by_period) is created under:
+#   {local_path}/{Exchange}/Data/Clean_Data/{span_label}/{pair}/
+histo_jobs:
+
+  - exchange: binance          # one of: binance, kraken, bybit, okx, coinbase
+    pairs:
+      - BTC/USDT               # 'CRYPTO/FIAT' format
+      - ETH/USDT
+    span: 3600                 # candle interval in seconds (>= 60)
+    format: parquet            # one of: parquet, csv, xlsx
+    by_period: Y               # file grouping: Y (year), M (month), D (day)
+
+  - exchange: kraken
+    pairs:
+      - BTC/USD
+      - ETH/USD
+    span: 86400                # daily candles
+    format: parquet
+    by_period: Y
+
+  - exchange: bybit
+    pairs:
+      - BTC/USDT
+    span: 900                  # 15-minute candles
+    format: csv
+    by_period: M               # one file per month
+
+
+# ---------------------------------------------------------------------------
+# Real-time (WebSocket) jobs  [not yet implemented — reserved for task 4.4]
+# ---------------------------------------------------------------------------
+# stream_jobs:
+#   - exchange: binance
+#     pairs:
+#       - BTC/USDT
+#     channels:
+#       - trades
+#       - book
+#     time_step: 60            # snapshot interval in seconds
+
+
+# ---------------------------------------------------------------------------
+# Alerts  (optional)
+# ---------------------------------------------------------------------------
+# alerts:
+#   webhook_url: "https://hooks.slack.com/services/T.../B.../..."
+#   max_consecutive_errors: 3  # send alert after N consecutive failures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
 
 [project.optional-dependencies]
 io = ["pyarrow>=13", "polars>=0.20"]
-dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0"]
+daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4"]
+dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
 doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton"]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Declarative YAML config with Pydantic v2 validation (`CollectorConfig`, `HistoJob`, `StorageConfig`, `RemoteConfig`, `AlertConfig`)
- `RemoteStorage.push()` delegates to rclone via subprocess; gracefully degrades if rclone is absent
- APScheduler 3.x-based histo scheduler: `build_histo_scheduler()`, `run_histo_job()`, `run_once()`

## Changes

- `dccd/daemon/config.py` — Pydantic models + `load_config()` YAML loader with strict validation (exchange allowlist, span ≥ 60, format/by_period/pair format checks)
- `dccd/daemon/storage.py` — `RemoteStorage`: rclone copy via subprocess, path safety check (must be under base), caches rclone availability
- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (one APScheduler interval job per `(exchange, pair)`), `run_histo_job()`, `run_once()` with per-job error isolation
- `dccd/daemon/__init__.py` — public re-exports
- `examples/config.example.yml` — annotated reference config (storage, histo_jobs, commented stream_jobs and alerts)
- `pyproject.toml` — `[daemon]` optional extra (`pyyaml>=6.0`, `apscheduler>=3.10,<4`)
- 33 new tests across `test_daemon_config.py`, `test_daemon_storage.py`, `test_daemon_scheduler.py`

## Changelog

Added under [Unreleased]:
- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2
- `dccd/daemon/storage.py` — `RemoteStorage.push()` via rclone
- `dccd/daemon/scheduler.py` — APScheduler-based histo scheduler
- `examples/config.example.yml` — annotated reference config
- `pyproject.toml` — `[daemon]` optional extra

## Test plan

- [x] pytest passes locally (165 passed)
- [x] ruff check dccd/ passes
- [ ] CI green