### PR TITLE
refactor: extract format_pair per exchange and lift continuous_dl base helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` static method on each REST exchange class; extracts inline pair-building logic from `__init__` and makes it independently testable (#XX)
+- `dccd/continuous_dl/exchange.py` — `ContinuousDownloader.__call__(*args, **kwargs)`: base `__call__` using `asyncio.new_event_loop()`; Bitfinex/Bitmex overrides trimmed to exchange-specific setup only (#XX)
+- `dccd/continuous_dl/exchange.py` — `_push_trades(parsed)`: validates each trade dict against `Trade` (Pydantic) then appends via `_raw_parser`; shared by Binance, Kraken, Bybit, OKX (#XX)
+- `dccd/continuous_dl/exchange.py` — `_push_book_updates(updates)`: applies a `{price: qty}` delta to `self.d` and snapshots the book into `_data`; shared by Binance, Kraken, Bybit, OKX (#XX)
+- `dccd/tests/test_kraken.py` — 10 parametrized cases for `FromKraken.format_pair` covering BTC→XBT, BCH/DASH exemption, X/Z prefix rules, and cross-crypto pairs (#XX)
+
+### Changed
+
+- `dccd/continuous_dl/exchange.py` — `self.d: dict = {}` initialised in base `__init__`; `_get_book_state()` and `_restore_book_state()` upgraded from stubs to working defaults; removed redundant overrides in Binance, Kraken, Bybit, OKX, Bitfinex (#XX)
+
 - `dccd/continuous_dl/exchange.py` — `set_trades_saver(saver, process_func)` and `set_book_saver(saver, process_func)`: separate savers for the trades and order-book channels; high-level helpers updated accordingly (#28)
 - `dccd/continuous_dl/exchange.py` — crash-recovery checkpoint: `checkpoint_dir` parameter serialises `self.d` (live book state) to JSON after each snapshot; reloaded on restart via `_load_checkpoint()` (#28)
 - `dccd/continuous_dl/exchange.py` — `snapshot_ts` (UTC milliseconds) injected into every yielded snapshot payload by `__anext__` (#28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` static method on each REST exchange class; extracts inline pair-building logic from `__init__` and makes it independently testable (#XX)
-- `dccd/continuous_dl/exchange.py` — `ContinuousDownloader.__call__(*args, **kwargs)`: base `__call__` using `asyncio.new_event_loop()`; Bitfinex/Bitmex overrides trimmed to exchange-specific setup only (#XX)
-- `dccd/continuous_dl/exchange.py` — `_push_trades(parsed)`: validates each trade dict against `Trade` (Pydantic) then appends via `_raw_parser`; shared by Binance, Kraken, Bybit, OKX (#XX)
-- `dccd/continuous_dl/exchange.py` — `_push_book_updates(updates)`: applies a `{price: qty}` delta to `self.d` and snapshots the book into `_data`; shared by Binance, Kraken, Bybit, OKX (#XX)
-- `dccd/tests/test_kraken.py` — 10 parametrized cases for `FromKraken.format_pair` covering BTC→XBT, BCH/DASH exemption, X/Z prefix rules, and cross-crypto pairs (#XX)
+- `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` static method on each REST exchange class; extracts inline pair-building logic from `__init__` and makes it independently testable (#29)
+- `dccd/continuous_dl/exchange.py` — `ContinuousDownloader.__call__(*args, **kwargs)`: base `__call__` using `asyncio.new_event_loop()`; Bitfinex/Bitmex overrides trimmed to exchange-specific setup only (#29)
+- `dccd/continuous_dl/exchange.py` — `_push_trades(parsed)`: validates each trade dict against `Trade` (Pydantic) then appends via `_raw_parser`; shared by Binance, Kraken, Bybit, OKX (#29)
+- `dccd/continuous_dl/exchange.py` — `_push_book_updates(updates)`: applies a `{price: qty}` delta to `self.d` and snapshots the book into `_data`; shared by Binance, Kraken, Bybit, OKX (#29)
+- `dccd/tests/test_kraken.py` — 10 parametrized cases for `FromKraken.format_pair` covering BTC→XBT, BCH/DASH exemption, X/Z prefix rules, and cross-crypto pairs (#29)
 
 ### Changed
 
-- `dccd/continuous_dl/exchange.py` — `self.d: dict = {}` initialised in base `__init__`; `_get_book_state()` and `_restore_book_state()` upgraded from stubs to working defaults; removed redundant overrides in Binance, Kraken, Bybit, OKX, Bitfinex (#XX)
+- `dccd/continuous_dl/exchange.py` — `self.d: dict = {}` initialised in base `__init__`; `_get_book_state()` and `_restore_book_state()` upgraded from stubs to working defaults; removed redundant overrides in Binance, Kraken, Bybit, OKX, Bitfinex (#29)
 
 - `dccd/continuous_dl/exchange.py` — `set_trades_saver(saver, process_func)` and `set_book_saver(saver, process_func)`: separate savers for the trades and order-book channels; high-level helpers updated accordingly (#28)
 - `dccd/continuous_dl/exchange.py` — crash-recovery checkpoint: `checkpoint_dir` parameter serialises `self.d` (live book state) to JSON after each snapshot; reloaded on restart via `_load_checkpoint()` (#28)

--- a/dccd/continuous_dl/binance.py
+++ b/dccd/continuous_dl/binance.py
@@ -134,7 +134,6 @@ class DownloadBinanceData(ContinuousDownloader):
             'book': self.parser_book,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, float] = {}
         self._load_checkpoint()
 
     async def _subscribe(self, **kwargs: object) -> None:
@@ -166,8 +165,7 @@ class DownloadBinanceData(ContinuousDownloader):
             The ``data`` field from the combined-stream trade envelope.
 
         """
-        for trade in _parser_trades(data):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(data))
 
     def parser_book(self, data: dict) -> None:
         """ Parse and update the order book from a depth message.
@@ -178,19 +176,7 @@ class DownloadBinanceData(ContinuousDownloader):
             The ``data`` field from the combined-stream depth envelope.
 
         """
-        updates = _parser_book(data)
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self) -> dict[str, float]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
-        self.d = state
+        self._push_book_updates(_parser_book(data))
 
 
 def get_trades_binance(path: str, pair: str = 'BTCUSDT', time_step: int = 60,

--- a/dccd/continuous_dl/bitfinex.py
+++ b/dccd/continuous_dl/bitfinex.py
@@ -255,7 +255,7 @@ class DownloadBitfinexData(ContinuousDownloader):
         self.parser = self.get_parser(channel)
         channel = channel[:-4] if channel[-4:] == '_raw' else channel
         self.logger.info('Try connect WS and set {} stream.'.format(channel))
-        return super().__call__(channel=channel, **kwargs)
+        return super().__call__(channel=channel, **kwargs)  # type: ignore[return-value]
 
 
 # =========================================================================== #

--- a/dccd/continuous_dl/bitfinex.py
+++ b/dccd/continuous_dl/bitfinex.py
@@ -31,7 +31,6 @@ Low level API
 """
 
 # Built-in packages
-import asyncio
 import logging
 import time
 from typing import Any
@@ -148,7 +147,6 @@ class DownloadBitfinexData(ContinuousDownloader):
             'trades_raw': self.parser_raw_trades,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, Any] = {}
         self._load_checkpoint()
 
     def parser_raw_book(self, data: list[Any]) -> None:
@@ -185,12 +183,6 @@ class DownloadBitfinexData(ContinuousDownloader):
         self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = {
             v['price']: v['amount'] for v in self.d.values()
         }
-
-    def _get_book_state(self) -> dict[str, Any]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, Any]) -> None:  # type: ignore[override]
-        self.d = state
 
     def parser_raw_trades(self, data: list[Any]) -> None:
         """ Parse raw trade data tick-by-tick.
@@ -261,18 +253,9 @@ class DownloadBitfinexData(ContinuousDownloader):
 
         """
         self.parser = self.get_parser(channel)
-
         channel = channel[:-4] if channel[-4:] == '_raw' else channel
-
         self.logger.info('Try connect WS and set {} stream.'.format(channel))
-
-        self.loop = asyncio.get_event_loop()
-        self.loop.run_until_complete(asyncio.gather(
-            self._connect(channel=channel, **kwargs),
-            self._loop()
-        ))
-
-        return self
+        return super().__call__(channel=channel, **kwargs)
 
 
 # =========================================================================== #

--- a/dccd/continuous_dl/bitmex.py
+++ b/dccd/continuous_dl/bitmex.py
@@ -31,7 +31,6 @@ Low level API
 """
 
 # Built-in packages
-import asyncio
 import time
 from datetime import datetime as dt
 from typing import Any
@@ -180,7 +179,6 @@ class DownloadBitmexData(ContinuousDownloader):
             'orderBookL2_25': self.parser_book,
             'trade': self.parser_trades,
         }
-        self.d: dict[int, Any] = {}
         self.start = False
         self._load_checkpoint()
 
@@ -233,9 +231,6 @@ class DownloadBitmexData(ContinuousDownloader):
         for i, d in enumerate(data['data']):
             slot['trades'].append(_parser_trades(d, i))
 
-    def _get_book_state(self) -> dict[int, Any]:  # type: ignore[override]
-        return dict(self.d)
-
     def _restore_book_state(self, state: dict[int, Any]) -> None:  # type: ignore[override]
         self.d = {int(k): v for k, v in state.items()}
 
@@ -273,16 +268,8 @@ class DownloadBitmexData(ContinuousDownloader):
 
         """
         self.parser = self.get_parser(args[0])
-
         self.logger.info('Try connect WS and set {} stream.'.format(args[0]))
-
-        self.loop = asyncio.get_event_loop()
-        self.loop.run_until_complete(asyncio.gather(
-            self._connect(args=':'.join(args)),
-            self._loop()
-        ))
-
-        return self
+        return super().__call__(args=':'.join(args))
 
 
 # =========================================================================== #

--- a/dccd/continuous_dl/bitmex.py
+++ b/dccd/continuous_dl/bitmex.py
@@ -269,7 +269,7 @@ class DownloadBitmexData(ContinuousDownloader):
         """
         self.parser = self.get_parser(args[0])
         self.logger.info('Try connect WS and set {} stream.'.format(args[0]))
-        return super().__call__(args=':'.join(args))
+        return super().__call__(args=':'.join(args))  # type: ignore[return-value]
 
 
 # =========================================================================== #

--- a/dccd/continuous_dl/bybit.py
+++ b/dccd/continuous_dl/bybit.py
@@ -140,7 +140,6 @@ class DownloadBybitData(ContinuousDownloader):
             'book': self.parser_book,
         }
         self.logger = logging.getLogger(__name__)
-        self.d = {}
         self._load_checkpoint()
 
     async def on_message(self, msg):
@@ -160,8 +159,7 @@ class DownloadBybitData(ContinuousDownloader):
             Raw WebSocket trade message.
 
         """
-        for trade in _parser_trades(msg):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(msg))
 
     def parser_book(self, msg):
         """ Parse and update order book from WebSocket messages.
@@ -172,19 +170,7 @@ class DownloadBybitData(ContinuousDownloader):
             Raw WebSocket orderbook message.
 
         """
-        updates = _parser_book(msg)
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self):
-        return dict(self.d)
-
-    def _restore_book_state(self, state):
-        self.d = state
+        self._push_book_updates(_parser_book(msg))
 
 
 def get_trades_bybit(path, pair='BTCUSDT', time_step=60, until=3600, form='csv'):

--- a/dccd/continuous_dl/exchange.py
+++ b/dccd/continuous_dl/exchange.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncIterator
 
 # Third party packages
 # Local packages
+from dccd.models import Trade
 from dccd.process_data import set_marketdepth, set_trades
 from dccd.tools.websocket import BasisWebSocket
 
@@ -102,6 +103,7 @@ class ContinuousDownloader(BasisWebSocket):
         # Set data
         self._data: dict[int, dict[str, Any]] = {}
         self._checkpoint_dir: Path | None = Path(checkpoint_dir) if checkpoint_dir else None
+        self.d: dict = {}
 
     def __aiter__(self) -> AsyncIterator[dict[str, Any] | None]:
         """ Set iterative method. """
@@ -181,11 +183,51 @@ class ContinuousDownloader(BasisWebSocket):
         """ Set current time rounded by `timestep`. """
         return int((time.time() + 0.001) // self.ts * self.ts)
 
-    def _get_book_state(self) -> dict[str, Any]:
-        return {}
+    def __call__(self, *args: Any, **kwargs: Any) -> 'ContinuousDownloader':
+        """ Start the WebSocket stream and block until it stops.
 
-    def _restore_book_state(self, state: dict[str, Any]) -> None:
-        pass
+        Parameters
+        ----------
+        *args, **kwargs
+            Forwarded to :meth:`~dccd.tools.websocket.BasisWebSocket._connect`.
+
+        Returns
+        -------
+        ContinuousDownloader
+            The downloader instance (for chaining).
+
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(asyncio.gather(
+                self._connect(*args, **kwargs),
+                self._loop(),
+            ))
+        finally:
+            loop.close()
+        return self
+
+    def _push_trades(self, parsed: list[dict[str, Any]]) -> None:
+        """ Validate and store a normalised list of trade dicts. """
+        for item in parsed:
+            Trade.model_validate(item)
+            self._raw_parser(item)
+
+    def _push_book_updates(self, updates: dict[str, Any]) -> None:
+        """ Apply a price→qty update dict to the local book and snapshot it. """
+        for price, qty in updates.items():
+            if qty == 0:
+                self.d.pop(price, None)
+            else:
+                self.d[price] = qty
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
+
+    def _get_book_state(self) -> dict:
+        return dict(self.d)
+
+    def _restore_book_state(self, state: dict) -> None:
+        self.d = state
 
     def _checkpoint_file(self) -> Path | None:
         if self._checkpoint_dir is None:

--- a/dccd/continuous_dl/kraken.py
+++ b/dccd/continuous_dl/kraken.py
@@ -177,7 +177,6 @@ class DownloadKrakenData(ContinuousDownloader):
             'kline': self.parser_kline,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, float] = {}
         self._load_checkpoint()
 
     async def _subscribe(self, **kwargs: object) -> None:
@@ -228,8 +227,7 @@ class DownloadKrakenData(ContinuousDownloader):
             The ``data`` field from the Kraken trade push message.
 
         """
-        for trade in _parser_trades(data):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(data))
 
     def parser_book(self, msg: dict) -> None:
         """ Parse and update the order book from a book push message.
@@ -240,19 +238,7 @@ class DownloadKrakenData(ContinuousDownloader):
             Full Kraken book push message (contains ``type`` and ``data``).
 
         """
-        updates = _parser_book(msg.get('data', []))
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self) -> dict[str, float]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
-        self.d = state
+        self._push_book_updates(_parser_book(msg.get('data', [])))
 
     def parser_kline(self, data: list[dict]) -> None:
         """ Parse and store an ohlc push message.

--- a/dccd/continuous_dl/okx.py
+++ b/dccd/continuous_dl/okx.py
@@ -193,7 +193,6 @@ class DownloadOKXData(ContinuousDownloader):
             'kline': self.parser_kline,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, float] = {}
         self._load_checkpoint()
 
     async def on_message(self, msg: dict) -> None:
@@ -222,8 +221,7 @@ class DownloadOKXData(ContinuousDownloader):
             The ``data`` field from the OKX trades push message.
 
         """
-        for trade in _parser_trades(data):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(data))
 
     def parser_book(self, msg: dict) -> None:
         """ Parse and update the order book from a books push message.
@@ -234,19 +232,7 @@ class DownloadOKXData(ContinuousDownloader):
             Full OKX books push message (contains ``action`` and ``data``).
 
         """
-        updates = _parser_book(msg.get('data', []))
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self) -> dict[str, float]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
-        self.d = state
+        self._push_book_updates(_parser_book(msg.get('data', [])))
 
     def parser_kline(self, data: list[list]) -> None:
         """ Parse and store a candle push message.

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -85,6 +85,25 @@ class FromBinance(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Binance pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USDT'``).
+
+        Returns
+        -------
+        str
+            Concatenated pair (e.g. ``'BTCUSDT'``).
+
+        """
+        if crypto == 'XBT':
+            crypto = 'BTC'
+        return crypto + fiat
+
     def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
         """ Initialize object. """
         if fiat in ['EUR', 'USD']:
@@ -94,14 +113,11 @@ class FromBinance(ImportDataCryptoCurrencies):
             )
             self.fiat = fiat = 'USDT'
 
-        if crypto == 'XBT':
-            crypto = 'BTC'
-
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Binance', fiat, form
         )
 
-        self.pair = crypto + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Binance/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -103,12 +103,29 @@ class FromBybit(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Bybit pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USDT'``).
+
+        Returns
+        -------
+        str
+            Concatenated pair (e.g. ``'BTCUSDT'``).
+
+        """
+        return crypto + fiat
+
     def __init__(self, path, crypto, span, fiat='USDT', form='xlsx'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Bybit', fiat, form
         )
-        self.pair = crypto + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Bybit/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -83,14 +83,31 @@ class FromCoinbase(ImportDataCryptoCurrencies):
 
     """
 
-    def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
-        """ Initialize object. """
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Coinbase pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USD'``).
+
+        Returns
+        -------
+        str
+            Dash-separated pair (e.g. ``'BTC-USD'``).
+
+        """
         if crypto == 'XBT':
             crypto = 'BTC'
+        return crypto + '-' + fiat
+
+    def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
+        """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Coinbase', fiat, form
         )
-        self.pair = crypto + '-' + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Coinbase/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/histo_dl/kraken.py
+++ b/dccd/histo_dl/kraken.py
@@ -81,22 +81,46 @@ class FromKraken(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Kraken pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols using common names (e.g. ``'BTC'``, ``'USD'``).
+
+        Returns
+        -------
+        str
+            Kraken pair string, e.g. ``'XXBTZUSD'``, ``'BCHUSD'``, or
+            ``'XXMRXXBT'`` for cross-crypto pairs.
+
+        Notes
+        -----
+        Rules applied in order:
+
+        1. ``'BTC'`` is renamed to ``'XBT'`` (Kraken convention).
+        2. ``'BCH'`` and ``'DASH'`` are exempt from the X/Z prefix scheme.
+        3. Major fiats (EUR, USD, CAD, JPY, GBP) use ``X<crypto>Z<fiat>``.
+        4. All other fiats (incl. crypto quoted in crypto) use
+           ``X<crypto>X<fiat>``.
+
+        """
+        if crypto == 'BTC':
+            crypto = 'XBT'
+        if crypto in ('BCH', 'DASH'):
+            return crypto + fiat
+        if fiat not in ('EUR', 'USD', 'CAD', 'JPY', 'GBP'):
+            return 'X' + crypto + 'X' + fiat
+        return 'X' + crypto + 'Z' + fiat
+
     def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Kraken', fiat=fiat, form=form
         )
-        if crypto == 'BTC':
-            crypto = 'XBT'
-
-        if crypto == 'BCH' or crypto == 'DASH':
-            self.pair = crypto + fiat
-
-        elif fiat not in ['EUR', 'USD', 'CAD', 'JPY', 'GBP']:
-            self.pair = 'X' + crypto + 'X' + fiat
-
-        else:
-            self.pair = 'X' + crypto + 'Z' + fiat
+        self.pair = self.format_pair(crypto, fiat)
 
     def _import_data(
         self, start: int | str = 'last', end: int | str | None = None

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -103,12 +103,29 @@ class FromOKX(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the OKX pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USDT'``).
+
+        Returns
+        -------
+        str
+            Dash-separated pair (e.g. ``'BTC-USDT'``).
+
+        """
+        return crypto + '-' + fiat
+
     def __init__(self, path, crypto, span, fiat='USDT', form='xlsx'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'OKX', fiat, form
         )
-        self.pair = crypto + '-' + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/OKX/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/tests/test_binance.py
+++ b/dccd/tests/test_binance.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromBinance as fb
+from dccd.histo_dl.binance import FromBinance
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC',  'USDT', 'BTCUSDT'),
+    ('ETH',  'USDT', 'ETHUSDT'),
+    ('XBT',  'USDT', 'BTCUSDT'),  # XBT alias → BTC
+])
+def test_format_pair(crypto, fiat, expected):
+    assert FromBinance.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_bybit.py
+++ b/dccd/tests/test_bybit.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromBybit
+from dccd.histo_dl.bybit import FromBybit as _FromBybit
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USDT', 'BTCUSDT'),
+    ('ETH', 'USDT', 'ETHUSDT'),
+    ('SOL', 'BTC',  'SOLBTC'),
+])
+def test_format_pair(crypto, fiat, expected):
+    assert _FromBybit.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_coinbase.py
+++ b/dccd/tests/test_coinbase.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromCoinbase as fc
+from dccd.histo_dl.coinbase import FromCoinbase
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USD',  'BTC-USD'),
+    ('ETH', 'EUR',  'ETH-EUR'),
+    ('XBT', 'USD',  'BTC-USD'),  # XBT alias → BTC
+])
+def test_format_pair(crypto, fiat, expected):
+    assert FromCoinbase.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_kraken.py
+++ b/dccd/tests/test_kraken.py
@@ -6,8 +6,25 @@ import time
 import pytest
 
 from dccd import FromKraken as fk
