### PR TITLE
feat: HealthMonitor (metrics + alerts) and dccd CLI (typer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/daemon/health.py` — `HealthMonitor`: rotating log handler (10 MB × 5 files at `{local_path}/.dccd/dccd.log`), per-job metrics JSON (`metrics.json`), and optional Slack/Discord webhook alerts on consecutive failures; `JobMetrics` dataclass tracks `last_run_at`, `last_success_at`, `rows_collected`, `errors_count` (#30)
+- `dccd/daemon/cli.py` — `dccd` CLI (`validate`, `run`, `start`, `status`, `add` commands) via typer; `[project.scripts]` entrypoint added to `pyproject.toml`; `typer>=0.12` added to the `daemon` optional extra (#30)
+
+### Changed
+
+- `dccd/daemon/scheduler.py` — `run_histo_job`, `build_histo_scheduler`, `run_once` accept an optional `health: HealthMonitor` parameter and call `record_success` / `record_failure` (#30)
+- `dccd/daemon/stream_manager.py` — `StreamManager.__init__` accepts optional `health: HealthMonitor`; `_run_forever` records success/failure on each iteration (#30)
+
 - `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` static method on each REST exchange class; extracts inline pair-building logic from `__init__` and makes it independently testable (#29)
 - `dccd/continuous_dl/exchange.py` — `ContinuousDownloader.__call__(*args, **kwargs)`: base `__call__` using `asyncio.new_event_loop()`; Bitfinex/Bitmex overrides trimmed to exchange-specific setup only (#29)
 - `dccd/continuous_dl/exchange.py` — `_push_trades(parsed)`: validates each trade dict against `Trade` (Pydantic) then appends via `_raw_parser`; shared by Binance, Kraken, Bybit, OKX (#29)

--- a/dccd/daemon/__init__.py
+++ b/dccd/daemon/__init__.py
@@ -11,6 +11,7 @@ Submodules
 .. autosummary::
 
    config
+   health
    storage
    scheduler
    stream_manager
@@ -18,12 +19,14 @@ Submodules
 """
 
 from dccd.daemon.config import CollectorConfig, load_config
+from dccd.daemon.health import HealthMonitor
 from dccd.daemon.scheduler import build_histo_scheduler, run_once
 from dccd.daemon.storage import RemoteStorage
 from dccd.daemon.stream_manager import StreamManager, SyncService
 
 __all__ = [
     'CollectorConfig',
+    'HealthMonitor',
     'load_config',
     'RemoteStorage',
     'StreamManager',

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Command-line interface for the dccd daemon.
+
+.. currentmodule:: dccd.daemon.cli
+
+Entry point installed by ``pyproject.toml [project.scripts]``:
+
+.. code-block:: bash
+
+    pip install "dccd[daemon]"
+    dccd --help
+
+Commands
+--------
+
+.. code-block:: text
+
+    dccd validate --config PATH
+        Parse and validate the YAML config; print a one-line summary.
+        Exit 0 on success, 1 on any error (file not found, bad YAML,
+        Pydantic validation failure).
+
+    dccd run --config PATH
+        Execute every histo_job once in order, then exit.
+        Metrics (success/failure counts) are printed on completion.
+        Useful for cron-based one-shot collection or smoke-testing a config.
+
+    dccd start --config PATH
+        Start the continuous daemon in the foreground:
+        - APScheduler BackgroundScheduler for all histo_jobs
+        - StreamManager (one thread per WebSocket pair)
+        - SyncService (periodic rclone push to remotes)
+        Block until SIGINT (Ctrl-C) or SIGTERM; shuts down cleanly on signal.
+
+    dccd status --config PATH
+        Read {local_path}/.dccd/metrics.json and render a table:
+
+            job                      last_run          last_success      rows  errors
+            -----------------------------------------------------------------------
+            binance/BTC/USDT         2026-05-17 10:00  2026-05-17 10:00  1200       0
+            kraken/ETH/USD           2026-05-17 09:58  2026-05-17 09:30   800       3
+
+    dccd add --exchange X --pair Y --span N [--config PATH]
+        Append a new histo_job to the YAML config file in-place and
+        re-validate the modified config before writing.
+
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+
+__all__ = ['app']
+
+app = typer.Typer(help='dccd — autonomous crypto data collection daemon')
+
+_DEFAULT_CONFIG = 'config.yml'
+
+
+def _load(config_path: str) -> object:
+    """Load config, exit with code 1 on any error."""
+    from dccd.daemon.config import load_config
+
+    try:
+        return load_config(config_path)
+    except FileNotFoundError:
+        typer.echo(f'Error: config file not found: {config_path}', err=True)
+        raise typer.Exit(1)
+    except Exception as exc:
+        typer.echo(f'Error: {exc}', err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def validate(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Validate a YAML config file and print a one-line summary.
+
+    Loads the file, runs Pydantic validation, and prints a count of
+    histo_jobs, stream_jobs, remotes, and the local storage path.
+    Exits with code 1 on any error (missing file, bad YAML, invalid config).
+
+    """
+    cfg = _load(config)
+    typer.echo(f'Config: {config}')
+    typer.echo(f'  storage.local_path : {cfg.storage.local_path}')  # type: ignore[attr-defined]
+    typer.echo(f'  remotes            : {len(cfg.storage.remotes)}')  # type: ignore[attr-defined]
+    typer.echo(f'  histo_jobs         : {len(cfg.histo_jobs)}')  # type: ignore[attr-defined]
+    typer.echo(f'  stream_jobs        : {len(cfg.stream_jobs)}')  # type: ignore[attr-defined]
+    typer.echo('Config is valid.')
+
+
+@app.command()
+def run(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Run every histo_job once sequentially, then exit.
+
+    Downloads and saves one candle batch per ``(exchange, pair)`` in
+    ``histo_jobs``.  A :class:`~dccd.daemon.health.HealthMonitor` is
+    instantiated so metrics are persisted even for this one-shot run.
+    Failed jobs are logged and skipped; remaining jobs continue.
+    Prints ``successes=N failures=M`` on completion.
+
+    """
+    from dccd.daemon.health import HealthMonitor
+    from dccd.daemon.scheduler import run_once
+
+    cfg = _load(config)
+    health = HealthMonitor(cfg.storage.local_path, cfg.alerts)  # type: ignore[attr-defined]
+    run_once(cfg, health=health)  # type: ignore[arg-type]
+    metrics = health.get_metrics()
+    successes = sum(1 for m in metrics.values() if m.errors_count == 0)
+    failures = sum(1 for m in metrics.values() if m.errors_count > 0)
+    typer.echo(f'Done. successes={successes} failures={failures}')
+
+
+@app.command()
+def start(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Start the continuous daemon and block until SIGINT or SIGTERM.
+
+    Starts three background components:
+
+    - **APScheduler** (interval jobs for every ``histo_job``),
+    - **StreamManager** (one thread per ``(exchange, pair)`` WebSocket),
+    - **SyncService** (periodic rclone push to all configured remotes).
+
+    A :class:`~dccd.daemon.health.HealthMonitor` is shared across all
+    components; metrics and a rotating log file are written to
+    ``{local_path}/.dccd/``.
+
+    Press Ctrl-C or send SIGTERM to stop gracefully.
+
+    """
+    from dccd.daemon.health import HealthMonitor
+    from dccd.daemon.scheduler import build_histo_scheduler
+    from dccd.daemon.stream_manager import StreamManager
+
+    cfg = _load(config)
+    health = HealthMonitor(cfg.storage.local_path, cfg.alerts)  # type: ignore[attr-defined]
+    scheduler = build_histo_scheduler(cfg, health=health)  # type: ignore[arg-type]
+    stream_mgr = StreamManager(cfg, health=health)  # type: ignore[arg-type]
+
+    stop_event = threading.Event()
+
+    def _handle_signal(signum: int, frame: object) -> None:
+        typer.echo('Stopping daemon…')
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    typer.echo('Starting daemon. Press Ctrl-C to stop.')
+    scheduler.start()
+    stream_mgr.start()
+    stop_event.wait()
+    scheduler.shutdown(wait=False)
+    stream_mgr.stop()
+    typer.echo('Daemon stopped.')
+
+
+@app.command()
+def status(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Print a health table from the saved metrics JSON.
+
+    Reads ``{local_path}/.dccd/metrics.json`` and renders a table with
+    one row per ``(exchange, pair)`` job.  Columns: ``job``, ``last_run``,
+    ``last_success``, ``rows`` (cumulative), ``errors`` (consecutive).
+    Prints ``No metrics yet.`` if the file does not exist.
+
+    """
+    cfg = _load(config)
+    metrics_file = Path(cfg.storage.local_path) / '.dccd' / 'metrics.json'  # type: ignore[attr-defined]
+
+    if not metrics_file.exists():
+        typer.echo('No metrics yet.')
+        return
+
+    data: dict = json.loads(metrics_file.read_text())
+
+    def _fmt_ts(ts: float | None) -> str:
+        if ts is None:
+            return '-'
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d %H:%M')
+
+    col_w = 24
+    header = (
+        f"{'job':<{col_w}} {'last_run':<17} {'last_success':<17} {'rows':>6} {'errors':>6}"
+    )
+    typer.echo(header)
+    typer.echo('-' * len(header))
+    for key, m in data.items():
+        typer.echo(
+            f"{key:<{col_w}} "
+            f"{_fmt_ts(m.get('last_run_at')):<17} "
+            f"{_fmt_ts(m.get('last_success_at')):<17} "
+            f"{m.get('rows_collected', 0):>6} "
+            f"{m.get('errors_count', 0):>6}"
+        )
+
+
+@app.command()
+def add(
+    exchange: str = typer.Option(..., '--exchange', '-e', help='Exchange name.'),
+    pair: str = typer.Option(..., '--pair', '-p', help='Trading pair (e.g. BTC/USDT).'),
+    span: int = typer.Option(..., '--span', '-s', help='Candle interval in seconds.'),
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Append a new histo job to the YAML config file in-place.
+
+    Adds a ``histo_jobs`` entry for the given ``(exchange, pair, span)``
+    and re-validates the whole config with Pydantic before writing.
+    Exits with code 1 and leaves the file unchanged if validation fails.
+
+    """
+    import yaml
+    from pydantic import ValidationError
+
+    from dccd.daemon.config import CollectorConfig
+
+    config_path = Path(config)
+    if not config_path.exists():
+        typer.echo(f'Error: config file not found: {config}', err=True)
+        raise typer.Exit(1)
+
+    raw: dict = yaml.safe_load(config_path.read_text())
+    raw.setdefault('histo_jobs', [])
+    raw['histo_jobs'].append({
+        'exchange': exchange,
+        'pairs': [pair],
+        'span': span,
+    })
+
+    try:
+        CollectorConfig.model_validate(raw)
+    except ValidationError as exc:
+        typer.echo(f'Validation error after add: {exc}', err=True)
+        raise typer.Exit(1)
+
+    config_path.write_text(yaml.dump(raw, default_flow_style=False))
+    typer.echo(f'Added histo job: exchange={exchange} pair={pair} span={span}s')
+    typer.echo(f'Config written to {config}.')

--- a/dccd/daemon/health.py
+++ b/dccd/daemon/health.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Health monitoring for the dccd daemon.
+
+Tracks per-job metrics (last run, last success, rows collected, error count),
+persists them to a JSON file, configures a rotating log handler, and sends
+optional webhook alerts when consecutive failures exceed the configured
+threshold.
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.request
+from dataclasses import asdict, dataclass
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import AlertConfig
+
+__all__ = ['HealthMonitor', 'JobMetrics']
+
+logger = logging.getLogger(__name__)
+
+_LOG_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+_LOG_BACKUP_COUNT = 5
+
+
+@dataclass
+class JobMetrics:
+    """ Per-job health metrics, updated after every execution attempt.
+
+    ``errors_count`` is a *consecutive* failure counter: it resets to 0
+    whenever :meth:`HealthMonitor.record_success` is called, so it reflects
+    the current streak of failures rather than a lifetime total.
+
+    Parameters
+    ----------
+    last_run_at : float or None
+        Unix timestamp of the most recent execution attempt (success or failure).
+    last_success_at : float or None
+        Unix timestamp of the most recent successful execution.
+        ``None`` until the first success.
+    rows_collected : int
+        Cumulative number of rows saved across all successful runs.
+    errors_count : int
+        Number of *consecutive* failures since the last success.
+        Resets to 0 on the next successful run.
+
+    """
+
+    last_run_at: float | None = None
+    last_success_at: float | None = None
+    rows_collected: int = 0
+    errors_count: int = 0
+
+
+class HealthMonitor:
+    """ Monitor job health, persist metrics, and send webhook alerts.
+
+    ``HealthMonitor`` serves three purposes:
+
+    1. **Rotating log** — attaches a :class:`~logging.handlers.RotatingFileHandler`
+       (10 MB × 5 backups) to the *root* logger on construction, so every
+       ``logging`` call anywhere in the process lands in
+       ``{local_path}/.dccd/dccd.log`` in addition to the console.
+    2. **Per-job metrics** — :meth:`record_success` / :meth:`record_failure`
+       update a :class:`JobMetrics` entry for each ``(exchange, pair)`` key and
+       flush the full metrics dict to ``{local_path}/.dccd/metrics.json`` after
+       each call.  The JSON file is reloaded on startup, so metrics survive
+       daemon restarts.
+    3. **Webhook alerts** — when ``errors_count`` reaches
+       ``alerts.max_consecutive_errors``, a JSON POST is sent to
+       ``alerts.webhook_url`` (Slack / Discord / generic).  Alerting is
+       completely optional: pass ``AlertConfig()`` with no ``webhook_url`` to
+       disable it.
+
+    Use this class directly when embedding the scheduler in your own process
+    (see :func:`~dccd.daemon.scheduler.run_once` and
+    :func:`~dccd.daemon.scheduler.build_histo_scheduler`).  The ``dccd``
+    CLI commands instantiate it automatically.
+
+    Parameters
+    ----------
+    local_path : str or Path
+        Root data directory (``CollectorConfig.storage.local_path``).
+        The hidden directory ``{local_path}/.dccd/`` is created on init if it
+        does not exist.
+    alerts : AlertConfig
+        Alerting configuration (webhook URL and error threshold).
+
+    Notes
+    -----
+    The rotating log handler is added to the **root** logger, not to the
+    module logger.  All loggers in the process therefore write to the file
+    after :class:`HealthMonitor` is constructed — this is intentional so that
+    APScheduler, WebSocket, and application logs are all captured together.
+
+    Calling :meth:`record_failure` does *not* suppress or re-raise the
+    original exception.  The caller is responsible for exception handling;
+    ``HealthMonitor`` only observes the outcome.
+
+    Examples
+    --------
+    Standalone usage inside a custom scheduler loop:
+
+    >>> from dccd.daemon.config import AlertConfig
+    >>> from dccd.daemon.health import HealthMonitor
+    >>> import tempfile, pathlib
+    >>> with tempfile.TemporaryDirectory() as tmp:
+    ...     alerts = AlertConfig()           # no webhook
+    ...     monitor = HealthMonitor(tmp, alerts)
+    ...     monitor.record_success('binance', 'BTC/USDT', rows=120)
+    ...     monitor.record_success('binance', 'BTC/USDT', rows=95)
+    ...     monitor.record_failure('kraken',  'ETH/USD')
+    ...     m = monitor.get_metrics()
+    ...     print(m['binance/BTC/USDT'].rows_collected)
+    ...     print(m['kraken/ETH/USD'].errors_count)
+    215
+    1
+
+    """
+
+    def __init__(self, local_path: str | Path, alerts: AlertConfig) -> None:
+        self._dir = Path(local_path) / '.dccd'
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._metrics_file = self._dir / 'metrics.json'
+        self._alerts = alerts
+        self._metrics: dict[str, JobMetrics] = {}
+        self._load_metrics()
+        self._setup_logging()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def record_success(self, exchange: str, pair: str, rows: int = 0) -> None:
+        """ Record a successful job execution.
+
+        Parameters
+        ----------
+        exchange : str
+            Exchange name (e.g. ``'binance'``).
+        pair : str
+            Trading pair (e.g. ``'BTC/USDT'``).
+        rows : int, optional
+            Number of data rows collected, default 0.
+
+        """
+        key = self._key(exchange, pair)
+        m = self._metrics.setdefault(key, JobMetrics())
+        now = time.time()
+        m.last_run_at = now
+        m.last_success_at = now
+        m.rows_collected += rows
+        m.errors_count = 0
+        self._save_metrics()
+        logger.debug('health: success %s %s rows=%d', exchange, pair, rows)
+
+    def record_failure(self, exchange: str, pair: str) -> None:
+        """ Record a failed job execution.
+
+        Parameters
+        ----------
+        exchange : str
+            Exchange name.
+        pair : str
+            Trading pair.
+
+        """
+        key = self._key(exchange, pair)
+        m = self._metrics.setdefault(key, JobMetrics())
+        m.last_run_at = time.time()
+        m.errors_count += 1
+        self._save_metrics()
+        logger.warning('health: failure %s %s errors=%d', exchange, pair, m.errors_count)
+        if (self._alerts.webhook_url
+                and m.errors_count >= self._alerts.max_consecutive_errors):
+            self._send_alert(exchange, pair, m.errors_count)
+
+    def get_metrics(self) -> dict[str, JobMetrics]:
+        """ Return a snapshot of the current metrics dict.
+
+        Returns
+        -------
+        dict of str to JobMetrics
+            Keys are ``'{exchange}/{pair}'`` strings.
+
+        """
+        return dict(self._metrics)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _key(exchange: str, pair: str) -> str:
+        return f'{exchange}/{pair}'
+
+    def _send_alert(self, exchange: str, pair: str, errors_count: int) -> None:
+        text = (
+            f':warning: dccd: {errors_count} consecutive errors '
+            f'on {exchange} {pair}'
+        )
+        payload = json.dumps({'text': text}).encode()
+        req = urllib.request.Request(
+            self._alerts.webhook_url,  # type: ignore[arg-type]
+            data=payload,
+            headers={'Content-Type': 'application/json'},
+        )
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            logger.info('health: alert sent for %s %s', exchange, pair)
+        except Exception:
+            logger.exception('health: failed to send alert for %s %s', exchange, pair)
+
+    def _save_metrics(self) -> None:
+        data = {k: asdict(v) for k, v in self._metrics.items()}
+        self._metrics_file.write_text(json.dumps(data, indent=2))
+
+    def _load_metrics(self) -> None:
+        if self._metrics_file.exists():
+            try:
+                data = json.loads(self._metrics_file.read_text())
+                self._metrics = {k: JobMetrics(**v) for k, v in data.items()}
+            except Exception:
+                logger.warning('health: could not load metrics from %s', self._metrics_file)
+
+    def _setup_logging(self) -> None:
+        log_file = self._dir / 'dccd.log'
+        handler = RotatingFileHandler(
+            log_file,
+            maxBytes=_LOG_MAX_BYTES,
+            backupCount=_LOG_BACKUP_COUNT,
+        )
+        handler.setFormatter(
+            logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+        )
+        logging.getLogger().addHandler(handler)

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -24,6 +24,7 @@ from dccd.histo_dl.okx import FromOKX
 
 if TYPE_CHECKING:
     from dccd.daemon.config import CollectorConfig, HistoJob
+    from dccd.daemon.health import HealthMonitor
 
 __all__ = ['build_histo_scheduler', 'run_histo_job', 'run_once']
 
@@ -38,7 +39,8 @@ _HISTO_CLASSES: dict[str, type[ImportDataCryptoCurrencies]] = {
 }
 
 
-def run_histo_job(job: HistoJob, pair: str, base_path: str) -> None:
+def run_histo_job(job: HistoJob, pair: str, base_path: str,
+                  health: HealthMonitor | None = None) -> None:
     """ Download and save one (exchange, pair) candle job locally.
 
     Data is saved to ``base_path`` on the daemon host.  Remote sync is
@@ -52,16 +54,28 @@ def run_histo_job(job: HistoJob, pair: str, base_path: str) -> None:
         Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
     base_path : str
         Root directory for local storage (``CollectorConfig.storage.local_path``).
+    health : HealthMonitor or None, optional
+        Health monitor to record success/failure metrics.
 
     """
     crypto, fiat = pair.split('/', 1)
     cls = _HISTO_CLASSES[job.exchange]
-    obj = cls(base_path, crypto, job.span, fiat, form=job.format)
-    obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
-    logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
+    try:
+        obj = cls(base_path, crypto, job.span, fiat, form=job.format)
+        obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
+        _data = getattr(obj, 'data', None)
+        rows = len(_data) if _data is not None else 0
+        logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
+        if health:
+            health.record_success(job.exchange, pair, rows)
+    except Exception:
+        if health:
+            health.record_failure(job.exchange, pair)
+        raise
 
 
-def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
+def build_histo_scheduler(config: CollectorConfig,
+                          health: HealthMonitor | None = None) -> BackgroundScheduler:
     """ Build an APScheduler BackgroundScheduler from a CollectorConfig.
 
     One interval job is registered per ``(exchange, pair)`` combination in
@@ -72,6 +86,8 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
     ----------
     config : CollectorConfig
         Daemon configuration.
+    health : HealthMonitor or None, optional
+        Health monitor forwarded to each scheduled job.
 
     Returns
     -------
@@ -96,7 +112,12 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
                 run_histo_job,
                 trigger='interval',
                 seconds=job.span,
-                args=[job, pair, config.storage.local_path],
+                kwargs={
+                    'job': job,
+                    'pair': pair,
+                    'base_path': config.storage.local_path,
+                    'health': health,
+                },
                 id=job_id,
                 name=f'{job.exchange} {pair} {job.span}s',
                 coalesce=True,
@@ -107,7 +128,8 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
     return scheduler
 
 
-def run_once(config: CollectorConfig) -> None:
+def run_once(config: CollectorConfig,
+             health: HealthMonitor | None = None) -> None:
     """ Execute all histo_jobs once and return.
 
     Each ``(exchange, pair)`` combination is run sequentially.  A job
@@ -117,12 +139,14 @@ def run_once(config: CollectorConfig) -> None:
     ----------
     config : CollectorConfig
         Daemon configuration.
+    health : HealthMonitor or None, optional
+        Health monitor forwarded to each job call.
 
     """
     for job in config.histo_jobs:
         for pair in job.pairs:
             try:
-                run_histo_job(job, pair, config.storage.local_path)
+                run_histo_job(job, pair, config.storage.local_path, health=health)
             except Exception:
                 logger.exception(
                     'histo job failed: %s %s', job.exchange, pair

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -34,6 +34,7 @@ from dccd.tools.io import IODataBase
 
 if TYPE_CHECKING:
     from dccd.daemon.config import CollectorConfig, StorageConfig, StreamJob
+    from dccd.daemon.health import HealthMonitor
 
 __all__ = ['StreamManager', 'SyncService']
 
@@ -265,8 +266,10 @@ class StreamManager:
 
     """
 
-    def __init__(self, config: CollectorConfig) -> None:
+    def __init__(self, config: CollectorConfig,
+                 health: HealthMonitor | None = None) -> None:
         self.config = config
+        self._health = health
         self._threads:     dict[str, threading.Thread]     = {}
         self._downloaders: dict[str, ContinuousDownloader] = {}
         self._stop_event = threading.Event()
@@ -305,8 +308,12 @@ class StreamManager:
         while not self._stop_event.is_set():
             try:
                 self._run_once(job, pair, channels)
+                if self._health:
+                    self._health.record_success(job.exchange, pair)
             except Exception:
                 logger.exception('stream crashed: %s %s', job.exchange, pair)
+                if self._health:
+                    self._health.record_failure(job.exchange, pair)
             if not self._stop_event.is_set():
                 self._stop_event.wait(timeout=_RESTART_DELAY)
 

--- a/dccd/tests/test_daemon_cli.py
+++ b/dccd/tests/test_daemon_cli.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""Tests for dccd.daemon.cli."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from dccd.daemon.cli import app
+
+runner = CliRunner()
+
+_MINIMAL_CONFIG = {
+    'storage': {'local_path': '/tmp/dccd_test_data'},
+    'histo_jobs': [
+        {'exchange': 'binance', 'pairs': ['BTC/USDT'], 'span': 3600},
+    ],
+}
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path) -> Path:
+    p = tmp_path / 'config.yml'
+    p.write_text(yaml.dump(_MINIMAL_CONFIG))
+    return p
+
+
+def test_validate_ok(config_file: Path) -> None:
+    result = runner.invoke(app, ['validate', '--config', str(config_file)])
+    assert result.exit_code == 0
+    assert 'valid' in result.output.lower()
+    assert 'binance' not in result.output  # summary is counts, not exchange names
+
+
+def test_validate_missing_file(tmp_path: Path) -> None:
+    result = runner.invoke(app, ['validate', '--config', str(tmp_path / 'no.yml')])
+    assert result.exit_code == 1
+
+
+def test_validate_bad_config(tmp_path: Path) -> None:
+    bad = tmp_path / 'bad.yml'
+    bad.write_text(yaml.dump({'storage': {'local_path': '/tmp'}, 'histo_jobs': []}))
+    result = runner.invoke(app, ['validate', '--config', str(bad)])
+    assert result.exit_code == 1
+
+
+def test_run_calls_run_once(config_file: Path) -> None:
+    with patch('dccd.daemon.health.HealthMonitor') as MockHealth, \
+         patch('dccd.daemon.scheduler.run_once') as mock_run_once:
+        MockHealth.return_value.get_metrics.return_value = {}
+        result = runner.invoke(app, ['run', '--config', str(config_file)])
+    assert result.exit_code == 0
+    mock_run_once.assert_called_once()
+
+
+def test_status_no_metrics(config_file: Path) -> None:
+    result = runner.invoke(app, ['status', '--config', str(config_file)])
+    assert result.exit_code == 0
+    assert 'No metrics yet' in result.output
+
+
+def test_status_shows_table(config_file: Path, tmp_path: Path) -> None:
+    dccd_dir = tmp_path / '.dccd_test_storage' / '.dccd'
+    dccd_dir.mkdir(parents=True)
+    metrics = {
+        'binance/BTC/USDT': {
+            'last_run_at': 1747440000.0,
+            'last_success_at': 1747440000.0,
+            'rows_collected': 100,
+            'errors_count': 0,
+        }
+    }
+    (dccd_dir / 'metrics.json').write_text(json.dumps(metrics))
+
+    cfg = {
+        'storage': {'local_path': str(dccd_dir.parent)},
+        'histo_jobs': [{'exchange': 'binance', 'pairs': ['BTC/USDT'], 'span': 3600}],
+    }
+    cfg_file = tmp_path / 'cfg2.yml'
+    cfg_file.write_text(yaml.dump(cfg))
+
+    result = runner.invoke(app, ['status', '--config', str(cfg_file)])
+    assert result.exit_code == 0
+    assert 'binance/BTC/USDT' in result.output
+    assert '100' in result.output
+
+
+def test_add_histo_job(config_file: Path) -> None:
+    result = runner.invoke(app, [
+        'add',
+        '--exchange', 'kraken',
+        '--pair', 'ETH/USD',
+        '--span', '86400',
+        '--config', str(config_file),
+    ])
+    assert result.exit_code == 0
+    loaded = yaml.safe_load(config_file.read_text())
+    pairs_all = [
+        p for job in loaded['histo_jobs'] for p in job['pairs']
+    ]
+    assert 'ETH/USD' in pairs_all

--- a/dccd/tests/test_daemon_health.py
+++ b/dccd/tests/test_daemon_health.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""Tests for dccd.daemon.health."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dccd.daemon.config import AlertConfig
+from dccd.daemon.health import HealthMonitor
+
+
+@pytest.fixture()
+def alert_cfg() -> AlertConfig:
+    return AlertConfig(webhook_url=None, max_consecutive_errors=3)
+
+
+@pytest.fixture()
+def monitor(tmp_path: Path, alert_cfg: AlertConfig) -> HealthMonitor:
+    return HealthMonitor(tmp_path, alert_cfg)
+
+
+def test_record_success_updates_metrics(monitor: HealthMonitor, tmp_path: Path) -> None:
+    monitor.record_success('binance', 'BTC/USDT', rows=10)
+    m = monitor.get_metrics()['binance/BTC/USDT']
+    assert m.last_run_at is not None
+    assert m.last_success_at == m.last_run_at
+    assert m.rows_collected == 10
+    assert m.errors_count == 0
+
+
+def test_record_success_resets_errors(monitor: HealthMonitor) -> None:
+    monitor.record_failure('binance', 'BTC/USDT')
+    monitor.record_failure('binance', 'BTC/USDT')
+    monitor.record_success('binance', 'BTC/USDT')
+    assert monitor.get_metrics()['binance/BTC/USDT'].errors_count == 0
+
+
+def test_record_failure_increments(monitor: HealthMonitor) -> None:
+    monitor.record_failure('kraken', 'ETH/USD')
+    monitor.record_failure('kraken', 'ETH/USD')
+    m = monitor.get_metrics()['kraken/ETH/USD']
+    assert m.errors_count == 2
+    assert m.last_run_at is not None
+    assert m.last_success_at is None
+
+
+def test_record_failure_triggers_webhook(tmp_path: Path) -> None:
+    cfg = AlertConfig(webhook_url='http://example.com/hook', max_consecutive_errors=2)
+    mon = HealthMonitor(tmp_path, cfg)
+
+    with patch('urllib.request.urlopen') as mock_open:
+        mon.record_failure('binance', 'BTC/USDT')
+        mock_open.assert_not_called()
+        mon.record_failure('binance', 'BTC/USDT')
+        mock_open.assert_called_once()
+
+
+def test_no_alert_below_threshold(tmp_path: Path) -> None:
+    cfg = AlertConfig(webhook_url='http://example.com/hook', max_consecutive_errors=5)
+    mon = HealthMonitor(tmp_path, cfg)
+    with patch('urllib.request.urlopen') as mock_open:
+        for _ in range(4):
+            mon.record_failure('binance', 'BTC/USDT')
+        mock_open.assert_not_called()
+
+
+def test_metrics_persist_reload(tmp_path: Path, alert_cfg: AlertConfig) -> None:
+    mon1 = HealthMonitor(tmp_path, alert_cfg)
+    mon1.record_success('binance', 'BTC/USDT', rows=42)
+    mon1.record_failure('kraken', 'ETH/USD')
+
+    mon2 = HealthMonitor(tmp_path, alert_cfg)
+    metrics = mon2.get_metrics()
+    assert metrics['binance/BTC/USDT'].rows_collected == 42
+    assert metrics['kraken/ETH/USD'].errors_count == 1
+
+
+def test_rotating_log_created(monitor: HealthMonitor, tmp_path: Path) -> None:
+    log_file = tmp_path / '.dccd' / 'dccd.log'
+    assert log_file.exists()

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -11,9 +11,11 @@ The daemon module provides an autonomous, server-side data collector.
 It reads a declarative YAML configuration, runs historical REST jobs on a
 schedule (APScheduler), opens WebSocket streams for real-time collection, and
 periodically syncs all local data to one or more remote destinations via rclone.
+Per-job metrics and a rotating log file are maintained by
+:class:`~dccd.daemon.health.HealthMonitor`.
 
-Quick start
------------
+Quick start (CLI)
+-----------------
 
 1. Install the daemon extra:
 
@@ -35,35 +37,80 @@ Quick start
        histo_jobs:
          - exchange: binance
            pairs: [BTC/USDT, ETH/USDT]
-           span: 3600
+           span: 3600          # candle interval in seconds
            format: parquet
-           by_period: Y
+           by_period: Y        # one file per year
 
+       # Optional real-time streams
        stream_jobs:
          - exchange: binance
            pairs: [BTC/USDT]
            channels: [trades, book]
            time_step: 60
 
-3. Run a one-shot collection, then start the daemon:
+       # Optional webhook alerts on consecutive failures
+       alerts:
+         webhook_url: "https://hooks.slack.com/services/..."
+         max_consecutive_errors: 3
 
-   .. code-block:: python
+3. Validate, run once, then start the daemon:
 
-       from dccd.daemon.config import load_config
-       from dccd.daemon.scheduler import run_once, build_histo_scheduler
-       from dccd.daemon.stream_manager import StreamManager
+   .. code-block:: bash
 
-       config = load_config('config.yml')
+       # Check config without running anything
+       dccd validate --config config.yml
+       # Config: config.yml
+       #   storage.local_path : /data/crypto/
+       #   remotes            : 1
+       #   histo_jobs         : 1
+       #   stream_jobs        : 1
+       # Config is valid.
 
        # One-shot: download all histo jobs once and exit
-       run_once(config)
+       dccd run --config config.yml
+       # Done. successes=2 failures=0
 
-       # Daemon: start periodic histo scheduler + WebSocket streams
-       scheduler = build_histo_scheduler(config)
-       scheduler.start()
+       # Continuous daemon (block until Ctrl-C / SIGTERM)
+       dccd start --config config.yml
 
-       mgr = StreamManager(config)
-       mgr.start()
+       # Inspect per-job health after the daemon has run
+       dccd status --config config.yml
+       # job                      last_run          last_success       rows  errors
+       # -------------------------------------------------------------------------
+       # binance/BTC/USDT         2026-05-17 10:00  2026-05-17 10:00   1200       0
+       # binance/ETH/USDT         2026-05-17 10:00  2026-05-17 10:00    980       0
+
+       # Add a new histo job to an existing config in-place
+       dccd add --exchange kraken --pair ETH/USD --span 86400 --config config.yml
+
+Python API
+----------
+
+Use the components directly when you need to embed the daemon inside your
+own process or customise startup/shutdown logic.  The script
+:file:`examples/daemon_example.py` shows the full wiring:
+
+.. code-block:: python
+
+    from dccd.daemon.config import load_config
+    from dccd.daemon.health import HealthMonitor
+    from dccd.daemon.scheduler import build_histo_scheduler, run_once
+    from dccd.daemon.stream_manager import StreamManager
+
+    config  = load_config('config.yml')
+    health  = HealthMonitor(config.storage.local_path, config.alerts)
+
+    # --- one-shot mode (cron-friendly) ---
+    run_once(config, health=health)
+
+    # --- or continuous mode ---
+    scheduler  = build_histo_scheduler(config, health=health)
+    stream_mgr = StreamManager(config, health=health)
+    scheduler.start()
+    stream_mgr.start()
+    # … wait for stop signal …
+    scheduler.shutdown(wait=False)
+    stream_mgr.stop()
 
 .. _daemon-config:
 
@@ -100,6 +147,15 @@ Stream manager
    stream_manager.StreamManager -- manage real-time WebSocket collection jobs
    stream_manager.SyncService -- periodically push local data to all remote destinations
 
+Health monitoring
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   health.HealthMonitor -- track per-job metrics, write rotating logs, send webhook alerts
+   health.JobMetrics -- per-job health metrics dataclass
+
 Storage
 -------
 
@@ -107,3 +163,11 @@ Storage
    :toctree: generated/
 
    storage.RemoteStorage -- push local data directories to remote destinations via rclone
+
+CLI
+---
+
+.. autosummary::
+   :toctree: generated/
+
+   cli.app -- typer application (``dccd`` entrypoint)

--- a/examples/daemon_example.py
+++ b/examples/daemon_example.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Programmatic daemon usage — without the CLI.
+
+This script shows how to wire the daemon components together in pure Python.
+It is the equivalent of ``dccd start --config config.yml`` but gives you full
+control over each component: useful when embedding the daemon inside a larger
+process or when you need custom startup/shutdown logic.
+
+Components
+----------
+- :func:`~dccd.daemon.config.load_config` — parse and validate the YAML config
+- :class:`~dccd.daemon.health.HealthMonitor` — rotating log + metrics JSON
+- :func:`~dccd.daemon.scheduler.build_histo_scheduler` — APScheduler for REST jobs
+- :class:`~dccd.daemon.stream_manager.StreamManager` — WebSocket threads
+- :func:`~dccd.daemon.scheduler.run_once` — one-shot alternative to the scheduler
+
+Prerequisites
+-------------
+    pip install "dccd[daemon]"
+    # Copy and adapt examples/config.example.yml to config.yml
+    # (or point CONFIG_PATH to any valid YAML config)
+
+"""
+
+import logging
+import signal
+import threading
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(name)s %(levelname)s %(message)s',
+)
+
+CONFIG_PATH = 'config.yml'
+
+# ---------------------------------------------------------------------------
+# 1. Load and validate the YAML configuration
+# ---------------------------------------------------------------------------
+from dccd.daemon.config import load_config
+
+config = load_config(CONFIG_PATH)
+print(f'Loaded config: {len(config.histo_jobs)} histo jobs, '
+      f'{len(config.stream_jobs)} stream jobs')
+
+# ---------------------------------------------------------------------------
+# 2. Initialise the health monitor
+#
+#    Creates {local_path}/.dccd/ with:
+#      - dccd.log  (rotating, 10 MB × 5 files)
+#      - metrics.json (updated after every job execution)
+#    Optional webhook alerts are configured in config.alerts.
+# ---------------------------------------------------------------------------
+from dccd.daemon.health import HealthMonitor
+
+health = HealthMonitor(config.storage.local_path, config.alerts)
+
+# ---------------------------------------------------------------------------
+# 3a. One-shot run: execute every histo_job once, then return
+#
+#     Use this in a cron job or for an initial backfill.
+#     Failed jobs are logged and skipped; others continue.
+# ---------------------------------------------------------------------------
+from dccd.daemon.scheduler import run_once
+
+# run_once(config, health=health)   # uncomment for one-shot mode
+
+# ---------------------------------------------------------------------------
+# 3b. Continuous daemon: scheduler + stream manager
+#
+#     build_histo_scheduler() creates an APScheduler BackgroundScheduler
+#     with one interval job per (exchange, pair) defined in histo_jobs.
+#
+#     StreamManager starts one background thread per (exchange, pair) for
+#     every stream_job; threads restart automatically on crash.
+# ---------------------------------------------------------------------------
+from dccd.daemon.scheduler import build_histo_scheduler
+from dccd.daemon.stream_manager import StreamManager
+
+scheduler = build_histo_scheduler(config, health=health)
+stream_mgr = StreamManager(config, health=health)
+
+# ---------------------------------------------------------------------------
+# 4. Graceful shutdown on SIGINT / SIGTERM
+# ---------------------------------------------------------------------------
+stop_event = threading.Event()
+
+
+def _shutdown(signum, frame):
+    print('\nShutting down daemon…')
+    stop_event.set()
+
+
+signal.signal(signal.SIGINT, _shutdown)
+signal.signal(signal.SIGTERM, _shutdown)
+
+# ---------------------------------------------------------------------------
+# 5. Start and block
+# ---------------------------------------------------------------------------
+print('Starting daemon. Press Ctrl-C to stop.')
+scheduler.start()
+stream_mgr.start()
+
+stop_event.wait()
+
+scheduler.shutdown(wait=False)
+stream_mgr.stop()
+
+# ---------------------------------------------------------------------------
+# 6. Print a final metrics snapshot
+# ---------------------------------------------------------------------------
+metrics = health.get_metrics()
+print(f'\nFinal metrics ({len(metrics)} jobs):')
+for key, m in metrics.items():
+    print(f'  {key:30s}  rows={m.rows_collected:6d}  errors={m.errors_count}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,12 @@ dependencies = [
 
 [project.optional-dependencies]
 io = ["pyarrow>=13", "polars>=0.20"]
-daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4"]
-dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
+daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12"]
+dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12"]
 doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
+
+[project.scripts]
+dccd = "dccd.daemon.cli:app"
 
 [project.urls]
 Homepage = "https://github.com/ArthurBernard/Download_Crypto_Currencies_Data"


### PR DESCRIPTION
## Summary

- `dccd/daemon/health.py`: `HealthMonitor` with `RotatingFileHandler` (10 MB × 5 files), per-job metrics JSON at `{local_path}/.dccd/metrics.json`, optional webhook alerts when consecutive failures exceed the configured threshold
- `dccd/daemon/cli.py`: `dccd` CLI with `validate`, `run`, `start`, `status`, `add` commands via typer; `[project.scripts]` entrypoint added to `pyproject.toml`; `typer>=0.12` added to `daemon` and `dev` extras
- `scheduler.py` and `stream_manager.py`: `health: HealthMonitor | None` wired through all three scheduler functions and `StreamManager`

## Changes

- `dccd/daemon/health.py` — new: `JobMetrics` dataclass + `HealthMonitor` class
- `dccd/daemon/cli.py` — new: typer app with 5 commands
- `dccd/daemon/__init__.py` — export `HealthMonitor`
- `dccd/daemon/scheduler.py` — `run_histo_job`, `build_histo_scheduler`, `run_once` accept optional `health` param
- `dccd/daemon/stream_manager.py` — `StreamManager.__init__` accepts optional `health` param; `_run_forever` records success/failure
- `pyproject.toml` — `typer>=0.12` added to `daemon` + `dev`; `[project.scripts]` section added
- `doc/source/daemon.rst` — quick-start updated to show CLI commands; health and CLI sections added to autosummary
- 14 new tests: `test_daemon_health.py` (7) + `test_daemon_cli.py` (7)

## Changelog

Added under [Unreleased]:
- `dccd/daemon/health.py` — `HealthMonitor` and `JobMetrics` (#30)
- `dccd/daemon/cli.py` — `dccd` CLI via typer (#30)
- `scheduler.py`, `stream_manager.py` — health param wired through (#30)

## Test plan

- [x] pytest passes locally (247 passed)
- [x] ruff check dccd/daemon/ passes
- [x] mypy dccd/daemon/ — no new errors (3 pre-existing in tools/io.py and histo_dl/exchange.py)
- [ ] CI green