### PR TITLE
feat: add StreamManager, SyncService, and refactor storage to multi-remote (task 4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#XX)
+- `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#26)
 - `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
 - `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)
 - `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#25)
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `dccd/daemon/config.py` — `StorageConfig.remote: RemoteConfig | None` replaced by `remotes: list[RemoteConfig]` (multiple destinations) and `sync_interval: int` (default 3600 s) (#XX)
-- `dccd/daemon/storage.py` — `RemoteStorage.push()` now iterates all `config.remotes`; supports root-path sync (path == local_path) (#XX)
-- `dccd/daemon/scheduler.py` — `run_histo_job` no longer takes a `storage` argument and no longer pushes; remote sync is fully delegated to `SyncService` (#XX)
+- `dccd/daemon/config.py` — `StorageConfig.remote: RemoteConfig | None` replaced by `remotes: list[RemoteConfig]` (multiple destinations) and `sync_interval: int` (default 3600 s) (#26)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()` now iterates all `config.remotes`; supports root-path sync (path == local_path) (#26)
+- `dccd/daemon/scheduler.py` — `run_histo_job` no longer takes a `storage` argument and no longer pushes; remote sync is fully delegated to `SyncService` (#26)
 
 ## [2.1.0] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#XX)
 - `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
 - `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)
 - `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#25)
 - `examples/config.example.yml` — annotated reference config for the daemon (#25)
 - `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#25)
+
+### Changed
+
+- `dccd/daemon/config.py` — `StorageConfig.remote: RemoteConfig | None` replaced by `remotes: list[RemoteConfig]` (multiple destinations) and `sync_interval: int` (default 3600 s) (#XX)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()` now iterates all `config.remotes`; supports root-path sync (path == local_path) (#XX)
+- `dccd/daemon/scheduler.py` — `run_histo_job` no longer takes a `storage` argument and no longer pushes; remote sync is fully delegated to `SyncService` (#XX)
 
 ## [2.1.0] - 2026-05-15
 

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,10 @@ With optional Parquet / Polars support::
 
     $ pip install "dccd[io]"
 
+With autonomous daemon support (APScheduler + PyYAML)::
+
+    $ pip install "dccd[daemon]"
+
 From source::
 
     $ git clone https://github.com/ArthurBernard/Download_Crypto_Currencies_Data
@@ -93,6 +97,14 @@ Presentation
     Stream real-time data (order book, trades) via WebSocket with automatic
     reconnection and configurable processing/saving callbacks.
 
+**Daemon** ``dccd.daemon``
+    Autonomous, server-side collector driven by a YAML config.  Runs REST
+    jobs on a schedule (APScheduler), opens WebSocket streams for real-time
+    collection, and periodically syncs all local data to one or more remote
+    destinations (NAS, S3, SFTP, …) via rclone.  Multiple remotes and a
+    configurable sync interval are supported; collection is never blocked by
+    remote availability.
+
 Output formats
 --------------
 
@@ -128,6 +140,43 @@ Other exchanges::
     FromKraken('/path/', 'ETH', 3600).import_data(start='2024-01-01', end='now').save()
     FromBybit('/path/', 'BTC', 86400).import_data(start='2024-01-01', end='now').save()
     FromOKX('/path/', 'BTC', 3600).import_data(start='2024-01-01', end='now').save()
+
+Daemon (autonomous collector)::
+
+    # config.yml
+    # storage:
+    #   local_path: /data/crypto/
+    #   remotes:
+    #     - provider: rclone
+    #       remote: "mynas:crypto/"
+    #   sync_interval: 3600
+    # histo_jobs:
+    #   - exchange: binance
+    #     pairs: [BTC/USDT, ETH/USDT]
+    #     span: 3600
+    #     format: parquet
+    #     by_period: Y
+    # stream_jobs:
+    #   - exchange: binance
+    #     pairs: [BTC/USDT]
+    #     channels: [trades, book]
+    #     time_step: 60
+
+    from dccd.daemon.config import load_config
+    from dccd.daemon.scheduler import run_once, build_histo_scheduler
+    from dccd.daemon.stream_manager import StreamManager
+
+    config = load_config('config.yml')
+
+    # One-shot: download all histo jobs once, then exit
+    run_once(config)
+
+    # Daemon mode: periodic REST + live WebSocket streams
+    scheduler = build_histo_scheduler(config)
+    scheduler.start()
+
+    mgr = StreamManager(config)
+    mgr.start()      # blocks until mgr.stop() is called
 
 Links
 =====

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,9 @@ Parquet files can be read back as either a ``pandas.DataFrame`` or a
 Quick start
 ===========
 
-Historical data (pandas)::
+Historical data (pandas):
+
+.. code-block:: python
 
     from dccd.histo_dl import FromBinance
 
@@ -125,15 +127,21 @@ Historical data (pandas)::
     obj.save(form='parquet')
     df = obj.get_data()            # pandas DataFrame
 
-Polars output::
+Polars output:
+
+.. code-block:: python
 
     df_pl = obj.get_data(format='polars')
 
-Incremental update (resume from last saved point)::
+Incremental update (resume from last saved point):
+
+.. code-block:: python
 
     obj.import_data(start='last', end='now').save(form='parquet')
 
-Other exchanges::
+Other exchanges:
+
+.. code-block:: python
 
     from dccd.histo_dl import FromKraken, FromBybit, FromOKX
 
@@ -141,26 +149,31 @@ Other exchanges::
     FromBybit('/path/', 'BTC', 86400).import_data(start='2024-01-01', end='now').save()
     FromOKX('/path/', 'BTC', 3600).import_data(start='2024-01-01', end='now').save()
 
-Daemon (autonomous collector)::
+Daemon (autonomous collector) — ``config.yml``:
 
-    # config.yml
-    # storage:
-    #   local_path: /data/crypto/
-    #   remotes:
-    #     - provider: rclone
-    #       remote: "mynas:crypto/"
-    #   sync_interval: 3600
-    # histo_jobs:
-    #   - exchange: binance
-    #     pairs: [BTC/USDT, ETH/USDT]
-    #     span: 3600
-    #     format: parquet
-    #     by_period: Y
-    # stream_jobs:
-    #   - exchange: binance
-    #     pairs: [BTC/USDT]
-    #     channels: [trades, book]
-    #     time_step: 60
+.. code-block:: yaml
+
+    storage:
+      local_path: /data/crypto/
+      remotes:
+        - provider: rclone
+          remote: "mynas:crypto/"
+      sync_interval: 3600
+
+    histo_jobs:
+      - exchange: binance
+        pairs: [BTC/USDT, ETH/USDT]
+        span: 3600
+        format: parquet
+        by_period: Y
+
+    stream_jobs:
+      - exchange: binance
+        pairs: [BTC/USDT]
+        channels: [trades, book]
+        time_step: 60
+
+.. code-block:: python
 
     from dccd.daemon.config import load_config
     from dccd.daemon.scheduler import run_once, build_histo_scheduler
@@ -176,7 +189,7 @@ Daemon (autonomous collector)::
     scheduler.start()
 
     mgr = StreamManager(config)
-    mgr.start()      # blocks until mgr.stop() is called
+    mgr.start()      # runs until mgr.stop() is called
 
 Links
 =====

--- a/dccd/daemon/__init__.py
+++ b/dccd/daemon/__init__.py
@@ -13,17 +13,21 @@ Submodules
    config
    storage
    scheduler
+   stream_manager
 
 """
 
 from dccd.daemon.config import CollectorConfig, load_config
 from dccd.daemon.scheduler import build_histo_scheduler, run_once
 from dccd.daemon.storage import RemoteStorage
+from dccd.daemon.stream_manager import StreamManager, SyncService
 
 __all__ = [
     'CollectorConfig',
     'load_config',
     'RemoteStorage',
+    'StreamManager',
+    'SyncService',
     'build_histo_scheduler',
     'run_once',
 ]

--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -58,13 +58,18 @@ class StorageConfig(BaseModel):
     ----------
     local_path : str
         Absolute path where data is stored on the daemon host.
-    remote : RemoteConfig or None
-        Remote push configuration. If ``None``, data is kept locally only.
+    remotes : list of RemoteConfig
+        Remote destinations.  Empty list (default) keeps data locally only.
+        Multiple entries are all synced by :class:`SyncService`.
+    sync_interval : int
+        Seconds between periodic syncs to remote destinations.  ``0`` disables
+        the sync service.  Default is ``3600`` (1 hour).
 
     """
 
     local_path: str
-    remote: RemoteConfig | None = None
+    remotes: list[RemoteConfig] = Field(default_factory=list)
+    sync_interval: int = 3600
 
 
 class HistoJob(BaseModel):

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
-from dccd.daemon.storage import RemoteStorage
 from dccd.histo_dl.binance import FromBinance
 from dccd.histo_dl.bybit import FromBybit
 from dccd.histo_dl.coinbase import FromCoinbase
@@ -39,13 +38,11 @@ _HISTO_CLASSES: dict[str, type[ImportDataCryptoCurrencies]] = {
 }
 
 
-def run_histo_job(
-    job: HistoJob,
-    pair: str,
-    base_path: str,
-    storage: RemoteStorage,
-) -> None:
-    """ Download and save one (exchange, pair) candle job, then push to remote.
+def run_histo_job(job: HistoJob, pair: str, base_path: str) -> None:
+    """ Download and save one (exchange, pair) candle job locally.
+
+    Data is saved to ``base_path`` on the daemon host.  Remote sync is
+    handled separately by :class:`~dccd.daemon.stream_manager.SyncService`.
 
     Parameters
     ----------
@@ -55,16 +52,12 @@ def run_histo_job(
         Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
     base_path : str
         Root directory for local storage (``CollectorConfig.storage.local_path``).
-    storage : RemoteStorage
-        Remote storage handler.  :meth:`~RemoteStorage.push` is called after
-        each successful save.
 
     """
     crypto, fiat = pair.split('/', 1)
     cls = _HISTO_CLASSES[job.exchange]
     obj = cls(base_path, crypto, job.span, fiat, form=job.format)
     obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
-    storage.push(obj.full_path)
     logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
 
 
@@ -95,7 +88,6 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
 
     """
     scheduler = BackgroundScheduler()
-    storage = RemoteStorage(config.storage)
 
     for job in config.histo_jobs:
         for pair in job.pairs:
@@ -104,7 +96,7 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
                 run_histo_job,
                 trigger='interval',
                 seconds=job.span,
-                args=[job, pair, config.storage.local_path, storage],
+                args=[job, pair, config.storage.local_path],
                 id=job_id,
                 name=f'{job.exchange} {pair} {job.span}s',
                 coalesce=True,
@@ -127,12 +119,10 @@ def run_once(config: CollectorConfig) -> None:
         Daemon configuration.
 
     """
-    storage = RemoteStorage(config.storage)
-
     for job in config.histo_jobs:
         for pair in job.pairs:
             try:
-                run_histo_job(job, pair, config.storage.local_path, storage)
+                run_histo_job(job, pair, config.storage.local_path)
             except Exception:
                 logger.exception(
                     'histo job failed: %s %s', job.exchange, pair

--- a/dccd/daemon/storage.py
+++ b/dccd/daemon/storage.py
@@ -25,15 +25,15 @@ logger = logging.getLogger(__name__)
 
 
 class RemoteStorage:
-    """ Push local data directories to a remote destination via rclone.
+    """ Push local data directories to remote destinations via rclone.
 
-    If no remote is configured, :meth:`push` is a silent no-op and data
+    If no remotes are configured, :meth:`push` is a silent no-op and data
     is kept on the daemon host only.
 
     Parameters
     ----------
     config : StorageConfig
-        Storage configuration (local path + optional rclone remote).
+        Storage configuration (local path + optional rclone remotes).
 
     """
 
@@ -50,9 +50,11 @@ class RemoteStorage:
             ``True`` if rclone is found, ``False`` otherwise.
 
         """
+        if not self.config.remotes:
+            return False
         if self._rclone_available is None:
             self._rclone_available = shutil.which('rclone') is not None
-            if not self._rclone_available and self.config.remote is not None:
+            if not self._rclone_available and self.config.remotes:
                 logger.warning(
                     'rclone not found in PATH — remote sync disabled. '
                     'Install rclone and ensure it is on your PATH.'
@@ -60,13 +62,14 @@ class RemoteStorage:
         return self._rclone_available
 
     def push(self, local_path: str | pathlib.Path) -> None:
-        """ Copy *local_path* to the configured remote destination.
+        """ Copy *local_path* to all configured remote destinations.
 
         The remote target mirrors the relative directory structure under
         ``config.local_path``.  For example, if ``local_path`` is
-        ``/data/crypto/Binance/Data/Clean_Data/Hourly/BTCUSDT`` and
-        ``config.local_path`` is ``/data/crypto``, the remote target will
-        be ``<remote>/Binance/Data/Clean_Data/Hourly/BTCUSDT``.
+        ``/data/crypto/Binance`` and ``config.local_path`` is ``/data/crypto``,
+        the target will be ``<remote>/Binance``.  If ``local_path`` equals
+        ``config.local_path`` (root sync), the contents are copied directly
+        into each remote root.
 
         Parameters
         ----------
@@ -79,7 +82,7 @@ class RemoteStorage:
         a remote-push failure does not interrupt the local collection loop.
 
         """
-        if self.config.remote is None:
+        if not self.config.remotes:
             return
 
         if not self.check_rclone():
@@ -97,17 +100,19 @@ class RemoteStorage:
             )
             return
 
-        remote_target = self.config.remote.remote.rstrip('/') + '/' + str(rel)
+        for remote_cfg in self.config.remotes:
+            root = remote_cfg.remote.rstrip('/')
+            remote_target = root if str(rel) == '.' else f'{root}/{rel}'
 
-        result = subprocess.run(
-            ['rclone', 'copy', str(local_abs), remote_target],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-
-        if result.returncode != 0:
-            logger.error(
-                'rclone copy failed (%s → %s): %s',
-                local_abs, remote_target, result.stderr.strip(),
+            result = subprocess.run(
+                ['rclone', 'copy', str(local_abs), remote_target],
+                capture_output=True,
+                text=True,
+                timeout=300,
             )
+
+            if result.returncode != 0:
+                logger.error(
+                    'rclone copy failed (%s → %s): %s',
+                    local_abs, remote_target, result.stderr.strip(),
+                )

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 # Exchange class registry
 # ---------------------------------------------------------------------------
 
-_STREAM_CLASSES: dict[str, type[ContinuousDownloader]] = {
+_STREAM_CLASSES: dict[str, Any] = {
     'binance':  DownloadBinanceData,
     'bybit':    DownloadBybitData,
     'kraken':   DownloadKrakenData,

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Real-time stream manager and periodic sync service for the dccd daemon.
+
+:class:`SyncService` runs a background thread that pushes the entire local
+data directory to all configured remotes at a fixed interval.
+
+:class:`StreamManager` starts one background thread per ``(exchange, pair)``
+combination (or per ``(exchange, pair, channel)`` for Bitfinex/Bitmex) and
+restarts them automatically on failure.
+
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+from dccd.continuous_dl.binance import DownloadBinanceData
+from dccd.continuous_dl.bitfinex import DownloadBitfinexData
+from dccd.continuous_dl.bitmex import DownloadBitmexData
+from dccd.continuous_dl.bybit import DownloadBybitData
+from dccd.continuous_dl.exchange import ContinuousDownloader
+from dccd.continuous_dl.kraken import DownloadKrakenData
+from dccd.continuous_dl.okx import DownloadOKXData
+from dccd.daemon.storage import RemoteStorage
+from dccd.process_data import set_marketdepth, set_orders, set_trades
+from dccd.tools.io import IODataBase
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import CollectorConfig, StorageConfig, StreamJob
+
+__all__ = ['StreamManager', 'SyncService']
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exchange class registry
+# ---------------------------------------------------------------------------
+
+_STREAM_CLASSES: dict[str, type[ContinuousDownloader]] = {
+    'binance':  DownloadBinanceData,
+    'bybit':    DownloadBybitData,
+    'kraken':   DownloadKrakenData,
+    'okx':      DownloadOKXData,
+    'bitfinex': DownloadBitfinexData,
+    'bitmex':   DownloadBitmexData,
+}
+
+# Bitfinex/Bitmex use one WS connection per channel → one thread per channel.
+# Other exchanges bundle all channels in one connection → one thread per pair.
+_PER_CHANNEL_EXCHANGES = frozenset({'bitfinex', 'bitmex'})
+
+# Channel name mappings for legacy exchanges
+_BITFINEX_CHANNEL: dict[str, str] = {'trades': 'trades', 'book': 'book'}
+_BITMEX_CHANNEL:   dict[str, str] = {'trades': 'trade',  'book': 'orderBookL2_25'}
+
+_RESTART_DELAY = 30  # seconds between stream restarts after a crash
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _format_pair(exchange: str, pair: str) -> str:
+    """ Convert ``'BTC/USDT'`` to the exchange-specific pair format.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name (lowercase).
+    pair : str
+        Trading pair in ``'CRYPTO/FIAT'`` format.
+
+    Returns
+    -------
+    str
+        Exchange-specific pair string.
+
+    Raises
+    ------
+    ValueError
+        If *exchange* is not supported for streaming.
+
+    """
+    crypto, fiat = pair.split('/', 1)
+    if exchange in ('binance', 'bybit'):
+        return crypto + fiat
+    if exchange == 'kraken':
+        return pair
+    if exchange == 'okx':
+        return f'{crypto}-{fiat}'
+    if exchange == 'bitfinex':
+        fiat_bf = 'UST' if fiat == 'USDT' else fiat
+        return f't{crypto}{fiat_bf}'
+    if exchange == 'bitmex':
+        xbt = 'XBT' if crypto == 'BTC' else crypto
+        return xbt + fiat
+    raise ValueError(f'exchange {exchange!r} is not supported for streaming')
+
+
+def _process_fn(channels: list[str]) -> Any:
+    """ Return the appropriate ``process_data`` function for *channels*.
+
+    Parameters
+    ----------
+    channels : list of str
+        Channel names (``'trades'``, ``'book'``, …).
+
+    Returns
+    -------
+    callable
+        One of :func:`~dccd.process_data.set_trades`,
+        :func:`~dccd.process_data.set_marketdepth`,
+        :func:`~dccd.process_data.set_orders`.
+
+    """
+    has_trades = 'trades' in channels
+    has_book   = 'book'   in channels
+    if has_trades and has_book:
+        return set_orders
+    if has_trades:
+        return set_trades
+    if has_book:
+        return set_marketdepth
+    return set_orders
+
+
+def _connect_kwargs(exchange: str, pair: str, channels: list[str]) -> dict[str, Any]:
+    """ Return keyword arguments to pass to ``downloader._connect()``.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name.
+    pair : str
+        Trading pair in ``'CRYPTO/FIAT'`` format.
+    channels : list of str
+        Channel(s) for this thread (singleton for Bitfinex/Bitmex).
+
+    Returns
+    -------
+    dict
+        Empty for exchanges that embed subscription in ``__init__``;
+        channel/symbol kwargs for Bitfinex; ``args`` string for Bitmex.
+
+    """
+    ch = channels[0]
+    if exchange == 'bitfinex':
+        return {'channel': _BITFINEX_CHANNEL.get(ch, ch),
+                'symbol':  _format_pair('bitfinex', pair)}
+    if exchange == 'bitmex':
+        bch = _BITMEX_CHANNEL.get(ch, ch)
+        return {'args': f'{bch}:{_format_pair("bitmex", pair)}'}
+    return {}
+
+
+def _iter_tasks(job: StreamJob) -> Iterator[tuple[str, list[str]]]:
+    """ Yield ``(pair, channels)`` for each thread to create.
+
+    Bitfinex and Bitmex have one WS connection per channel, so each
+    ``(pair, channel)`` pair gets its own thread.  All other exchanges
+    handle multiple channels in one connection.
+
+    Parameters
+    ----------
+    job : StreamJob
+        Stream job configuration.
+
+    Yields
+    ------
+    pair : str
+    channels : list of str
+
+    """
+    if job.exchange in _PER_CHANNEL_EXCHANGES:
+        for pair in job.pairs:
+            for ch in job.channels:
+                yield pair, [ch]
+    else:
+        for pair in job.pairs:
+            yield pair, job.channels
+
+
+# ---------------------------------------------------------------------------
+# SyncService
+# ---------------------------------------------------------------------------
+
+class SyncService:
+    """ Periodically push the entire local data directory to all remotes.
+
+    This is the single point of truth for remote synchronisation.  Neither
+    histo jobs nor stream threads push data themselves — they save locally
+    and rely on this service to replicate to remote destinations.
+
+    Parameters
+    ----------
+    config : StorageConfig
+        Storage configuration (``remotes`` list + ``sync_interval``).
+
+    Notes
+    -----
+    If ``config.remotes`` is empty or ``config.sync_interval`` is 0, the
+    service is a no-op and no background thread is started.
+
+    """
+
+    def __init__(self, config: StorageConfig) -> None:
+        self.config = config
+        self._storage = RemoteStorage(config)
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """ Start the background sync thread (idempotent). """
+        if not self.config.remotes or self.config.sync_interval <= 0:
+            logger.info(
+                'SyncService disabled (remotes=%d, sync_interval=%d)',
+                len(self.config.remotes), self.config.sync_interval,
+            )
+            return
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True, name='sync-service',
+        )
+        self._thread.start()
+        logger.info('SyncService started (interval=%ds)', self.config.sync_interval)
+
+    def stop(self) -> None:
+        """ Signal the sync thread to stop at the next interval boundary. """
+        self._stop.set()
+
+    def sync_now(self) -> None:
+        """ Push ``local_path`` to all remotes immediately (blocking). """
+        self._storage.push(self.config.local_path)
+
+    def _loop(self) -> None:
+        while not self._stop.wait(timeout=self.config.sync_interval):
+            try:
+                self.sync_now()
+            except Exception:
+                logger.exception('SyncService: sync failed')
+
+
+# ---------------------------------------------------------------------------
+# StreamManager
+# ---------------------------------------------------------------------------
+
+class StreamManager:
+    """ Manage real-time WebSocket collection jobs.
+
+    Starts one background thread per ``(exchange, pair)`` (or per
+    ``(exchange, pair, channel)`` for Bitfinex/Bitmex).  Each thread
+    runs indefinitely and is automatically restarted after a crash.
+    A :class:`SyncService` instance pushes data to remotes periodically.
+
+    Parameters
+    ----------
+    config : CollectorConfig
+        Daemon configuration (``stream_jobs`` + ``storage``).
+
+    """
+
+    def __init__(self, config: CollectorConfig) -> None:
+        self.config = config
+        self._threads:     dict[str, threading.Thread]     = {}
+        self._downloaders: dict[str, ContinuousDownloader] = {}
+        self._stop_event = threading.Event()
+        self._sync = SyncService(config.storage)
+
+    def start(self) -> None:
+        """ Start the sync service and all stream threads. """
+        self._sync.start()
+        for job in self.config.stream_jobs:
+            for pair, channels in _iter_tasks(job):
+                ch_tag = '_'.join(channels)
+                key = f'{job.exchange}_{pair.replace("/", "_")}_{ch_tag}'
+                t = threading.Thread(
+                    target=self._run_forever,
+                    args=(job, pair, channels),
+                    name=key,
+                    daemon=True,
+                )
+                self._threads[key] = t
+                t.start()
+                logger.info('stream started: %s %s channels=%s', job.exchange, pair, channels)
+
+    def stop(self) -> None:
+        """ Signal all streams and the sync service to stop. """
+        self._stop_event.set()
+        self._sync.stop()
+        for dl in self._downloaders.values():
+            dl.until = time.time()
+            dl.is_connect = False
+
+    # ------------------------------------------------------------------
+    # Thread body
+    # ------------------------------------------------------------------
+
+    def _run_forever(self, job: StreamJob, pair: str, channels: list[str]) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._run_once(job, pair, channels)
+            except Exception:
+                logger.exception('stream crashed: %s %s', job.exchange, pair)
+            if not self._stop_event.is_set():
+                self._stop_event.wait(timeout=_RESTART_DELAY)
+
+    def _run_once(self, job: StreamJob, pair: str, channels: list[str]) -> None:
+        cls = _STREAM_CLASSES[job.exchange]
+
+        # Bitfinex/Bitmex do not take pair in __init__; they receive it
+        # via _connect() kwargs.  All other exchanges set the pair in __init__.
+        if job.exchange in _PER_CHANNEL_EXCHANGES:
+            downloader: ContinuousDownloader = cls(
+                time_step=job.time_step, until=0,
+            )
+            # self.parser must be initialised before _loop() / on_message()
+            ch_map = _BITFINEX_CHANNEL if job.exchange == 'bitfinex' else _BITMEX_CHANNEL
+            ch_key = ch_map.get(channels[0], channels[0])
+            downloader.parser = downloader.get_parser(ch_key)  # type: ignore[attr-defined]
+        else:
+            downloader = cls(
+                pair=_format_pair(job.exchange, pair),
+                time_step=job.time_step,
+                until=0,
+            )
+
+        ch_tag = '_'.join(channels)
+        key = f'{job.exchange}_{pair.replace("/", "_")}_{ch_tag}'
+        self._downloaders[key] = downloader
+
+        xch = job.exchange.capitalize()
+        save_path = (
+            f'{self.config.storage.local_path.rstrip("/")}'
+            f'/{xch}/Data/WS_Data/{job.time_step}s/{pair.replace("/", "_")}'
+        )
+
+        downloader.set_process_data(_process_fn(channels))
+        downloader.set_saver(IODataBase(save_path, method='csv'))
+
+        conn_kw = _connect_kwargs(job.exchange, pair, channels)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(asyncio.gather(
+                downloader._connect(**conn_kw),
+                downloader._loop(),
+            ))
+        finally:
+            loop.close()
+            self._downloaders.pop(key, None)
+            logger.info('stream ended: %s %s', job.exchange, pair)

--- a/dccd/tests/test_daemon_config.py
+++ b/dccd/tests/test_daemon_config.py
@@ -65,12 +65,38 @@ def test_remote_config_parsed():
         **_VALID_CONFIG,
         'storage': {
             'local_path': '/data/',
-            'remote': {'provider': 'rclone', 'remote': 'mynas:crypto/'},
+            'remotes': [{'provider': 'rclone', 'remote': 'mynas:crypto/'}],
         },
     }
     cfg = CollectorConfig.model_validate(data)
-    assert cfg.storage.remote is not None
-    assert cfg.storage.remote.remote == 'mynas:crypto/'
+    assert len(cfg.storage.remotes) == 1
+    assert cfg.storage.remotes[0].remote == 'mynas:crypto/'
+
+
+def test_multiple_remotes_parsed():
+    data = {
+        **_VALID_CONFIG,
+        'storage': {
+            'local_path': '/data/',
+            'remotes': [
+                {'provider': 'rclone', 'remote': 'mynas:crypto/'},
+                {'provider': 'rclone', 'remote': 's3:bucket/crypto/'},
+            ],
+        },
+    }
+    cfg = CollectorConfig.model_validate(data)
+    assert len(cfg.storage.remotes) == 2
+
+
+def test_sync_interval_default():
+    cfg = CollectorConfig.model_validate(_VALID_CONFIG)
+    assert cfg.storage.sync_interval == 3600
+
+
+def test_sync_interval_custom():
+    data = {**_VALID_CONFIG, 'storage': {**_VALID_STORAGE, 'sync_interval': 300}}
+    cfg = CollectorConfig.model_validate(data)
+    assert cfg.storage.sync_interval == 300
 
 
 # ---------------------------------------------------------------------------

--- a/dccd/tests/test_daemon_scheduler.py
+++ b/dccd/tests/test_daemon_scheduler.py
@@ -7,7 +7,6 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from dccd.daemon.config import CollectorConfig, HistoJob, StorageConfig
 from dccd.daemon.scheduler import build_histo_scheduler, run_histo_job, run_once
-from dccd.daemon.storage import RemoteStorage
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -22,10 +21,6 @@ def _make_config(histo_jobs=None, tmp_path=None):
             HistoJob(exchange='kraken', pairs=['BTC/USD'], span=86400),
         ],
     )
-
-
-def _make_storage(tmp_path):
-    return RemoteStorage(StorageConfig(local_path=str(tmp_path)))
 
 
 # ---------------------------------------------------------------------------
@@ -83,34 +78,31 @@ def test_run_histo_job_calls_chain(tmp_path):
     import dccd.daemon.scheduler as sched_mod
 
     job = HistoJob(exchange='binance', pairs=['BTC/USDT'], span=3600)
-    storage = MagicMock(spec=RemoteStorage)
     mock_cls, mock_obj = _mock_exchange_cls(str(tmp_path / 'Binance'))
 
     original = sched_mod._HISTO_CLASSES.copy()
     sched_mod._HISTO_CLASSES['binance'] = mock_cls
     try:
-        run_histo_job(job, 'BTC/USDT', str(tmp_path), storage)
+        run_histo_job(job, 'BTC/USDT', str(tmp_path))
     finally:
         sched_mod._HISTO_CLASSES.update(original)
 
     mock_cls.assert_called_once_with(str(tmp_path), 'BTC', 3600, 'USDT', form='parquet')
     mock_obj.import_data.assert_called_once_with('last', 'now')
     mock_obj.save.assert_called_once_with(form='parquet', by_period='Y')
-    storage.push.assert_called_once_with(str(tmp_path / 'Binance'))
 
 
 def test_run_histo_job_splits_pair_correctly(tmp_path):
     import dccd.daemon.scheduler as sched_mod
 
     job = HistoJob(exchange='okx', pairs=['ETH/USDT'], span=3600)
-    storage = MagicMock(spec=RemoteStorage)
     mock_cls, mock_obj = _mock_exchange_cls('/tmp')
     mock_obj.full_path = '/tmp'
 
     original = sched_mod._HISTO_CLASSES.copy()
     sched_mod._HISTO_CLASSES['okx'] = mock_cls
     try:
-        run_histo_job(job, 'ETH/USDT', str(tmp_path), storage)
+        run_histo_job(job, 'ETH/USDT', str(tmp_path))
     finally:
         sched_mod._HISTO_CLASSES.update(original)
 

--- a/dccd/tests/test_daemon_storage.py
+++ b/dccd/tests/test_daemon_storage.py
@@ -7,8 +7,8 @@ from dccd.daemon.config import RemoteConfig, StorageConfig
 from dccd.daemon.storage import RemoteStorage
 
 
-def _storage(tmp_path, remote=None):
-    cfg = StorageConfig(local_path=str(tmp_path), remote=remote)
+def _storage(tmp_path, remotes=None):
+    cfg = StorageConfig(local_path=str(tmp_path), remotes=remotes or [])
     return RemoteStorage(cfg)
 
 
@@ -16,8 +16,12 @@ def _remote():
     return RemoteConfig(provider='rclone', remote='mynas:crypto/')
 
 
+def _remotes(*paths):
+    return [RemoteConfig(provider='rclone', remote=p) for p in paths]
+
+
 # ---------------------------------------------------------------------------
-# push() without remote — no-op
+# push() without remotes — no-op
 # ---------------------------------------------------------------------------
 
 def test_push_no_remote_never_calls_subprocess(tmp_path):
@@ -34,13 +38,13 @@ def test_push_no_remote_never_calls_subprocess(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_check_rclone_found(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     with patch('shutil.which', return_value='/usr/bin/rclone'):
         assert s.check_rclone() is True
 
 
 def test_check_rclone_not_found_logs_warning(tmp_path, caplog):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     import logging
     with patch('shutil.which', return_value=None):
         with caplog.at_level(logging.WARNING, logger='dccd.daemon.storage'):
@@ -50,19 +54,25 @@ def test_check_rclone_not_found_logs_warning(tmp_path, caplog):
 
 
 def test_check_rclone_cached(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     with patch('shutil.which', return_value='/usr/bin/rclone') as mock_which:
         s.check_rclone()
         s.check_rclone()
     mock_which.assert_called_once()
 
 
+def test_check_rclone_no_remotes_returns_false(tmp_path):
+    s = _storage(tmp_path)
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        assert s.check_rclone() is False
+
+
 # ---------------------------------------------------------------------------
-# push() with remote + rclone present
+# push() with single remote + rclone present
 # ---------------------------------------------------------------------------
 
 def test_push_calls_rclone_with_correct_args(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     sub_dir = tmp_path / 'Binance' / 'Data'
     sub_dir.mkdir(parents=True)
 
@@ -82,8 +92,7 @@ def test_push_calls_rclone_with_correct_args(tmp_path):
 
 
 def test_push_remote_no_trailing_slash(tmp_path):
-    remote = RemoteConfig(provider='rclone', remote='mynas:crypto')  # no trailing /
-    s = _storage(tmp_path, remote)
+    s = _storage(tmp_path, [RemoteConfig(provider='rclone', remote='mynas:crypto')])
     sub_dir = tmp_path / 'sub'
     sub_dir.mkdir()
 
@@ -99,11 +108,51 @@ def test_push_remote_no_trailing_slash(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# push() with multiple remotes
+# ---------------------------------------------------------------------------
+
+def test_push_multiple_remotes_calls_rclone_twice(tmp_path):
+    s = _storage(tmp_path, _remotes('mynas:crypto/', 's3:bucket/crypto/'))
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(sub_dir)
+
+    assert mock_run.call_count == 2
+    dests = [call[0][0][3] for call in mock_run.call_args_list]
+    assert 'mynas:crypto/sub' in dests
+    assert 's3:bucket/crypto/sub' in dests
+
+
+# ---------------------------------------------------------------------------
+# push() root path (path == local_path)
+# ---------------------------------------------------------------------------
+
+def test_push_root_path_uses_remote_root(tmp_path):
+    s = _storage(tmp_path, [_remote()])
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(tmp_path)
+
+    dest = mock_run.call_args[0][0][3]
+    assert dest == 'mynas:crypto'
+
+
+# ---------------------------------------------------------------------------
 # push() with rclone not found
 # ---------------------------------------------------------------------------
 
 def test_push_rclone_absent_does_not_call_subprocess(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     sub_dir = tmp_path / 'sub'
     sub_dir.mkdir()
 
@@ -119,7 +168,7 @@ def test_push_rclone_absent_does_not_call_subprocess(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_push_rclone_failure_logs_error_no_exception(tmp_path, caplog):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     sub_dir = tmp_path / 'sub'
     sub_dir.mkdir()
 
@@ -141,7 +190,7 @@ def test_push_rclone_failure_logs_error_no_exception(tmp_path, caplog):
 # ---------------------------------------------------------------------------
 
 def test_push_path_outside_base_logs_error(tmp_path, caplog):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     outside = tmp_path.parent / 'other'
     outside.mkdir(exist_ok=True)
 

--- a/dccd/tests/test_daemon_stream_manager.py
+++ b/dccd/tests/test_daemon_stream_manager.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dccd.daemon.config import CollectorConfig, StorageConfig, StreamJob
+from dccd.daemon.stream_manager import (
+    StreamManager,
+    SyncService,
+    _connect_kwargs,
+    _format_pair,
+    _iter_tasks,
+    _process_fn,
+)
+from dccd.process_data import set_marketdepth, set_orders, set_trades
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _storage_cfg(tmp_path, remotes=None, sync_interval=3600):
+    remotes = remotes or []
+    return StorageConfig(
+        local_path=str(tmp_path),
+        remotes=remotes,
+        sync_interval=sync_interval,
+    )
+
+
+def _stream_job(exchange='binance', pairs=None, channels=None, time_step=60):
+    return StreamJob(
+        exchange=exchange,
+        pairs=pairs or ['BTC/USDT'],
+        channels=channels or ['trades', 'book'],
+        time_step=time_step,
+    )
+
+
+def _make_config(tmp_path, jobs=None, remotes=None):
+    return CollectorConfig(
+        storage=_storage_cfg(tmp_path, remotes=remotes),
+        stream_jobs=jobs or [_stream_job()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_pair
+# ---------------------------------------------------------------------------
+
+def test_format_pair_binance():
+    assert _format_pair('binance', 'BTC/USDT') == 'BTCUSDT'
+
+
+def test_format_pair_bybit():
+    assert _format_pair('bybit', 'ETH/USDT') == 'ETHUSDT'
+
+
+def test_format_pair_kraken():
+    assert _format_pair('kraken', 'BTC/USD') == 'BTC/USD'
+
+
+def test_format_pair_okx():
+    assert _format_pair('okx', 'BTC/USDT') == 'BTC-USDT'
+
+
+def test_format_pair_bitfinex_usd():
+    assert _format_pair('bitfinex', 'BTC/USD') == 'tBTCUSD'
+
+
+def test_format_pair_bitfinex_usdt():
+    assert _format_pair('bitfinex', 'BTC/USDT') == 'tBTCUST'
+
+
+def test_format_pair_bitmex_btc():
+    assert _format_pair('bitmex', 'BTC/USD') == 'XBTUSD'
+
+
+def test_format_pair_bitmex_eth():
+    assert _format_pair('bitmex', 'ETH/USD') == 'ETHUSD'
+
+
+def test_format_pair_unsupported_raises():
+    with pytest.raises(ValueError, match='not supported'):
+        _format_pair('poloniex', 'BTC/USDT')
+
+
+# ---------------------------------------------------------------------------
+# _process_fn
+# ---------------------------------------------------------------------------
+
+def test_process_fn_trades():
+    assert _process_fn(['trades']) is set_trades
+
+
+def test_process_fn_book():
+    assert _process_fn(['book']) is set_marketdepth
+
+
+def test_process_fn_both():
+    assert _process_fn(['trades', 'book']) is set_orders
+
+
+def test_process_fn_fallback():
+    assert _process_fn(['kline']) is set_orders
+
+
+# ---------------------------------------------------------------------------
+# _connect_kwargs
+# ---------------------------------------------------------------------------
+
+def test_connect_kwargs_binance():
+    assert _connect_kwargs('binance', 'BTC/USDT', ['trades']) == {}
+
+
+def test_connect_kwargs_kraken():
+    assert _connect_kwargs('kraken', 'BTC/USD', ['trades', 'book']) == {}
+
+
+def test_connect_kwargs_bitfinex_trades():
+    kw = _connect_kwargs('bitfinex', 'BTC/USD', ['trades'])
+    assert kw == {'channel': 'trades', 'symbol': 'tBTCUSD'}
+
+
+def test_connect_kwargs_bitmex_book():
+    kw = _connect_kwargs('bitmex', 'BTC/USD', ['book'])
+    assert kw == {'args': 'orderBookL2_25:XBTUSD'}
+
+
+# ---------------------------------------------------------------------------
+# _iter_tasks
+# ---------------------------------------------------------------------------
+
+def test_iter_tasks_binance_single_thread_for_all_channels():
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades', 'book'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 1
+    pair, channels = tasks[0]
+    assert pair == 'BTC/USDT'
+    assert 'trades' in channels and 'book' in channels
+
+
+def test_iter_tasks_bitfinex_one_thread_per_channel():
+    job = _stream_job(exchange='bitfinex', pairs=['BTC/USD'], channels=['trades', 'book'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 2
+    channel_lists = [ch for _, ch in tasks]
+    assert ['trades'] in channel_lists
+    assert ['book'] in channel_lists
+
+
+def test_iter_tasks_bitmex_one_thread_per_channel():
+    job = _stream_job(exchange='bitmex', pairs=['BTC/USD'], channels=['trades', 'book'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 2
+
+
+def test_iter_tasks_multiple_pairs():
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT', 'ETH/USDT'], channels=['trades'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 2
+
+
+# ---------------------------------------------------------------------------
+# SyncService
+# ---------------------------------------------------------------------------
+
+def test_sync_service_no_remotes_no_thread(tmp_path):
+    svc = SyncService(_storage_cfg(tmp_path, remotes=[], sync_interval=60))
+    svc.start()
+    assert svc._thread is None
+
+
+def test_sync_service_sync_interval_zero_no_thread(tmp_path):
+    from dccd.daemon.config import RemoteConfig
+    svc = SyncService(_storage_cfg(
+        tmp_path,
+        remotes=[RemoteConfig(provider='rclone', remote='mynas:crypto/')],
+        sync_interval=0,
+    ))
+    svc.start()
+    assert svc._thread is None
+
+
+def test_sync_service_stop_sets_event(tmp_path):
+    svc = SyncService(_storage_cfg(tmp_path))
+    svc.stop()
+    assert svc._stop.is_set()
+
+
+def test_sync_service_sync_now_calls_push(tmp_path):
+    from dccd.daemon.config import RemoteConfig
+    svc = SyncService(_storage_cfg(
+        tmp_path,
+        remotes=[RemoteConfig(provider='rclone', remote='mynas:crypto/')],
+    ))
+    with patch.object(svc._storage, 'push') as mock_push:
+        svc.sync_now()
+    mock_push.assert_called_once_with(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# StreamManager.start / stop
+# ---------------------------------------------------------------------------
+
+def test_stream_manager_start_creates_threads(tmp_path):
+    cfg = _make_config(tmp_path, jobs=[
+        _stream_job(exchange='binance', pairs=['BTC/USDT', 'ETH/USDT']),
+    ])
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):  # don't actually run
+        with patch.object(mgr._sync, 'start'):
+            mgr.start()
+
+    assert len(mgr._threads) == 2
+
+
+def test_stream_manager_start_starts_sync(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):
+        with patch.object(mgr._sync, 'start') as mock_sync_start:
+            mgr.start()
+
+    mock_sync_start.assert_called_once()
+
+
+def test_stream_manager_bitfinex_two_channels_two_threads(tmp_path):
+    cfg = _make_config(tmp_path, jobs=[
+        _stream_job(exchange='bitfinex', pairs=['BTC/USD'], channels=['trades', 'book']),
+    ])
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):
+        with patch.object(mgr._sync, 'start'):
+            mgr.start()
+
+    assert len(mgr._threads) == 2
+
+
+def test_stream_manager_stop_sets_event(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    with patch.object(mgr._sync, 'stop'):
+        mgr.stop()
+    assert mgr._stop_event.is_set()
+
+
+def test_stream_manager_stop_signals_downloaders(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+
+    dl = MagicMock()
+    dl.until = time.time() + 9999
+    dl.is_connect = True
+    mgr._downloaders['fake'] = dl
+
+    with patch.object(mgr._sync, 'stop'):
+        mgr.stop()
+
+    assert dl.is_connect is False
+    assert dl.until <= time.time()
+
+
+# ---------------------------------------------------------------------------
+# StreamManager._run_forever
+# ---------------------------------------------------------------------------
+
+def test_run_forever_stops_immediately_if_stop_set(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    mgr._stop_event.set()
+
+    with patch.object(mgr, '_run_once') as mock_once:
+        mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'])
+
+    mock_once.assert_not_called()
+
+
+def test_run_forever_restarts_on_exception(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    call_count = 0
+
+    def _side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError('crash')
+        mgr._stop_event.set()  # stop after second call
+
+    with patch.object(mgr, '_run_once', side_effect=_side_effect):
+        with patch.object(mgr._stop_event, 'wait', return_value=False):
+            mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'])
+
+    assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# StreamManager._run_once (unit, mocked downloader)
+# ---------------------------------------------------------------------------
+
+def _patch_stream_classes(exchange, mock_cls):
+    """Context manager that replaces one entry in _STREAM_CLASSES."""
+    import dccd.daemon.stream_manager as sm
+    original = sm._STREAM_CLASSES.copy()
+    sm._STREAM_CLASSES[exchange] = mock_cls
+    return original
+
+
+def test_run_once_configures_downloader(tmp_path):
+    import dccd.daemon.stream_manager as sm
+
+    job = _stream_job(exchange='binance', channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    mock_obj = MagicMock()
+    mock_cls = MagicMock(return_value=mock_obj)
+
+    original = sm._STREAM_CLASSES.copy()
+    sm._STREAM_CLASSES['binance'] = mock_cls
+    try:
+        with patch('asyncio.new_event_loop') as mock_loop_fn, \
+             patch('asyncio.set_event_loop'), \
+             patch('asyncio.gather'):
+            mock_loop = MagicMock()
+            mock_loop_fn.return_value = mock_loop
+            mock_loop.run_until_complete.side_effect = None
+            mgr._run_once(job, 'BTC/USDT', ['trades'])
+    finally:
+        sm._STREAM_CLASSES.update(original)
+
+    mock_cls.assert_called_once_with(pair='BTCUSDT', time_step=60, until=0)
+    mock_obj.set_process_data.assert_called_once_with(set_trades)
+    mock_obj.set_saver.assert_called_once()
+
+
+def test_run_once_bitfinex_sets_parser(tmp_path):
+    import dccd.daemon.stream_manager as sm
+
+    job = _stream_job(exchange='bitfinex', channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    mock_obj = MagicMock()
+    mock_obj.get_parser.return_value = MagicMock()
+    mock_cls = MagicMock(return_value=mock_obj)
+
+    original = sm._STREAM_CLASSES.copy()
+    sm._STREAM_CLASSES['bitfinex'] = mock_cls
+    try:
+        with patch('asyncio.new_event_loop') as mock_loop_fn, \
+             patch('asyncio.set_event_loop'), \
+             patch('asyncio.gather'):
+            mock_loop = MagicMock()
+            mock_loop_fn.return_value = mock_loop
+            mock_loop.run_until_complete.side_effect = None
+            mgr._run_once(job, 'BTC/USD', ['trades'])
+    finally:
+        sm._STREAM_CLASSES.update(original)
+
+    mock_obj.get_parser.assert_called_once_with('trades')
+    assert mock_obj.parser is mock_obj.get_parser.return_value

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -15,11 +15,15 @@ periodically syncs all local data to one or more remote destinations via rclone.
 Quick start
 -----------
 
-1. Install the daemon extra::
+1. Install the daemon extra:
+
+   .. code-block:: bash
 
        pip install "dccd[daemon]"
 
-2. Write a configuration file (see :ref:`daemon-config`)::
+2. Write a configuration file (see :ref:`daemon-config`):
+
+   .. code-block:: yaml
 
        storage:
          local_path: /data/crypto/
@@ -41,7 +45,9 @@ Quick start
            channels: [trades, book]
            time_step: 60
 
-3. Run a one-shot collection, then start the daemon::
+3. Run a one-shot collection, then start the daemon:
+
+   .. code-block:: python
 
        from dccd.daemon.config import load_config
        from dccd.daemon.scheduler import run_once, build_histo_scheduler

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -1,0 +1,103 @@
+-----------------------------------------
+ Daemon (:mod:`dccd.daemon`)
+-----------------------------------------
+
+.. automodule:: dccd.daemon
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:
+
+The daemon module provides an autonomous, server-side data collector.
+It reads a declarative YAML configuration, runs historical REST jobs on a
+schedule (APScheduler), opens WebSocket streams for real-time collection, and
+periodically syncs all local data to one or more remote destinations via rclone.
+
+Quick start
+-----------
+
+1. Install the daemon extra::
+
+       pip install "dccd[daemon]"
+
+2. Write a configuration file (see :ref:`daemon-config`)::
+
+       storage:
+         local_path: /data/crypto/
+         remotes:
+           - provider: rclone
+             remote: "mynas:crypto/"
+         sync_interval: 3600
+
+       histo_jobs:
+         - exchange: binance
+           pairs: [BTC/USDT, ETH/USDT]
+           span: 3600
+           format: parquet
+           by_period: Y
+
+       stream_jobs:
+         - exchange: binance
+           pairs: [BTC/USDT]
+           channels: [trades, book]
+           time_step: 60
+
+3. Run a one-shot collection, then start the daemon::
+
+       from dccd.daemon.config import load_config
+       from dccd.daemon.scheduler import run_once, build_histo_scheduler
+       from dccd.daemon.stream_manager import StreamManager
+
+       config = load_config('config.yml')
+
+       # One-shot: download all histo jobs once and exit
+       run_once(config)
+
+       # Daemon: start periodic histo scheduler + WebSocket streams
+       scheduler = build_histo_scheduler(config)
+       scheduler.start()
+
+       mgr = StreamManager(config)
+       mgr.start()
+
+.. _daemon-config:
+
+Configuration
+-------------
+
+.. autosummary::
+   :toctree: generated/
+
+   config.load_config -- load and validate a YAML configuration file
+   config.CollectorConfig -- root configuration model
+   config.StorageConfig -- local storage path and remote sync settings
+   config.RemoteConfig -- one rclone remote destination
+   config.HistoJob -- historical (REST) data collection job
+   config.StreamJob -- real-time (WebSocket) data collection job
+   config.AlertConfig -- optional webhook alerting settings
+
+Scheduler
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   scheduler.build_histo_scheduler -- build an APScheduler BackgroundScheduler from config
+   scheduler.run_histo_job -- download and save one (exchange, pair) candle job
+   scheduler.run_once -- execute all histo_jobs once and return
+
+Stream manager
+--------------
+
+.. autosummary::
+   :toctree: generated/
+
+   stream_manager.StreamManager -- manage real-time WebSocket collection jobs
+   stream_manager.SyncService -- periodically push local data to all remote destinations
+
+Storage
+-------
+
+.. autosummary::
+   :toctree: generated/
+
+   storage.RemoteStorage -- push local data directories to remote destinations via rclone

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -86,14 +86,18 @@ Supported exchanges
 Presentation
 ------------
 
-The ``dccd`` package provides two main methods to download data:
+The ``dccd`` package provides three ways to download data:
 
-- **Continuous Downloader** :mod:`dccd.continuous_dl`:
-   Stream real-time data (order book, trades, OHLCV) via WebSocket with automatic
-   reconnection. Supports Binance, Bitfinex, Bitmex, Bybit, Kraken, and OKX.
 - **Historical Downloader** :mod:`dccd.histo_dl`:
    Download OHLCV data via REST APIs with chunked requests and incremental updates.
    Supports Binance, Coinbase, Kraken, Bybit, and OKX.
+- **Continuous Downloader** :mod:`dccd.continuous_dl`:
+   Stream real-time data (order book, trades, OHLCV) via WebSocket with automatic
+   reconnection. Supports Binance, Bitfinex, Bitmex, Bybit, Kraken, and OKX.
+- **Daemon** :mod:`dccd.daemon`:
+   Autonomous, server-side collector driven by a YAML config.  Runs REST jobs on a
+   schedule (APScheduler), opens WebSocket streams, and syncs data to remote
+   destinations (NAS, S3, SFTP, …) via rclone.
 
 Contents
 --------
@@ -114,5 +118,6 @@ Contents
    histo_dl.kraken
    histo_dl.bybit
    histo_dl.okx
+   daemon
    process_data
    tools

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,14 +8,18 @@ Installation
 ------------
 
 From pip:
-   $ pip install dccd
+
+.. code-block:: bash
+
+   pip install dccd
 
 From source:
-   $ git clone https://github.com/ArthurBernard/Download_Crypto_Currencies_Data.git
 
-   $ cd Download_Crypto_Currencies_Data
+.. code-block:: bash
 
-   $ pip install -e .
+   git clone https://github.com/ArthurBernard/Download_Crypto_Currencies_Data.git
+   cd Download_Crypto_Currencies_Data
+   pip install -e .
 
 Supported exchanges
 -------------------

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -12,20 +12,26 @@ storage:
   # Root directory on the daemon host where data files are written.
   local_path: /data/crypto/
 
-  # Optional: push data to a remote after each save.
+  # Optional: push data to one or more remotes after each sync cycle.
   # Requires rclone (https://rclone.org) installed on the daemon host and
-  # a named remote configured with `rclone config`.
+  # named remotes configured with `rclone config`.
   #
-  # Examples:
+  # Supported destinations (examples):
   #   mynas:crypto/         → NAS / Freebox via SMB or SFTP
   #   mypc:data/crypto/     → local PC via SFTP (OpenSSH)
   #   s3:mybucket/crypto/   → Amazon S3
   #   gdrive:crypto/        → Google Drive
   #
   # Remove this block to keep data on the daemon host only.
-  remote:
-    provider: rclone
-    remote: "mynas:crypto/"   # rclone remote name + path
+  remotes:
+    - provider: rclone
+      remote: "mynas:crypto/"       # primary destination (NAS / Freebox)
+    # - provider: rclone
+    #   remote: "s3:mybucket/crypto/"  # secondary destination (S3 backup)
+
+  # Interval in seconds between sync cycles (default: 3600 = 1 hour).
+  # Set to 0 to disable remote sync entirely.
+  sync_interval: 3600
 
 
 # ---------------------------------------------------------------------------
@@ -61,10 +67,14 @@ histo_jobs:
 
 
 # ---------------------------------------------------------------------------
-# Real-time (WebSocket) jobs  [not yet implemented — reserved for task 4.4]
+# Real-time (WebSocket) jobs
 # ---------------------------------------------------------------------------
+# Each job opens one WebSocket connection per pair (or per pair+channel for
+# Bitfinex/Bitmex) and saves snapshots every time_step seconds under:
+#   {local_path}/{Exchange}/Data/WS_Data/{time_step}s/{pair}/
+#
 # stream_jobs:
-#   - exchange: binance
+#   - exchange: binance        # one of: binance, kraken, bybit, okx, bitfinex, bitmex
 #     pairs:
 #       - BTC/USDT
 #     channels:


### PR DESCRIPTION
## Summary

- `StreamManager`: one background thread per `(exchange, pair)` for newer exchanges; one per `(exchange, pair, channel)` for Bitfinex/Bitmex. Auto-restarts on crash with 30 s delay.
- `SyncService`: single background thread that pushes the entire `local_path` to all configured remotes every `sync_interval` seconds (default 1 h). Fully decoupled from data collection — storage unavailability never interrupts streams or histo jobs.
- `StorageConfig`: `remote: RemoteConfig | None` → `remotes: list[RemoteConfig]` + `sync_interval: int`. Multiple remote destinations supported out of the box.

## Changes

- `dccd/daemon/stream_manager.py` — new: `StreamManager`, `SyncService`, helpers `_format_pair`, `_process_fn`, `_connect_kwargs`, `_iter_tasks`
- `dccd/daemon/config.py` — `StorageConfig`: `remote → remotes` (list), add `sync_interval`
- `dccd/daemon/storage.py` — `RemoteStorage.push()` iterates all remotes; root-path sync (path == local_path); `check_rclone()` returns False when no remotes configured
- `dccd/daemon/scheduler.py` — `run_histo_job` drops `storage` param and push call; all sync delegated to `SyncService`
- `dccd/daemon/__init__.py` — export `StreamManager`, `SyncService`
- `examples/config.example.yml` — `remote → remotes` list, add `sync_interval`, document `stream_jobs`
- Tests updated/added: `test_daemon_config.py`, `test_daemon_storage.py`, `test_daemon_scheduler.py`, new `test_daemon_stream_manager.py` (40 tests)

## Changelog

Added under [Unreleased]:
- `dccd/daemon/stream_manager.py` — `StreamManager` + `SyncService`
- `StorageConfig.remote` → `remotes: list[RemoteConfig]` + `sync_interval`
- `run_histo_job` no longer pushes; sync delegated to `SyncService`

## Test plan

- [x] pytest passes locally (205 passed)
- [x] ruff check dccd/ passes
- [ ] CI green