+from dccd.histo_dl.kraken import FromKraken
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USD',  'XXBTZUSD'),
+    ('BTC', 'EUR',  'XXBTZEUR'),
+    ('BTC', 'CAD',  'XXBTZCAD'),
+    ('BTC', 'JPY',  'XXBTZJPY'),
+    ('BTC', 'GBP',  'XXBTZGBP'),
+    ('BCH', 'EUR',  'BCHEUR'),
+    ('BCH', 'USD',  'BCHUSD'),
+    ('DASH', 'USD', 'DASHUSD'),
+    ('XMR', 'XBT',  'XXMRXXBT'),
+    ('XMR', 'EUR',  'XXMRZEUR'),
+])
+def test_format_pair(crypto, fiat, expected):
+    assert FromKraken.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_okx.py
+++ b/dccd/tests/test_okx.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromOKX
+from dccd.histo_dl.okx import FromOKX as _FromOKX
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USDT', 'BTC-USDT'),
+    ('ETH', 'USDT', 'ETH-USDT'),
+    ('SOL', 'BTC',  'SOL-BTC'),
+])
+def test_format_pair(crypto, fiat, expected):
+    assert _FromOKX.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- **Task 2.2** — `format_pair(crypto, fiat)` `@staticmethod` added to each histo_dl exchange class (Binance, Coinbase, Bybit, OKX, Kraken), replacing inline pair-building logic in each `__init__`
- **Task 2.3** — Duplicated patterns lifted into `ContinuousDownloader` base: `self.d` initialisation, `_get_book_state`/`_restore_book_state` defaults, `_push_trades` (Pydantic validation), `_push_book_updates`, and a shared `__call__` replacing the deprecated `asyncio.get_event_loop()`

## Changes

- `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair` staticmethod + `__init__` simplified to `self.pair = self.format_pair(crypto, fiat)`
- `dccd/continuous_dl/exchange.py` — `self.d = {}` in base `__init__`; real `_get_book_state`/`_restore_book_state` defaults; `_push_trades`, `_push_book_updates`, base `__call__`
- `dccd/continuous_dl/{binance,kraken,bybit,okx}.py` — `parser_trades`/`parser_book` reduced to one-liners; `self.d`, `_get_book_state`, `_restore_book_state` removed
- `dccd/continuous_dl/{bitfinex,bitmex}.py` — `self.d`, duplicate `_get_book_state` removed; `__call__` trimmed to `self.parser` setup + `super().__call__(...)`; unused `asyncio` import removed
- `dccd/tests/test_kraken.py` — 10 parametrized `format_pair` cases; similar lighter tests in Binance, Coinbase, Bybit, OKX test files (22 new tests total)

## Test plan

- [x] `pytest` — 233 passed
- [x] `ruff check dccd/` — all checks passed
- [ ] CI green