### PR TITLE
fix: add pyyaml and apscheduler to doc extras for ReadTheDocs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 io = ["pyarrow>=13", "polars>=0.20"]
 daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4"]
 dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
-doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton"]
+doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
 
 [project.urls]
 Homepage = "https://github.com/ArthurBernard/Download_Crypto_Currencies_Data"


### PR DESCRIPTION
## Summary

- `dccd.daemon.config` imports `yaml` at module level, but `pyyaml` was missing from the `doc` extra
- ReadTheDocs installs `.[doc]`, so the import failed and the Sphinx build crashed
- Added `pyyaml>=6.0` and `apscheduler>=3.10,<4` to the `doc` extras (mirrors what is already in the `daemon` extra)

## Test plan

- [ ] ReadTheDocs build passes after merge