### PR TITLE
release: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#XX)
+- `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#26)
 - `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
 - `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)
 - `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#25)
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `dccd/daemon/config.py` — `StorageConfig.remote: RemoteConfig | None` replaced by `remotes: list[RemoteConfig]` (multiple destinations) and `sync_interval: int` (default 3600 s) (#XX)
-- `dccd/daemon/storage.py` — `RemoteStorage.push()` now iterates all `config.remotes`; supports root-path sync (path == local_path) (#XX)
-- `dccd/daemon/scheduler.py` — `run_histo_job` no longer takes a `storage` argument and no longer pushes; remote sync is fully delegated to `SyncService` (#XX)
+- `dccd/daemon/config.py` — `StorageConfig.remote: RemoteConfig | None` replaced by `remotes: list[RemoteConfig]` (multiple destinations) and `sync_interval: int` (default 3600 s) (#26)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()` now iterates all `config.remotes`; supports root-path sync (path == local_path) (#26)
+- `dccd/daemon/scheduler.py` — `run_histo_job` no longer takes a `storage` argument and no longer pushes; remote sync is fully delegated to `SyncService` (#26)
 
 ## [2.1.0] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/continuous_dl/exchange.py` — `set_trades_saver(saver, process_func)` and `set_book_saver(saver, process_func)`: separate savers for the trades and order-book channels; high-level helpers updated accordingly (#28)
+- `dccd/continuous_dl/exchange.py` — crash-recovery checkpoint: `checkpoint_dir` parameter serialises `self.d` (live book state) to JSON after each snapshot; reloaded on restart via `_load_checkpoint()` (#28)
+- `dccd/continuous_dl/exchange.py` — `snapshot_ts` (UTC milliseconds) injected into every yielded snapshot payload by `__anext__` (#28)
 - `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#26)
 - `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
 - `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#XX)
-- `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#XX)
-- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#XX)
-- `examples/config.example.yml` — annotated reference config for the daemon (#XX)
-- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#XX)
+- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)
+- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#25)
+- `examples/config.example.yml` — annotated reference config for the daemon (#25)
+- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#25)
 
 ## [2.1.0] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,46 +6,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-05-17
+
 ### Added
 
-- `dccd/histo_dl/exchange.py` — `import_trades(start, end)` and `import_orderbook(depth)` public methods on `ImportDataCryptoCurrencies`; `_sort_trades` and `_sort_orderbook` helpers validate via Pydantic, sort and deduplicate; `trades_df` / `orderbook_df` attributes; `save_trades` and `save_orderbook` helpers
-- `dccd/histo_dl/{binance,kraken,bybit,okx,coinbase}.py` — `_import_trades(start, end)` and `_import_orderbook(depth)` implemented for all five exchanges (Binance/Kraken full history; Bybit/Coinbase recent-only snapshot)
-- `dccd/models.py` — `Trade.tid` made optional (`int | None`); `OrderBookEntry` gains required `side` field and `count` made optional (`int | None`)
-- Tests: 15 new test cases across 5 exchange test files (trades keys, order-book sides, HTTP 500 path) + `test_orderbookentry_count_optional` in `test_models.py`
-
-- `dccd/daemon/health.py` — `HealthMonitor`: rotating log handler (10 MB × 5 files at `{local_path}/.dccd/dccd.log`), per-job metrics JSON (`metrics.json`), and optional Slack/Discord webhook alerts on consecutive failures; `JobMetrics` dataclass tracks `last_run_at`, `last_success_at`, `rows_collected`, `errors_count` (#30)
-- `dccd/daemon/cli.py` — `dccd` CLI (`validate`, `run`, `start`, `status`, `add` commands) via typer; `[project.scripts]` entrypoint added to `pyproject.toml`; `typer>=0.12` added to the `daemon` optional extra (#30)
-
-### Changed
-
-- `dccd/daemon/scheduler.py` — `run_histo_job`, `build_histo_scheduler`, `run_once` accept an optional `health: HealthMonitor` parameter and call `record_success` / `record_failure` (#30)
-- `dccd/daemon/stream_manager.py` — `StreamManager.__init__` accepts optional `health: HealthMonitor`; `_run_forever` records success/failure on each iteration (#30)
-
-- `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` static method on each REST exchange class; extracts inline pair-building logic from `__init__` and makes it independently testable (#29)
-- `dccd/continuous_dl/exchange.py` — `ContinuousDownloader.__call__(*args, **kwargs)`: base `__call__` using `asyncio.new_event_loop()`; Bitfinex/Bitmex overrides trimmed to exchange-specific setup only (#29)
-- `dccd/continuous_dl/exchange.py` — `_push_trades(parsed)`: validates each trade dict against `Trade` (Pydantic) then appends via `_raw_parser`; shared by Binance, Kraken, Bybit, OKX (#29)
-- `dccd/continuous_dl/exchange.py` — `_push_book_updates(updates)`: applies a `{price: qty}` delta to `self.d` and snapshots the book into `_data`; shared by Binance, Kraken, Bybit, OKX (#29)
-- `dccd/tests/test_kraken.py` — 10 parametrized cases for `FromKraken.format_pair` covering BTC→XBT, BCH/DASH exemption, X/Z prefix rules, and cross-crypto pairs (#29)
-
-### Changed
-
-- `dccd/continuous_dl/exchange.py` — `self.d: dict = {}` initialised in base `__init__`; `_get_book_state()` and `_restore_book_state()` upgraded from stubs to working defaults; removed redundant overrides in Binance, Kraken, Bybit, OKX, Bitfinex (#29)
-
-- `dccd/continuous_dl/exchange.py` — `set_trades_saver(saver, process_func)` and `set_book_saver(saver, process_func)`: separate savers for the trades and order-book channels; high-level helpers updated accordingly (#28)
-- `dccd/continuous_dl/exchange.py` — crash-recovery checkpoint: `checkpoint_dir` parameter serialises `self.d` (live book state) to JSON after each snapshot; reloaded on restart via `_load_checkpoint()` (#28)
-- `dccd/continuous_dl/exchange.py` — `snapshot_ts` (UTC milliseconds) injected into every yielded snapshot payload by `__anext__` (#28)
+- `dccd/histo_dl/exchange.py` — `import_trades(start, end)` and `import_orderbook(depth)` public methods on `ImportDataCryptoCurrencies`; `_sort_trades` / `_sort_orderbook` helpers validate via Pydantic, sort and deduplicate; `trades_df` / `orderbook_df` attributes; `save_trades` / `save_orderbook` save helpers (#31)
+- `dccd/histo_dl/{binance,kraken,bybit,okx,coinbase}.py` — `_import_trades(start, end)` and `_import_orderbook(depth)` implemented for all five exchanges; Binance and Kraken support full history via paginated endpoints; Bybit (≤ 1 000) and Coinbase (≤ 100) return recent-only snapshots (#31)
+- `dccd/models.py` — `Trade.tid` made optional (`int | None`); `OrderBookEntry` gains required `side` field (`'bid'` or `'ask'`) and `count` made optional (`int | None`) (#31)
+- `dccd/daemon/health.py` — `HealthMonitor`: rotating log handler (10 MB × 5 files), per-job metrics JSON, and optional Slack/Discord webhook alerts on consecutive failures; `JobMetrics` dataclass (#30)
+- `dccd/daemon/cli.py` — `dccd` CLI (`validate`, `run`, `start`, `status`, `add` commands) via typer; `[project.scripts]` entrypoint; `typer>=0.12` added to the `daemon` extra (#30)
 - `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#26)
-- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
-- `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)
-- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#25)
+- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, `load_config()` (#25)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()` via rclone; supports multiple remotes and root-path sync (#25, #26)
+- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x), `run_histo_job()`, `run_once()` (#25)
 - `examples/config.example.yml` — annotated reference config for the daemon (#25)
-- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#25)
+- `examples/daemon_example.py` — programmatic daemon example in 6 steps (#30)
+- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`, `typer`) (#25, #30)
 
 ### Changed
 
-- `dccd/daemon/config.py` — `StorageConfig.remote: RemoteConfig | None` replaced by `remotes: list[RemoteConfig]` (multiple destinations) and `sync_interval: int` (default 3600 s) (#26)
-- `dccd/daemon/storage.py` — `RemoteStorage.push()` now iterates all `config.remotes`; supports root-path sync (path == local_path) (#26)
-- `dccd/daemon/scheduler.py` — `run_histo_job` no longer takes a `storage` argument and no longer pushes; remote sync is fully delegated to `SyncService` (#26)
+- `dccd/daemon/scheduler.py` — `run_histo_job`, `build_histo_scheduler`, `run_once` accept an optional `health: HealthMonitor` parameter (#30)
+- `dccd/daemon/stream_manager.py` — `StreamManager.__init__` accepts optional `health: HealthMonitor`; `_run_forever` records success/failure on each iteration (#30)
+- `dccd/daemon/config.py` — `StorageConfig.remote` replaced by `remotes: list[RemoteConfig]` and `sync_interval: int` (#26)
+- `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` extracted as a static method, independently testable (#29)
+- `dccd/continuous_dl/exchange.py` — unified `__call__`, `_push_trades`, `_push_book_updates`, `_get_book_state`, `_restore_book_state` in base class; separate `set_trades_saver` / `set_book_saver`; crash-recovery checkpoint; `snapshot_ts` injected into every snapshot payload (#28, #29)
 
 ## [2.1.0] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` static method on each REST exchange class; extracts inline pair-building logic from `__init__` and makes it independently testable (#29)
+- `dccd/continuous_dl/exchange.py` — `ContinuousDownloader.__call__(*args, **kwargs)`: base `__call__` using `asyncio.new_event_loop()`; Bitfinex/Bitmex overrides trimmed to exchange-specific setup only (#29)
+- `dccd/continuous_dl/exchange.py` — `_push_trades(parsed)`: validates each trade dict against `Trade` (Pydantic) then appends via `_raw_parser`; shared by Binance, Kraken, Bybit, OKX (#29)
+- `dccd/continuous_dl/exchange.py` — `_push_book_updates(updates)`: applies a `{price: qty}` delta to `self.d` and snapshots the book into `_data`; shared by Binance, Kraken, Bybit, OKX (#29)
+- `dccd/tests/test_kraken.py` — 10 parametrized cases for `FromKraken.format_pair` covering BTC→XBT, BCH/DASH exemption, X/Z prefix rules, and cross-crypto pairs (#29)
+
+### Changed
+
+- `dccd/continuous_dl/exchange.py` — `self.d: dict = {}` initialised in base `__init__`; `_get_book_state()` and `_restore_book_state()` upgraded from stubs to working defaults; removed redundant overrides in Binance, Kraken, Bybit, OKX, Bitfinex (#29)
+
 - `dccd/continuous_dl/exchange.py` — `set_trades_saver(saver, process_func)` and `set_book_saver(saver, process_func)`: separate savers for the trades and order-book channels; high-level helpers updated accordingly (#28)
 - `dccd/continuous_dl/exchange.py` — crash-recovery checkpoint: `checkpoint_dir` parameter serialises `self.d` (live book state) to JSON after each snapshot; reloaded on restart via `_load_checkpoint()` (#28)
 - `dccd/continuous_dl/exchange.py` — `snapshot_ts` (UTC milliseconds) injected into every yielded snapshot payload by `__anext__` (#28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/daemon/health.py` — `HealthMonitor`: rotating log handler (10 MB × 5 files at `{local_path}/.dccd/dccd.log`), per-job metrics JSON (`metrics.json`), and optional Slack/Discord webhook alerts on consecutive failures; `JobMetrics` dataclass tracks `last_run_at`, `last_success_at`, `rows_collected`, `errors_count` (#30)
+- `dccd/daemon/cli.py` — `dccd` CLI (`validate`, `run`, `start`, `status`, `add` commands) via typer; `[project.scripts]` entrypoint added to `pyproject.toml`; `typer>=0.12` added to the `daemon` optional extra (#30)
+
+### Changed
+
+- `dccd/daemon/scheduler.py` — `run_histo_job`, `build_histo_scheduler`, `run_once` accept an optional `health: HealthMonitor` parameter and call `record_success` / `record_failure` (#30)
+- `dccd/daemon/stream_manager.py` — `StreamManager.__init__` accepts optional `health: HealthMonitor`; `_run_forever` records success/failure on each iteration (#30)
+
 - `dccd/histo_dl/{binance,coinbase,bybit,okx,kraken}.py` — `format_pair(crypto, fiat)` static method on each REST exchange class; extracts inline pair-building logic from `__init__` and makes it independently testable (#29)
 - `dccd/continuous_dl/exchange.py` — `ContinuousDownloader.__call__(*args, **kwargs)`: base `__call__` using `asyncio.new_event_loop()`; Bitfinex/Bitmex overrides trimmed to exchange-specific setup only (#29)
 - `dccd/continuous_dl/exchange.py` — `_push_trades(parsed)`: validates each trade dict against `Trade` (Pydantic) then appends via `_raw_parser`; shared by Binance, Kraken, Bybit, OKX (#29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/histo_dl/exchange.py` — `import_trades(start, end)` and `import_orderbook(depth)` public methods on `ImportDataCryptoCurrencies`; `_sort_trades` and `_sort_orderbook` helpers validate via Pydantic, sort and deduplicate; `trades_df` / `orderbook_df` attributes; `save_trades` and `save_orderbook` helpers
+- `dccd/histo_dl/{binance,kraken,bybit,okx,coinbase}.py` — `_import_trades(start, end)` and `_import_orderbook(depth)` implemented for all five exchanges (Binance/Kraken full history; Bybit/Coinbase recent-only snapshot)
+- `dccd/models.py` — `Trade.tid` made optional (`int | None`); `OrderBookEntry` gains required `side` field and `count` made optional (`int | None`)
+- Tests: 15 new test cases across 5 exchange test files (trades keys, order-book sides, HTTP 500 path) + `test_orderbookentry_count_optional` in `test_models.py`
+
 - `dccd/daemon/health.py` — `HealthMonitor`: rotating log handler (10 MB × 5 files at `{local_path}/.dccd/dccd.log`), per-job metrics JSON (`metrics.json`), and optional Slack/Discord webhook alerts on consecutive failures; `JobMetrics` dataclass tracks `last_run_at`, `last_success_at`, `rows_collected`, `errors_count` (#30)
 - `dccd/daemon/cli.py` — `dccd` CLI (`validate`, `run`, `start`, `status`, `add` commands) via typer; `[project.scripts]` entrypoint added to `pyproject.toml`; `typer>=0.12` added to the `daemon` optional extra (#30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#XX)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#XX)
+- `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#XX)
+- `examples/config.example.yml` — annotated reference config for the daemon (#XX)
+- `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#XX)
+
 ## [2.1.0] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/daemon/stream_manager.py` — `StreamManager` (one thread per `(exchange, pair)`, auto-restart on crash) and `SyncService` (periodic rclone push to all remotes, decoupled from collection) (#XX)
 - `dccd/daemon/config.py` — declarative YAML config with Pydantic v2: `CollectorConfig`, `HistoJob`, `StreamJob`, `StorageConfig`, `AlertConfig`, `RemoteConfig`, and `load_config()` loader (#25)
 - `dccd/daemon/storage.py` — `RemoteStorage.push()`: delegates to rclone via subprocess; no-op when no remote configured, warning if rclone absent (#25)
 - `dccd/daemon/scheduler.py` — `build_histo_scheduler()` (APScheduler 3.x `BackgroundScheduler`, one interval job per `(exchange, pair)`), `run_histo_job()`, and `run_once()` (#25)
 - `examples/config.example.yml` — annotated reference config for the daemon (#25)
 - `pyproject.toml` — `[daemon]` optional extra (`pyyaml`, `apscheduler`) (#25)
+
+### Changed
+
+- `dccd/daemon/config.py` — `StorageConfig.remote: RemoteConfig | None` replaced by `remotes: list[RemoteConfig]` (multiple destinations) and `sync_interval: int` (default 3600 s) (#XX)
+- `dccd/daemon/storage.py` — `RemoteStorage.push()` now iterates all `config.remotes`; supports root-path sync (path == local_path) (#XX)
+- `dccd/daemon/scheduler.py` — `run_histo_job` no longer takes a `storage` argument and no longer pushes; remote sync is fully delegated to `SyncService` (#XX)
 
 ## [2.1.0] - 2026-05-15
 

--- a/README.rst
+++ b/README.rst
@@ -68,15 +68,15 @@ Supported exchanges
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
 | Exchange         | REST OHLCV | REST Trades | REST Order Book | WS OHLCV | WS Trades | WS Order Book  |
 +==================+============+=============+=================+==========+===========+================+
-| Binance          | ✓          |             |                 |          | ✓         | ✓              |
+| Binance          | ✓          | ✓           | ✓               |          | ✓         | ✓              |
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
-| Coinbase         | ✓          |             |                 |          |           |                |
+| Coinbase         | ✓          | ✓†          | ✓               |          |           |                |
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
-| Kraken           | ✓          |             |                 | ✓        | ✓         | ✓              |
+| Kraken           | ✓          | ✓           | ✓               | ✓        | ✓         | ✓              |
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
-| Bybit            | ✓          |             |                 |          | ✓         | ✓              |
+| Bybit            | ✓          | ✓†          | ✓               |          | ✓         | ✓              |
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
-| OKX              | ✓          |             |                 | ✓        | ✓         | ✓              |
+| OKX              | ✓          | ✓           | ✓               | ✓        | ✓         | ✓              |
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
 | Bitfinex         |            |             |                 | ✓\*      | ✓         | ✓              |
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
@@ -84,6 +84,8 @@ Supported exchanges
 +------------------+------------+-------------+-----------------+----------+-----------+----------------+
 
 \* Bitfinex WS OHLCV is aggregated from the trades stream via ``get_ohlc_bitfinex``.
+
+† Recent trades only (Bybit ≤ 1 000, Coinbase ≤ 100) — no deep historical pagination via the public REST API.
 
 Presentation
 ============
@@ -148,6 +150,31 @@ Other exchanges:
     FromKraken('/path/', 'ETH', 3600).import_data(start='2024-01-01', end='now').save()
     FromBybit('/path/', 'BTC', 86400).import_data(start='2024-01-01', end='now').save()
     FromOKX('/path/', 'BTC', 3600).import_data(start='2024-01-01', end='now').save()
+
+Trades (historical or recent):
+
+.. code-block:: python
+
+    from dccd.histo_dl import FromBinance, FromKraken
+
+    obj = FromBinance('/path/', 'BTC', 3600, fiat='USDT')
+    obj.import_trades(start='2024-01-01 00:00:00', end='2024-01-02 00:00:00')
+    obj.save_trades(form='csv')
+    df = obj.trades_df    # pandas DataFrame — columns: timestamp, price, amount, type, tid
+
+    # Kraken also supports full history; Bybit/Coinbase return recent-only snapshots
+    FromKraken('/path/', 'BTC', 3600).import_trades(start='2024-01-01', end='2024-01-02').save_trades()
+
+Order book snapshot:
+
+.. code-block:: python
+
+    from dccd.histo_dl import FromOKX
+
+    obj = FromOKX('/path/', 'BTC', 3600)
+    obj.import_orderbook(depth=50)
+    obj.save_orderbook(form='csv')
+    df = obj.orderbook_df    # columns: side, price, amount, count
 
 Daemon (autonomous collector) — ``config.yml``:
 

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,10 @@ With optional Parquet / Polars support::
 
     $ pip install "dccd[io]"
 
+With autonomous daemon support (APScheduler + PyYAML)::
+
+    $ pip install "dccd[daemon]"
+
 From source::
 
     $ git clone https://github.com/ArthurBernard/Download_Crypto_Currencies_Data
@@ -93,6 +97,14 @@ Presentation
     Stream real-time data (order book, trades) via WebSocket with automatic
     reconnection and configurable processing/saving callbacks.
 
+**Daemon** ``dccd.daemon``
+    Autonomous, server-side collector driven by a YAML config.  Runs REST
+    jobs on a schedule (APScheduler), opens WebSocket streams for real-time
+    collection, and periodically syncs all local data to one or more remote
+    destinations (NAS, S3, SFTP, …) via rclone.  Multiple remotes and a
+    configurable sync interval are supported; collection is never blocked by
+    remote availability.
+
 Output formats
 --------------
 
@@ -128,6 +140,43 @@ Other exchanges::
     FromKraken('/path/', 'ETH', 3600).import_data(start='2024-01-01', end='now').save()
     FromBybit('/path/', 'BTC', 86400).import_data(start='2024-01-01', end='now').save()
     FromOKX('/path/', 'BTC', 3600).import_data(start='2024-01-01', end='now').save()
+
+Daemon (autonomous collector)::
+
+    # config.yml
+    # storage:
+    #   local_path: /data/crypto/
+    #   remotes:
+    #     - provider: rclone
+    #       remote: "mynas:crypto/"
+    #   sync_interval: 3600
+    # histo_jobs:
+    #   - exchange: binance
+    #     pairs: [BTC/USDT, ETH/USDT]
+    #     span: 3600
+    #     format: parquet
+    #     by_period: Y
+    # stream_jobs:
+    #   - exchange: binance
+    #     pairs: [BTC/USDT]
+    #     channels: [trades, book]
+    #     time_step: 60
+
+    from dccd.daemon.config import load_config
+    from dccd.daemon.scheduler import run_once, build_histo_scheduler
+    from dccd.daemon.stream_manager import StreamManager
+
+    config = load_config('config.yml')
+
+    # One-shot: download all histo jobs once, then exit
+    run_once(config)
+
+    # Daemon mode: periodic REST + live WebSocket streams
+    scheduler = build_histo_scheduler(config)
+    scheduler.start()
+
+    mgr = StreamManager(config)
+    mgr.start()      # blocks until mgr.stop() is called
 
 Links
 =====

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,9 @@ Parquet files can be read back as either a ``pandas.DataFrame`` or a
 Quick start
 ===========
 
-Historical data (pandas)::
+Historical data (pandas):
+
+.. code-block:: python
 
     from dccd.histo_dl import FromBinance
 
@@ -125,15 +127,21 @@ Historical data (pandas)::
     obj.save(form='parquet')
     df = obj.get_data()            # pandas DataFrame
 
-Polars output::
+Polars output:
+
+.. code-block:: python
 
     df_pl = obj.get_data(format='polars')
 
-Incremental update (resume from last saved point)::
+Incremental update (resume from last saved point):
+
+.. code-block:: python
 
     obj.import_data(start='last', end='now').save(form='parquet')
 
-Other exchanges::
+Other exchanges:
+
+.. code-block:: python
 
     from dccd.histo_dl import FromKraken, FromBybit, FromOKX
 
@@ -141,26 +149,31 @@ Other exchanges::
     FromBybit('/path/', 'BTC', 86400).import_data(start='2024-01-01', end='now').save()
     FromOKX('/path/', 'BTC', 3600).import_data(start='2024-01-01', end='now').save()
 
-Daemon (autonomous collector)::
+Daemon (autonomous collector) — ``config.yml``:
 
-    # config.yml
-    # storage:
-    #   local_path: /data/crypto/
-    #   remotes:
-    #     - provider: rclone
-    #       remote: "mynas:crypto/"
-    #   sync_interval: 3600
-    # histo_jobs:
-    #   - exchange: binance
-    #     pairs: [BTC/USDT, ETH/USDT]
-    #     span: 3600
-    #     format: parquet
-    #     by_period: Y
-    # stream_jobs:
-    #   - exchange: binance
-    #     pairs: [BTC/USDT]
-    #     channels: [trades, book]
-    #     time_step: 60
+.. code-block:: yaml
+
+    storage:
+      local_path: /data/crypto/
+      remotes:
+        - provider: rclone
+          remote: "mynas:crypto/"
+      sync_interval: 3600
+
+    histo_jobs:
+      - exchange: binance
+        pairs: [BTC/USDT, ETH/USDT]
+        span: 3600
+        format: parquet
+        by_period: Y
+
+    stream_jobs:
+      - exchange: binance
+        pairs: [BTC/USDT]
+        channels: [trades, book]
+        time_step: 60
+
+.. code-block:: python
 
     from dccd.daemon.config import load_config
     from dccd.daemon.scheduler import run_once, build_histo_scheduler
@@ -176,7 +189,7 @@ Daemon (autonomous collector)::
     scheduler.start()
 
     mgr = StreamManager(config)
-    mgr.start()      # blocks until mgr.stop() is called
+    mgr.start()      # runs until mgr.stop() is called
 
 Links
 =====

--- a/dccd/continuous_dl/binance.py
+++ b/dccd/continuous_dl/binance.py
@@ -134,7 +134,6 @@ class DownloadBinanceData(ContinuousDownloader):
             'book': self.parser_book,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, float] = {}
         self._load_checkpoint()
 
     async def _subscribe(self, **kwargs: object) -> None:
@@ -166,8 +165,7 @@ class DownloadBinanceData(ContinuousDownloader):
             The ``data`` field from the combined-stream trade envelope.
 
         """
-        for trade in _parser_trades(data):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(data))
 
     def parser_book(self, data: dict) -> None:
         """ Parse and update the order book from a depth message.
@@ -178,19 +176,7 @@ class DownloadBinanceData(ContinuousDownloader):
             The ``data`` field from the combined-stream depth envelope.
 
         """
-        updates = _parser_book(data)
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self) -> dict[str, float]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
-        self.d = state
+        self._push_book_updates(_parser_book(data))
 
 
 def get_trades_binance(path: str, pair: str = 'BTCUSDT', time_step: int = 60,

--- a/dccd/continuous_dl/binance.py
+++ b/dccd/continuous_dl/binance.py
@@ -29,7 +29,6 @@ import time
 # Third party packages
 # Local packages
 from dccd.continuous_dl.exchange import ContinuousDownloader
-from dccd.process_data import set_marketdepth, set_orders, set_trades
 from dccd.tools.io import IODataBase
 
 __all__ = [
@@ -119,7 +118,7 @@ class DownloadBinanceData(ContinuousDownloader):
     """
 
     def __init__(self, pair: str = 'BTCUSDT', time_step: int = 60,
-                 until: int | None = 3600) -> None:
+                 until: int | None = 3600, checkpoint_dir: str | None = None) -> None:
         """ Initialize object. """
         if until is None:
             until = 0
@@ -128,13 +127,15 @@ class DownloadBinanceData(ContinuousDownloader):
 
         self.pair = pair
         url = _BINANCE_WS_URL.format(sym=pair.lower())
-        ContinuousDownloader.__init__(self, url, time_step=time_step, STOP=until)
+        ContinuousDownloader.__init__(self, url, time_step=time_step, STOP=until,
+                                      checkpoint_dir=checkpoint_dir)
         self._parser_data = {
             'trades': self.parser_trades,
             'book': self.parser_book,
         }
         self.logger = logging.getLogger(__name__)
         self.d: dict[str, float] = {}
+        self._load_checkpoint()
 
     async def _subscribe(self, **kwargs: object) -> None:
         """ Wait for connection; Binance streams are declared in the URL. """
@@ -183,12 +184,13 @@ class DownloadBinanceData(ContinuousDownloader):
                 self.d.pop(price, None)
             else:
                 self.d[price] = qty
-        self._data[self.t] = dict(self.d)
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
 
-    def _raw_parser(self, data: object) -> None:
-        if self.t not in self._data:
-            self._data[self.t] = []
-        self._data[self.t].append(data)  # type: ignore[union-attr]
+    def _get_book_state(self) -> dict[str, float]:
+        return dict(self.d)
+
+    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
+        self.d = state
 
 
 def get_trades_binance(path: str, pair: str = 'BTCUSDT', time_step: int = 60,
@@ -210,8 +212,7 @@ def get_trades_binance(path: str, pair: str = 'BTCUSDT', time_step: int = 60,
 
     """
     downloader = DownloadBinanceData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_trades)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
@@ -234,8 +235,7 @@ def get_orderbook_binance(path: str, pair: str = 'BTCUSDT', time_step: int = 60,
 
     """
     downloader = DownloadBinanceData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_marketdepth)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_book_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
@@ -246,7 +246,8 @@ def get_data_binance(path: str, pair: str = 'BTCUSDT', time_step: int = 60,
     Parameters
     ----------
     path : str
-        Path to save data.
+        Root path; trades saved under ``<path>/trades/``, book under
+        ``<path>/book/``.
     pair : str, optional
         Trading pair in Binance format (e.g. 'BTCUSDT'), default is 'BTCUSDT'.
     time_step : int, optional
@@ -258,6 +259,6 @@ def get_data_binance(path: str, pair: str = 'BTCUSDT', time_step: int = 60,
 
     """
     downloader = DownloadBinanceData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_orders)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(f'{path}/trades', method=form))
+    downloader.set_book_saver(IODataBase(f'{path}/book', method=form))
     downloader(pair=pair)

--- a/dccd/continuous_dl/bitfinex.py
+++ b/dccd/continuous_dl/bitfinex.py
@@ -31,7 +31,6 @@ Low level API
 """
 
 # Built-in packages
-import asyncio
 import logging
 import time
 from typing import Any
@@ -148,7 +147,6 @@ class DownloadBitfinexData(ContinuousDownloader):
             'trades_raw': self.parser_raw_trades,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, Any] = {}
         self._load_checkpoint()
 
     def parser_raw_book(self, data: list[Any]) -> None:
@@ -185,12 +183,6 @@ class DownloadBitfinexData(ContinuousDownloader):
         self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = {
             v['price']: v['amount'] for v in self.d.values()
         }
-
-    def _get_book_state(self) -> dict[str, Any]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, Any]) -> None:  # type: ignore[override]
-        self.d = state
 
     def parser_raw_trades(self, data: list[Any]) -> None:
         """ Parse raw trade data tick-by-tick.
@@ -261,18 +253,9 @@ class DownloadBitfinexData(ContinuousDownloader):
 
         """
         self.parser = self.get_parser(channel)
-
         channel = channel[:-4] if channel[-4:] == '_raw' else channel
-
         self.logger.info('Try connect WS and set {} stream.'.format(channel))
-
-        self.loop = asyncio.get_event_loop()
-        self.loop.run_until_complete(asyncio.gather(
-            self._connect(channel=channel, **kwargs),
-            self._loop()
-        ))
-
-        return self
+        return super().__call__(channel=channel, **kwargs)  # type: ignore[return-value]
 
 
 # =========================================================================== #

--- a/dccd/continuous_dl/bitfinex.py
+++ b/dccd/continuous_dl/bitfinex.py
@@ -117,7 +117,8 @@ class DownloadBitfinexData(ContinuousDownloader):
 
     """
 
-    def __init__(self, time_step: int = 60, until: int | None = 3600) -> None:
+    def __init__(self, time_step: int = 60, until: int | None = 3600,
+                 checkpoint_dir: str | None = None) -> None:
         """ Initialize object.
 
         Parameters
@@ -127,6 +128,9 @@ class DownloadBitfinexData(ContinuousDownloader):
         until : int or None, optional
             Seconds to run, or a future Unix timestamp to stop at.
             Default is ``3600``.
+        checkpoint_dir : str or None, optional
+            Directory to write the order-book crash-recovery checkpoint.
+            Disabled when ``None`` (default).
 
         """
         if until is None:
@@ -135,7 +139,7 @@ class DownloadBitfinexData(ContinuousDownloader):
             until -= int(time.time())
 
         ContinuousDownloader.__init__(self, 'bitfinex', time_step=time_step,
-                                      STOP=until)
+                                      STOP=until, checkpoint_dir=checkpoint_dir)
 
         self._parser_data: dict[str, Any] = {
             'book': self.parser_book,
@@ -145,6 +149,7 @@ class DownloadBitfinexData(ContinuousDownloader):
         }
         self.logger = logging.getLogger(__name__)
         self.d: dict[str, Any] = {}
+        self._load_checkpoint()
 
     def parser_raw_book(self, data: list[Any]) -> None:
         """ Parse raw order book, each timestep set in a list all orders.
@@ -177,7 +182,15 @@ class DownloadBitfinexData(ContinuousDownloader):
         else:
             self.d.pop(parsed['price'])
 
-        self._data[self.t] = {v['price']: v['amount'] for v in self.d.values()}  # type: ignore[assignment]
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = {
+            v['price']: v['amount'] for v in self.d.values()
+        }
+
+    def _get_book_state(self) -> dict[str, Any]:
+        return dict(self.d)
+
+    def _restore_book_state(self, state: dict[str, Any]) -> None:  # type: ignore[override]
+        self.d = state
 
     def parser_raw_trades(self, data: list[Any]) -> None:
         """ Parse raw trade data tick-by-tick.

--- a/dccd/continuous_dl/bitmex.py
+++ b/dccd/continuous_dl/bitmex.py
@@ -31,7 +31,6 @@ Low level API
 """
 
 # Built-in packages
-import asyncio
 import time
 from datetime import datetime as dt
 from typing import Any
@@ -180,7 +179,6 @@ class DownloadBitmexData(ContinuousDownloader):
             'orderBookL2_25': self.parser_book,
             'trade': self.parser_trades,
         }
-        self.d: dict[int, Any] = {}
         self.start = False
         self._load_checkpoint()
 
@@ -233,9 +231,6 @@ class DownloadBitmexData(ContinuousDownloader):
         for i, d in enumerate(data['data']):
             slot['trades'].append(_parser_trades(d, i))
 
-    def _get_book_state(self) -> dict[int, Any]:  # type: ignore[override]
-        return dict(self.d)
-
     def _restore_book_state(self, state: dict[int, Any]) -> None:  # type: ignore[override]
         self.d = {int(k): v for k, v in state.items()}
 
@@ -273,16 +268,8 @@ class DownloadBitmexData(ContinuousDownloader):
 
         """
         self.parser = self.get_parser(args[0])
-
         self.logger.info('Try connect WS and set {} stream.'.format(args[0]))
-
-        self.loop = asyncio.get_event_loop()
-        self.loop.run_until_complete(asyncio.gather(
-            self._connect(args=':'.join(args)),
-            self._loop()
-        ))
-
-        return self
+        return super().__call__(args=':'.join(args))  # type: ignore[return-value]
 
 
 # =========================================================================== #

--- a/dccd/continuous_dl/bitmex.py
+++ b/dccd/continuous_dl/bitmex.py
@@ -182,6 +182,7 @@ class DownloadBitmexData(ContinuousDownloader):
         }
         self.d: dict[int, Any] = {}
         self.start = False
+        self._load_checkpoint()
 
     def parser_book(self, data: dict[str, Any]) -> None:
         """ Parse and maintain a local copy of the order book.
@@ -214,7 +215,9 @@ class DownloadBitmexData(ContinuousDownloader):
             else:
                 self.logger.error('Unknown action {}: {}'.format(action, data))
 
-        self._data[self.t] = {v['price']: v['amount'] for v in self.d.values()}  # type: ignore[assignment]
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = {
+            v['price']: v['amount'] for v in self.d.values()
+        }
 
     def parser_trades(self, data: dict[str, Any]) -> None:
         """ Parse trade data and accumulate records for the current timestep.
@@ -226,15 +229,15 @@ class DownloadBitmexData(ContinuousDownloader):
             key with a list of trade records.
 
         """
-        i, _data = 0, []
-        for d in data['data']:
-            _data += [_parser_trades(d, i)]
-            i += 1
+        slot = self._data.setdefault(self.t, {'trades': [], 'book': {}})
+        for i, d in enumerate(data['data']):
+            slot['trades'].append(_parser_trades(d, i))
 
-        if self.t in self._data.keys():
-            self._data[self.t] += _data
-        else:
-            self._data[self.t] = _data
+    def _get_book_state(self) -> dict[int, Any]:  # type: ignore[override]
+        return dict(self.d)
+
+    def _restore_book_state(self, state: dict[int, Any]) -> None:  # type: ignore[override]
+        self.d = {int(k): v for k, v in state.items()}
 
     async def on_message(self, data: dict[str, Any] | list[Any]) -> None:
         """ Route an incoming websocket message to the appropriate parser. """

--- a/dccd/continuous_dl/bybit.py
+++ b/dccd/continuous_dl/bybit.py
@@ -29,7 +29,6 @@ import time
 # Third party packages
 # Local packages
 from dccd.continuous_dl.exchange import ContinuousDownloader
-from dccd.process_data import set_marketdepth, set_orders, set_trades
 from dccd.tools.io import IODataBase
 
 __all__ = [
@@ -122,7 +121,7 @@ class DownloadBybitData(ContinuousDownloader):
 
     """
 
-    def __init__(self, pair='BTCUSDT', time_step=60, until=3600):
+    def __init__(self, pair='BTCUSDT', time_step=60, until=3600, checkpoint_dir=None):
         """ Initialize object. """
         if until is None:
             until = 0
@@ -132,6 +131,7 @@ class DownloadBybitData(ContinuousDownloader):
         self.pair = pair
         ContinuousDownloader.__init__(
             self, _BYBIT_WS_URL, time_step=time_step, STOP=until,
+            checkpoint_dir=checkpoint_dir,
             subs={'op': 'subscribe',
                   'args': [f'publicTrade.{pair}', f'orderbook.50.{pair}']},
         )
@@ -141,6 +141,7 @@ class DownloadBybitData(ContinuousDownloader):
         }
         self.logger = logging.getLogger(__name__)
         self.d = {}
+        self._load_checkpoint()
 
     async def on_message(self, msg):
         """ Dispatch incoming WebSocket messages. """
@@ -177,16 +178,16 @@ class DownloadBybitData(ContinuousDownloader):
                 self.d.pop(price, None)
             else:
                 self.d[price] = qty
-        self._data[self.t] = dict(self.d)
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
 
-    def _raw_parser(self, data):
-        if self.t not in self._data:
-            self._data[self.t] = []
-        self._data[self.t].append(data)
+    def _get_book_state(self):
+        return dict(self.d)
+
+    def _restore_book_state(self, state):
+        self.d = state
 
 
-def get_trades_bybit(path, pair='BTCUSDT', time_step=60, until=3600,
-                     form='csv'):
+def get_trades_bybit(path, pair='BTCUSDT', time_step=60, until=3600, form='csv'):
     """ Download trades data from Bybit.
 
     Parameters
@@ -204,13 +205,11 @@ def get_trades_bybit(path, pair='BTCUSDT', time_step=60, until=3600,
 
     """
     downloader = DownloadBybitData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_trades)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
-def get_orderbook_bybit(path, pair='BTCUSDT', time_step=60, until=3600,
-                        form='csv'):
+def get_orderbook_bybit(path, pair='BTCUSDT', time_step=60, until=3600, form='csv'):
     """ Download order book data from Bybit.
 
     Parameters
@@ -228,8 +227,7 @@ def get_orderbook_bybit(path, pair='BTCUSDT', time_step=60, until=3600,
 
     """
     downloader = DownloadBybitData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_marketdepth)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_book_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
@@ -239,7 +237,8 @@ def get_data_bybit(path, pair='BTCUSDT', time_step=60, until=3600, form='csv'):
     Parameters
     ----------
     path : str
-        Path to save data.
+        Root path; trades saved under ``<path>/trades/``, book under
+        ``<path>/book/``.
     pair : str, optional
         Trading pair, default is 'BTCUSDT'.
     time_step : int, optional
@@ -251,6 +250,6 @@ def get_data_bybit(path, pair='BTCUSDT', time_step=60, until=3600, form='csv'):
 
     """
     downloader = DownloadBybitData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_orders)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(f'{path}/trades', method=form))
+    downloader.set_book_saver(IODataBase(f'{path}/book', method=form))
     downloader(pair=pair)

--- a/dccd/continuous_dl/bybit.py
+++ b/dccd/continuous_dl/bybit.py
@@ -140,7 +140,6 @@ class DownloadBybitData(ContinuousDownloader):
             'book': self.parser_book,
         }
         self.logger = logging.getLogger(__name__)
-        self.d = {}
         self._load_checkpoint()
 
     async def on_message(self, msg):
@@ -160,8 +159,7 @@ class DownloadBybitData(ContinuousDownloader):
             Raw WebSocket trade message.
 
         """
-        for trade in _parser_trades(msg):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(msg))
 
     def parser_book(self, msg):
         """ Parse and update order book from WebSocket messages.
@@ -172,19 +170,7 @@ class DownloadBybitData(ContinuousDownloader):
             Raw WebSocket orderbook message.
 
         """
-        updates = _parser_book(msg)
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self):
-        return dict(self.d)
-
-    def _restore_book_state(self, state):
-        self.d = state
+        self._push_book_updates(_parser_book(msg))
 
 
 def get_trades_bybit(path, pair='BTCUSDT', time_step=60, until=3600, form='csv'):

--- a/dccd/continuous_dl/exchange.py
+++ b/dccd/continuous_dl/exchange.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncIterator
 
 # Third party packages
 # Local packages
+from dccd.models import Trade
 from dccd.process_data import set_marketdepth, set_trades
 from dccd.tools.websocket import BasisWebSocket
 
@@ -102,6 +103,7 @@ class ContinuousDownloader(BasisWebSocket):
         # Set data
         self._data: dict[int, dict[str, Any]] = {}
         self._checkpoint_dir: Path | None = Path(checkpoint_dir) if checkpoint_dir else None
+        self.d: dict = {}
 
     def __aiter__(self) -> AsyncIterator[dict[str, Any] | None]:
         """ Set iterative method. """
@@ -181,11 +183,51 @@ class ContinuousDownloader(BasisWebSocket):
         """ Set current time rounded by `timestep`. """
         return int((time.time() + 0.001) // self.ts * self.ts)
 
-    def _get_book_state(self) -> dict[str, Any]:
-        return {}
+    def __call__(self, *args: Any, **kwargs: Any) -> 'ContinuousDownloader':
+        """ Start the WebSocket stream and block until it stops.
 
-    def _restore_book_state(self, state: dict[str, Any]) -> None:
-        pass
+        Parameters
+        ----------
+        *args, **kwargs
+            Forwarded to :meth:`~dccd.tools.websocket.BasisWebSocket._connect`.
+
+        Returns
+        -------
+        ContinuousDownloader
+            The downloader instance (for chaining).
+
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(asyncio.gather(
+                self._connect(*args, **kwargs),
+                self._loop(),
+            ))
+        finally:
+            loop.close()
+        return self
+
+    def _push_trades(self, parsed: list[dict[str, Any]]) -> None:
+        """ Validate and store a normalised list of trade dicts. """
+        for item in parsed:
+            Trade.model_validate(item)
+            self._raw_parser(item)
+
+    def _push_book_updates(self, updates: dict[str, Any]) -> None:
+        """ Apply a price→qty update dict to the local book and snapshot it. """
+        for price, qty in updates.items():
+            if qty == 0:
+                self.d.pop(price, None)
+            else:
+                self.d[price] = qty
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
+
+    def _get_book_state(self) -> dict:
+        return dict(self.d)
+
+    def _restore_book_state(self, state: dict) -> None:
+        self.d = state
 
     def _checkpoint_file(self) -> Path | None:
         if self._checkpoint_dir is None:

--- a/dccd/continuous_dl/exchange.py
+++ b/dccd/continuous_dl/exchange.py
@@ -10,12 +10,15 @@
 
 # Built-in packages
 import asyncio
+import json
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, AsyncIterator
 
 # Third party packages
 # Local packages
+from dccd.process_data import set_marketdepth, set_trades
 from dccd.tools.websocket import BasisWebSocket
 
 __all__ = ['ContinuousDownloader']
@@ -82,7 +85,8 @@ class ContinuousDownloader(BasisWebSocket):
     }
     _parser_data: dict[str, Callable[..., Any]] = {}
 
-    def __init__(self, host: str, time_step: int = 60, STOP: int = 3600, **kwargs: Any) -> None:
+    def __init__(self, host: str, time_step: int = 60, STOP: int = 3600,
+                 checkpoint_dir: str | None = None, **kwargs: Any) -> None:
         """ Initialize object. """
         if host.lower() in ContinuousDownloader._parser_exchange.keys():
             BasisWebSocket.__init__(self, **self._parser_exchange[host])
@@ -96,15 +100,16 @@ class ContinuousDownloader(BasisWebSocket):
         self.until = time.time() + STOP if STOP > 0 else time.time() * 10
 
         # Set data
-        self._data: dict[int, list[Any]] = {}
+        self._data: dict[int, dict[str, Any]] = {}
+        self._checkpoint_dir: Path | None = Path(checkpoint_dir) if checkpoint_dir else None
 
-    def __aiter__(self) -> AsyncIterator[list[Any] | None]:
+    def __aiter__(self) -> AsyncIterator[dict[str, Any] | None]:
         """ Set iterative method. """
         self.logger.debug('Starting generator websocket')
 
         return self
 
-    async def __anext__(self) -> list[Any] | None:
+    async def __anext__(self) -> dict[str, Any] | None:
         """ Iterate object. """
         if time.time() > self.until:
             self.logger.info('StopIteration')
@@ -120,39 +125,49 @@ class ContinuousDownloader(BasisWebSocket):
 
         t, self.t = self.t, self._current_timestep()
 
-        if t in self._data.keys():
+        if t in self._data:
+            payload = self._data.pop(t)
+            payload['snapshot_ts'] = int(time.time() * 1000)
+            return payload
 
-            return self._data.pop(t)
-
-        else:
-
-            return None
+        return None
 
     async def _loop(self) -> None:
         """ Loop to process and save data into database. """
         await self.wait_that('is_connect')
 
-        async for data in self:
-            self.logger.debug('Get data.')
-
-            # Continue if no data received
-            if data is None:
+        async for snapshot in self:
+            if snapshot is None:
                 self.logger.debug('No data')
-
                 continue
 
-            # Set DataFrame
-            df = self.process_data(data, **self.process_params)
+            trades = snapshot.get('trades', [])
+            book = snapshot.get('book', {})
+            ts = snapshot['snapshot_ts']
 
-            # Update database
-            self.saver(df, **self.io_params)
+            if trades and hasattr(self, '_trades_saver'):
+                df = self._trades_process_func(trades)
+                self._trades_saver(df, **self._trades_saver_kwargs)
 
-            self.logger.debug('Processed data:\n' + str(df))
-            self.logger.debug('Catch data of TS : {}'.format(self.t))
+            if book and hasattr(self, '_book_saver'):
+                df = self._book_process_func(book, t=ts // 1000)
+                self._book_saver(df, **self._book_saver_kwargs)
+
+            self._save_checkpoint()
+
+            # Legacy fallback for callers that still use set_process_data + set_saver
+            if not (hasattr(self, '_trades_saver') or hasattr(self, '_book_saver')):
+                if hasattr(self, 'process_data') and hasattr(self, 'saver'):
+                    legacy_data = trades if trades else book
+                    if legacy_data:
+                        df = self.process_data(legacy_data, **self.process_params)
+                        self.saver(df, **self.io_params)
+
+            self.logger.debug(
+                'snapshot_ts=%d trades=%d book_levels=%d', ts, len(trades), len(book)
+            )
 
             if not self.is_connect:
-                self.logger.info('End to import data from Bitfinex.\n')
-
                 return
 
     async def on_message(self, data: dict[str, Any] | list[Any]) -> None:
@@ -160,16 +175,75 @@ class ContinuousDownloader(BasisWebSocket):
         self._raw_parser(data)
 
     def _raw_parser(self, data: Any) -> None:
-        # Set all data to a list
-        if self.t in self._data.keys():
-            self._data[self.t] += [data]
-
-        else:
-            self._data[self.t] = [data]
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['trades'].append(data)
 
     def _current_timestep(self) -> int:
         """ Set current time rounded by `timestep`. """
         return int((time.time() + 0.001) // self.ts * self.ts)
+
+    def _get_book_state(self) -> dict[str, Any]:
+        return {}
+
+    def _restore_book_state(self, state: dict[str, Any]) -> None:
+        pass
+
+    def _checkpoint_file(self) -> Path | None:
+        if self._checkpoint_dir is None:
+            return None
+        name = getattr(self, 'pair', 'default')
+        return self._checkpoint_dir / f'{name}_book.json'
+
+    def _save_checkpoint(self) -> None:
+        f = self._checkpoint_file()
+        if f is None:
+            return
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(json.dumps(self._get_book_state()))
+
+    def _load_checkpoint(self) -> None:
+        f = self._checkpoint_file()
+        if f and f.exists():
+            self._restore_book_state(json.loads(f.read_text()))
+
+    def set_trades_saver(self, saver: Callable[..., Any],
+                         process_func: Callable[..., Any] = set_trades,
+                         **kwargs: Any) -> None:
+        """ Set saver for the trades channel.
+
+        Parameters
+        ----------
+        saver : callable
+            Callable to persist the processed DataFrame (e.g. ``IODataBase``).
+        process_func : callable, optional
+            Function to convert raw trade list to a DataFrame, default is
+            :func:`dccd.process_data.set_trades`.
+        **kwargs
+            Extra keyword arguments forwarded to ``saver`` on each call.
+
+        """
+        self._trades_saver = saver
+        self._trades_process_func = process_func
+        self._trades_saver_kwargs = kwargs
+
+    def set_book_saver(self, saver: Callable[..., Any],
+                       process_func: Callable[..., Any] = set_marketdepth,
+                       **kwargs: Any) -> None:
+        """ Set saver for the order-book channel.
+
+        Parameters
+        ----------
+        saver : callable
+            Callable to persist the processed DataFrame (e.g. ``IODataBase``).
+        process_func : callable, optional
+            Function to convert the book dict to a DataFrame, default is
+            :func:`dccd.process_data.set_marketdepth`.
+        **kwargs
+            Extra keyword arguments forwarded to ``saver`` on each call.
+
+        """
+        self._book_saver = saver
+        self._book_process_func = process_func
+        self._book_saver_kwargs = kwargs
 
     def set_process_data(self, func: Callable[..., Any], **kwargs: Any) -> None:
         """ Set processing function.

--- a/dccd/continuous_dl/kraken.py
+++ b/dccd/continuous_dl/kraken.py
@@ -177,7 +177,6 @@ class DownloadKrakenData(ContinuousDownloader):
             'kline': self.parser_kline,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, float] = {}
         self._load_checkpoint()
 
     async def _subscribe(self, **kwargs: object) -> None:
@@ -228,8 +227,7 @@ class DownloadKrakenData(ContinuousDownloader):
             The ``data`` field from the Kraken trade push message.
 
         """
-        for trade in _parser_trades(data):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(data))
 
     def parser_book(self, msg: dict) -> None:
         """ Parse and update the order book from a book push message.
@@ -240,19 +238,7 @@ class DownloadKrakenData(ContinuousDownloader):
             Full Kraken book push message (contains ``type`` and ``data``).
 
         """
-        updates = _parser_book(msg.get('data', []))
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self) -> dict[str, float]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
-        self.d = state
+        self._push_book_updates(_parser_book(msg.get('data', [])))
 
     def parser_kline(self, data: list[dict]) -> None:
         """ Parse and store an ohlc push message.

--- a/dccd/continuous_dl/kraken.py
+++ b/dccd/continuous_dl/kraken.py
@@ -31,7 +31,6 @@ from datetime import datetime, timezone
 # Third party packages
 # Local packages
 from dccd.continuous_dl.exchange import ContinuousDownloader
-from dccd.process_data import set_marketdepth, set_orders, set_trades
 from dccd.tools.io import IODataBase
 
 __all__ = [
@@ -158,7 +157,8 @@ class DownloadKrakenData(ContinuousDownloader):
     """
 
     def __init__(self, pair: str = 'BTC/USD', time_step: int = 60,
-                 until: int | None = 3600, span: int | None = None) -> None:
+                 until: int | None = 3600, span: int | None = None,
+                 checkpoint_dir: str | None = None) -> None:
         """ Initialize object. """
         if until is None:
             until = 0
@@ -169,6 +169,7 @@ class DownloadKrakenData(ContinuousDownloader):
         self._span = span
         ContinuousDownloader.__init__(
             self, _KRAKEN_WS_URL, time_step=time_step, STOP=until,
+            checkpoint_dir=checkpoint_dir,
         )
         self._parser_data = {
             'trades': self.parser_trades,
@@ -177,6 +178,7 @@ class DownloadKrakenData(ContinuousDownloader):
         }
         self.logger = logging.getLogger(__name__)
         self.d: dict[str, float] = {}
+        self._load_checkpoint()
 
     async def _subscribe(self, **kwargs: object) -> None:
         """ Send per-channel subscribe messages to Kraken WebSocket v2. """
@@ -244,7 +246,13 @@ class DownloadKrakenData(ContinuousDownloader):
                 self.d.pop(price, None)
             else:
                 self.d[price] = qty
-        self._data[self.t] = dict(self.d)
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
+
+    def _get_book_state(self) -> dict[str, float]:
+        return dict(self.d)
+
+    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
+        self.d = state
 
     def parser_kline(self, data: list[dict]) -> None:
         """ Parse and store an ohlc push message.
@@ -257,12 +265,6 @@ class DownloadKrakenData(ContinuousDownloader):
         """
         for candle in _parser_kline(data):
             self._raw_parser(candle)
-
-    def _raw_parser(self, data: object) -> None:
-        if self.t not in self._data:
-            self._data[self.t] = []
-        self._data[self.t].append(data)  # type: ignore[union-attr]
-
 
 def get_trades_kraken(path: str, pair: str = 'BTC/USD', time_step: int = 60,
                       until: int = 3600, form: str = 'csv') -> None:
@@ -283,8 +285,7 @@ def get_trades_kraken(path: str, pair: str = 'BTC/USD', time_step: int = 60,
 
     """
     downloader = DownloadKrakenData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_trades)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
@@ -307,8 +308,7 @@ def get_orderbook_kraken(path: str, pair: str = 'BTC/USD', time_step: int = 60,
 
     """
     downloader = DownloadKrakenData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_marketdepth)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_book_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
@@ -319,7 +319,8 @@ def get_data_kraken(path: str, pair: str = 'BTC/USD', time_step: int = 60,
     Parameters
     ----------
     path : str
-        Path to save data.
+        Root path; trades saved under ``<path>/trades/``, book under
+        ``<path>/book/``.
     pair : str, optional
         Trading pair in Kraken format (e.g. 'BTC/USD'), default is 'BTC/USD'.
     time_step : int, optional
@@ -331,6 +332,6 @@ def get_data_kraken(path: str, pair: str = 'BTC/USD', time_step: int = 60,
 
     """
     downloader = DownloadKrakenData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_orders)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(f'{path}/trades', method=form))
+    downloader.set_book_saver(IODataBase(f'{path}/book', method=form))
     downloader(pair=pair)

--- a/dccd/continuous_dl/okx.py
+++ b/dccd/continuous_dl/okx.py
@@ -29,7 +29,6 @@ import time
 # Third party packages
 # Local packages
 from dccd.continuous_dl.exchange import ContinuousDownloader
-from dccd.process_data import set_marketdepth, set_orders, set_trades
 from dccd.tools.io import IODataBase
 
 __all__ = [
@@ -167,7 +166,8 @@ class DownloadOKXData(ContinuousDownloader):
     """
 
     def __init__(self, pair: str = 'BTC-USDT', time_step: int = 60,
-                 until: int | None = 3600, span: int | None = None) -> None:
+                 until: int | None = 3600, span: int | None = None,
+                 checkpoint_dir: str | None = None) -> None:
         """ Initialize object. """
         if until is None:
             until = 0
@@ -184,6 +184,7 @@ class DownloadOKXData(ContinuousDownloader):
 
         ContinuousDownloader.__init__(
             self, _OKX_WS_URL, time_step=time_step, STOP=until,
+            checkpoint_dir=checkpoint_dir,
             subs={'op': 'subscribe', 'args': args},
         )
         self._parser_data = {
@@ -193,6 +194,7 @@ class DownloadOKXData(ContinuousDownloader):
         }
         self.logger = logging.getLogger(__name__)
         self.d: dict[str, float] = {}
+        self._load_checkpoint()
 
     async def on_message(self, msg: dict) -> None:
         """ Dispatch incoming OKX WebSocket push messages.
@@ -238,7 +240,13 @@ class DownloadOKXData(ContinuousDownloader):
                 self.d.pop(price, None)
             else:
                 self.d[price] = qty
-        self._data[self.t] = dict(self.d)
+        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
+
+    def _get_book_state(self) -> dict[str, float]:
+        return dict(self.d)
+
+    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
+        self.d = state
 
     def parser_kline(self, data: list[list]) -> None:
         """ Parse and store a candle push message.
@@ -251,12 +259,6 @@ class DownloadOKXData(ContinuousDownloader):
         """
         for candle in _parser_kline(data):
             self._raw_parser(candle)
-
-    def _raw_parser(self, data: object) -> None:
-        if self.t not in self._data:
-            self._data[self.t] = []
-        self._data[self.t].append(data)  # type: ignore[union-attr]
-
 
 def get_trades_okx(path: str, pair: str = 'BTC-USDT', time_step: int = 60,
                    until: int = 3600, form: str = 'csv') -> None:
@@ -277,8 +279,7 @@ def get_trades_okx(path: str, pair: str = 'BTC-USDT', time_step: int = 60,
 
     """
     downloader = DownloadOKXData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_trades)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
@@ -301,8 +302,7 @@ def get_orderbook_okx(path: str, pair: str = 'BTC-USDT', time_step: int = 60,
 
     """
     downloader = DownloadOKXData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_marketdepth)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_book_saver(IODataBase(path, method=form))
     downloader(pair=pair)
 
 
@@ -313,7 +313,8 @@ def get_data_okx(path: str, pair: str = 'BTC-USDT', time_step: int = 60,
     Parameters
     ----------
     path : str
-        Path to save data.
+        Root path; trades saved under ``<path>/trades/``, book under
+        ``<path>/book/``.
     pair : str, optional
         Trading pair in OKX format (e.g. 'BTC-USDT'), default is 'BTC-USDT'.
     time_step : int, optional
@@ -325,6 +326,6 @@ def get_data_okx(path: str, pair: str = 'BTC-USDT', time_step: int = 60,
 
     """
     downloader = DownloadOKXData(pair=pair, time_step=time_step, until=until)
-    downloader.set_process_data(set_orders)
-    downloader.set_saver(IODataBase(path, method=form))
+    downloader.set_trades_saver(IODataBase(f'{path}/trades', method=form))
+    downloader.set_book_saver(IODataBase(f'{path}/book', method=form))
     downloader(pair=pair)

--- a/dccd/continuous_dl/okx.py
+++ b/dccd/continuous_dl/okx.py
@@ -193,7 +193,6 @@ class DownloadOKXData(ContinuousDownloader):
             'kline': self.parser_kline,
         }
         self.logger = logging.getLogger(__name__)
-        self.d: dict[str, float] = {}
         self._load_checkpoint()
 
     async def on_message(self, msg: dict) -> None:
@@ -222,8 +221,7 @@ class DownloadOKXData(ContinuousDownloader):
             The ``data`` field from the OKX trades push message.
 
         """
-        for trade in _parser_trades(data):
-            self._raw_parser(trade)
+        self._push_trades(_parser_trades(data))
 
     def parser_book(self, msg: dict) -> None:
         """ Parse and update the order book from a books push message.
@@ -234,19 +232,7 @@ class DownloadOKXData(ContinuousDownloader):
             Full OKX books push message (contains ``action`` and ``data``).
 
         """
-        updates = _parser_book(msg.get('data', []))
-        for price, qty in updates.items():
-            if qty == 0:
-                self.d.pop(price, None)
-            else:
-                self.d[price] = qty
-        self._data.setdefault(self.t, {'trades': [], 'book': {}})['book'] = dict(self.d)
-
-    def _get_book_state(self) -> dict[str, float]:
-        return dict(self.d)
-
-    def _restore_book_state(self, state: dict[str, float]) -> None:  # type: ignore[override]
-        self.d = state
+        self._push_book_updates(_parser_book(msg.get('data', [])))
 
     def parser_kline(self, data: list[list]) -> None:
         """ Parse and store a candle push message.

--- a/dccd/daemon/__init__.py
+++ b/dccd/daemon/__init__.py
@@ -13,17 +13,21 @@ Submodules
    config
    storage
    scheduler
+   stream_manager
 
 """
 
 from dccd.daemon.config import CollectorConfig, load_config
 from dccd.daemon.scheduler import build_histo_scheduler, run_once
 from dccd.daemon.storage import RemoteStorage
+from dccd.daemon.stream_manager import StreamManager, SyncService
 
 __all__ = [
     'CollectorConfig',
     'load_config',
     'RemoteStorage',
+    'StreamManager',
+    'SyncService',
     'build_histo_scheduler',
     'run_once',
 ]

--- a/dccd/daemon/__init__.py
+++ b/dccd/daemon/__init__.py
@@ -11,6 +11,7 @@ Submodules
 .. autosummary::
 
    config
+   health
    storage
    scheduler
    stream_manager
@@ -18,12 +19,14 @@ Submodules
 """
 
 from dccd.daemon.config import CollectorConfig, load_config
+from dccd.daemon.health import HealthMonitor
 from dccd.daemon.scheduler import build_histo_scheduler, run_once
 from dccd.daemon.storage import RemoteStorage
 from dccd.daemon.stream_manager import StreamManager, SyncService
 
 __all__ = [
     'CollectorConfig',
+    'HealthMonitor',
     'load_config',
     'RemoteStorage',
     'StreamManager',

--- a/dccd/daemon/__init__.py
+++ b/dccd/daemon/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Daemon module for autonomous data collection.
+
+.. currentmodule:: dccd.daemon
+
+Submodules
+----------
+
+.. autosummary::
+
+   config
+   storage
+   scheduler
+
+"""
+
+from dccd.daemon.config import CollectorConfig, load_config
+from dccd.daemon.scheduler import build_histo_scheduler, run_once
+from dccd.daemon.storage import RemoteStorage
+
+__all__ = [
+    'CollectorConfig',
+    'load_config',
+    'RemoteStorage',
+    'build_histo_scheduler',
+    'run_once',
+]

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Command-line interface for the dccd daemon.
+
+.. currentmodule:: dccd.daemon.cli
+
+Entry point installed by ``pyproject.toml [project.scripts]``:
+
+.. code-block:: bash
+
+    pip install "dccd[daemon]"
+    dccd --help
+
+Commands
+--------
+
+.. code-block:: text
+
+    dccd validate --config PATH
+        Parse and validate the YAML config; print a one-line summary.
+        Exit 0 on success, 1 on any error (file not found, bad YAML,
+        Pydantic validation failure).
+
+    dccd run --config PATH
+        Execute every histo_job once in order, then exit.
+        Metrics (success/failure counts) are printed on completion.
+        Useful for cron-based one-shot collection or smoke-testing a config.
+
+    dccd start --config PATH
+        Start the continuous daemon in the foreground:
+        - APScheduler BackgroundScheduler for all histo_jobs
+        - StreamManager (one thread per WebSocket pair)
+        - SyncService (periodic rclone push to remotes)
+        Block until SIGINT (Ctrl-C) or SIGTERM; shuts down cleanly on signal.
+
+    dccd status --config PATH
+        Read {local_path}/.dccd/metrics.json and render a table:
+
+            job                      last_run          last_success      rows  errors
+            -----------------------------------------------------------------------
+            binance/BTC/USDT         2026-05-17 10:00  2026-05-17 10:00  1200       0
+            kraken/ETH/USD           2026-05-17 09:58  2026-05-17 09:30   800       3
+
+    dccd add --exchange X --pair Y --span N [--config PATH]
+        Append a new histo_job to the YAML config file in-place and
+        re-validate the modified config before writing.
+
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+
+__all__ = ['app']
+
+app = typer.Typer(help='dccd — autonomous crypto data collection daemon')
+
+_DEFAULT_CONFIG = 'config.yml'
+
+
+def _load(config_path: str) -> object:
+    """Load config, exit with code 1 on any error."""
+    from dccd.daemon.config import load_config
+
+    try:
+        return load_config(config_path)
+    except FileNotFoundError:
+        typer.echo(f'Error: config file not found: {config_path}', err=True)
+        raise typer.Exit(1)
+    except Exception as exc:
+        typer.echo(f'Error: {exc}', err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def validate(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Validate a YAML config file and print a one-line summary.
+
+    Loads the file, runs Pydantic validation, and prints a count of
+    histo_jobs, stream_jobs, remotes, and the local storage path.
+    Exits with code 1 on any error (missing file, bad YAML, invalid config).
+
+    """
+    cfg = _load(config)
+    typer.echo(f'Config: {config}')
+    typer.echo(f'  storage.local_path : {cfg.storage.local_path}')  # type: ignore[attr-defined]
+    typer.echo(f'  remotes            : {len(cfg.storage.remotes)}')  # type: ignore[attr-defined]
+    typer.echo(f'  histo_jobs         : {len(cfg.histo_jobs)}')  # type: ignore[attr-defined]
+    typer.echo(f'  stream_jobs        : {len(cfg.stream_jobs)}')  # type: ignore[attr-defined]
+    typer.echo('Config is valid.')
+
+
+@app.command()
+def run(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Run every histo_job once sequentially, then exit.
+
+    Downloads and saves one candle batch per ``(exchange, pair)`` in
+    ``histo_jobs``.  A :class:`~dccd.daemon.health.HealthMonitor` is
+    instantiated so metrics are persisted even for this one-shot run.
+    Failed jobs are logged and skipped; remaining jobs continue.
+    Prints ``successes=N failures=M`` on completion.
+
+    """
+    from dccd.daemon.health import HealthMonitor
+    from dccd.daemon.scheduler import run_once
+
+    cfg = _load(config)
+    health = HealthMonitor(cfg.storage.local_path, cfg.alerts)  # type: ignore[attr-defined]
+    run_once(cfg, health=health)  # type: ignore[arg-type]
+    metrics = health.get_metrics()
+    successes = sum(1 for m in metrics.values() if m.errors_count == 0)
+    failures = sum(1 for m in metrics.values() if m.errors_count > 0)
+    typer.echo(f'Done. successes={successes} failures={failures}')
+
+
+@app.command()
+def start(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Start the continuous daemon and block until SIGINT or SIGTERM.
+
+    Starts three background components:
+
+    - **APScheduler** (interval jobs for every ``histo_job``),
+    - **StreamManager** (one thread per ``(exchange, pair)`` WebSocket),
+    - **SyncService** (periodic rclone push to all configured remotes).
+
+    A :class:`~dccd.daemon.health.HealthMonitor` is shared across all
+    components; metrics and a rotating log file are written to
+    ``{local_path}/.dccd/``.
+
+    Press Ctrl-C or send SIGTERM to stop gracefully.
+
+    """
+    from dccd.daemon.health import HealthMonitor
+    from dccd.daemon.scheduler import build_histo_scheduler
+    from dccd.daemon.stream_manager import StreamManager
+
+    cfg = _load(config)
+    health = HealthMonitor(cfg.storage.local_path, cfg.alerts)  # type: ignore[attr-defined]
+    scheduler = build_histo_scheduler(cfg, health=health)  # type: ignore[arg-type]
+    stream_mgr = StreamManager(cfg, health=health)  # type: ignore[arg-type]
+
+    stop_event = threading.Event()
+
+    def _handle_signal(signum: int, frame: object) -> None:
+        typer.echo('Stopping daemon…')
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    typer.echo('Starting daemon. Press Ctrl-C to stop.')
+    scheduler.start()
+    stream_mgr.start()
+    stop_event.wait()
+    scheduler.shutdown(wait=False)
+    stream_mgr.stop()
+    typer.echo('Daemon stopped.')
+
+
+@app.command()
+def status(
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Print a health table from the saved metrics JSON.
+
+    Reads ``{local_path}/.dccd/metrics.json`` and renders a table with
+    one row per ``(exchange, pair)`` job.  Columns: ``job``, ``last_run``,
+    ``last_success``, ``rows`` (cumulative), ``errors`` (consecutive).
+    Prints ``No metrics yet.`` if the file does not exist.
+
+    """
+    cfg = _load(config)
+    metrics_file = Path(cfg.storage.local_path) / '.dccd' / 'metrics.json'  # type: ignore[attr-defined]
+
+    if not metrics_file.exists():
+        typer.echo('No metrics yet.')
+        return
+
+    data: dict = json.loads(metrics_file.read_text())
+
+    def _fmt_ts(ts: float | None) -> str:
+        if ts is None:
+            return '-'
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d %H:%M')
+
+    col_w = 24
+    header = (
+        f"{'job':<{col_w}} {'last_run':<17} {'last_success':<17} {'rows':>6} {'errors':>6}"
+    )
+    typer.echo(header)
+    typer.echo('-' * len(header))
+    for key, m in data.items():
+        typer.echo(
+            f"{key:<{col_w}} "
+            f"{_fmt_ts(m.get('last_run_at')):<17} "
+            f"{_fmt_ts(m.get('last_success_at')):<17} "
+            f"{m.get('rows_collected', 0):>6} "
+            f"{m.get('errors_count', 0):>6}"
+        )
+
+
+@app.command()
+def add(
+    exchange: str = typer.Option(..., '--exchange', '-e', help='Exchange name.'),
+    pair: str = typer.Option(..., '--pair', '-p', help='Trading pair (e.g. BTC/USDT).'),
+    span: int = typer.Option(..., '--span', '-s', help='Candle interval in seconds.'),
+    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
+                               help='Path to the YAML config file.'),
+) -> None:
+    """ Append a new histo job to the YAML config file in-place.
+
+    Adds a ``histo_jobs`` entry for the given ``(exchange, pair, span)``
+    and re-validates the whole config with Pydantic before writing.
+    Exits with code 1 and leaves the file unchanged if validation fails.
+
+    """
+    import yaml
+    from pydantic import ValidationError
+
+    from dccd.daemon.config import CollectorConfig
+
+    config_path = Path(config)
+    if not config_path.exists():
+        typer.echo(f'Error: config file not found: {config}', err=True)
+        raise typer.Exit(1)
+
+    raw: dict = yaml.safe_load(config_path.read_text())
+    raw.setdefault('histo_jobs', [])
+    raw['histo_jobs'].append({
+        'exchange': exchange,
+        'pairs': [pair],
+        'span': span,
+    })
+
+    try:
+        CollectorConfig.model_validate(raw)
+    except ValidationError as exc:
+        typer.echo(f'Validation error after add: {exc}', err=True)
+        raise typer.Exit(1)
+
+    config_path.write_text(yaml.dump(raw, default_flow_style=False))
+    typer.echo(f'Added histo job: exchange={exchange} pair={pair} span={span}s')
+    typer.echo(f'Config written to {config}.')

--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Declarative configuration for the dccd daemon.
+
+Loads a YAML file and validates it with Pydantic v2 models.
+
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+__all__ = [
+    'CollectorConfig',
+    'AlertConfig',
+    'HistoJob',
+    'RemoteConfig',
+    'StorageConfig',
+    'StreamJob',
+    'load_config',
+]
+
+SUPPORTED_HISTO_EXCHANGES: frozenset[str] = frozenset(
+    {'binance', 'kraken', 'bybit', 'okx', 'coinbase'}
+)
+SUPPORTED_STREAM_EXCHANGES: frozenset[str] = frozenset(
+    {'binance', 'kraken', 'bybit', 'okx', 'bitfinex', 'bitmex'}
+)
+SUPPORTED_FORMATS: frozenset[str] = frozenset({'xlsx', 'csv', 'parquet'})
+SUPPORTED_BY_PERIOD: frozenset[str] = frozenset({'Y', 'M', 'D'})
+
+
+class RemoteConfig(BaseModel):
+    """ Remote storage configuration for rclone.
+
+    Parameters
+    ----------
+    provider : str
+        Remote provider, default is ``'rclone'``.
+    remote : str
+        rclone remote destination, e.g. ``'mynas:crypto/'``.
+
+    """
+
+    provider: str = 'rclone'
+    remote: str
+
+
+class StorageConfig(BaseModel):
+    """ Local and optional remote storage configuration.
+
+    Parameters
+    ----------
+    local_path : str
+        Absolute path where data is stored on the daemon host.
+    remote : RemoteConfig or None
+        Remote push configuration. If ``None``, data is kept locally only.
+
+    """
+
+    local_path: str
+    remote: RemoteConfig | None = None
+
+
+class HistoJob(BaseModel):
+    """ Historical (REST) data collection job.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name. Must be one of ``SUPPORTED_HISTO_EXCHANGES``.
+    pairs : list of str
+        Trading pairs in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
+    span : int
+        Candle interval in seconds. Must be >= 60.
+    format : str
+        Output format: ``'xlsx'``, ``'csv'``, or ``'parquet'``.
+    by_period : str
+        File grouping period: ``'Y'`` (year), ``'M'`` (month), ``'D'`` (day).
+
+    """
+
+    exchange: str
+    pairs: list[str]
+    span: int
+    format: str = 'parquet'
+    by_period: str = 'Y'
+
+    @field_validator('exchange')
+    @classmethod
+    def _validate_exchange(cls, v: str) -> str:
+        if v not in SUPPORTED_HISTO_EXCHANGES:
+            raise ValueError(
+                f"Unknown exchange {v!r}. "
+                f"Supported: {sorted(SUPPORTED_HISTO_EXCHANGES)}"
+            )
+        return v
+
+    @field_validator('pairs')
+    @classmethod
+    def _validate_pairs(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("'pairs' must not be empty")
+        for pair in v:
+            if '/' not in pair:
+                raise ValueError(
+                    f"Pair {pair!r} must be in 'CRYPTO/FIAT' format (e.g. 'BTC/USDT')"
+                )
+        return v
+
+    @field_validator('span')
+    @classmethod
+    def _validate_span(cls, v: int) -> int:
+        if v < 60:
+            raise ValueError(f"span must be >= 60 seconds, got {v}")
+        return v
+
+    @field_validator('format')
+    @classmethod
+    def _validate_format(cls, v: str) -> str:
+        if v not in SUPPORTED_FORMATS:
+            raise ValueError(
+                f"Unknown format {v!r}. Supported: {sorted(SUPPORTED_FORMATS)}"
+            )
+        return v
+
+    @field_validator('by_period')
+    @classmethod
+    def _validate_by_period(cls, v: str) -> str:
+        if v not in SUPPORTED_BY_PERIOD:
+            raise ValueError(
+                f"Unknown by_period {v!r}. Supported: {sorted(SUPPORTED_BY_PERIOD)}"
+            )
+        return v
+
+
+class StreamJob(BaseModel):
+    """ Real-time (WebSocket) data collection job.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name. Must be one of ``SUPPORTED_STREAM_EXCHANGES``.
+    pairs : list of str
+        Trading pairs (format depends on exchange).
+    channels : list of str
+        WebSocket channels to subscribe to (e.g. ``['trades', 'book']``).
+    time_step : int
+        Snapshot interval in seconds, default is 60.
+
+    """
+
+    exchange: str
+    pairs: list[str]
+    channels: list[str]
+    time_step: int = 60
+
+    @field_validator('exchange')
+    @classmethod
+    def _validate_exchange(cls, v: str) -> str:
+        if v not in SUPPORTED_STREAM_EXCHANGES:
+            raise ValueError(
+                f"Unknown exchange {v!r}. "
+                f"Supported: {sorted(SUPPORTED_STREAM_EXCHANGES)}"
+            )
+        return v
+
+    @field_validator('pairs', 'channels')
+    @classmethod
+    def _validate_nonempty(cls, v: list[str], info: Any) -> list[str]:
+        if not v:
+            raise ValueError(f"'{info.field_name}' must not be empty")
+        return v
+
+
+class AlertConfig(BaseModel):
+    """ Optional alerting configuration.
+
+    Parameters
+    ----------
+    webhook_url : str or None
+        Slack/Discord webhook URL for error notifications. ``None`` disables alerts.
+    max_consecutive_errors : int
+        Number of consecutive job failures before sending an alert, default 3.
+
+    """
+
+    webhook_url: str | None = None
+    max_consecutive_errors: int = 3
+
+
+class CollectorConfig(BaseModel):
+    """ Root configuration model for the dccd daemon.
+
+    Parameters
+    ----------
+    storage : StorageConfig
+        Local (and optional remote) storage settings.
+    histo_jobs : list of HistoJob
+        REST API polling jobs.
+    stream_jobs : list of StreamJob
+        WebSocket streaming jobs.
+    alerts : AlertConfig
+        Alerting settings.
+
+    """
+
+    storage: StorageConfig
+    histo_jobs: list[HistoJob] = Field(default_factory=list)
+    stream_jobs: list[StreamJob] = Field(default_factory=list)
+    alerts: AlertConfig = Field(default_factory=AlertConfig)
+
+    @model_validator(mode='after')
+    def _at_least_one_job(self) -> 'CollectorConfig':
+        if not self.histo_jobs and not self.stream_jobs:
+            raise ValueError(
+                "Configuration must define at least one job "
+                "(histo_jobs or stream_jobs)"
+            )
+        return self
+
+
+def load_config(path: str | pathlib.Path) -> CollectorConfig:
+    """ Load and validate a YAML daemon configuration file.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the YAML configuration file.
+
+    Returns
+    -------
+    CollectorConfig
+        Validated configuration object.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* does not exist.
+    yaml.YAMLError
+        If the file contains invalid YAML.
+    pydantic.ValidationError
+        If the configuration fails validation.
+
+    """
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return CollectorConfig.model_validate(data)

--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -58,13 +58,18 @@ class StorageConfig(BaseModel):
     ----------
     local_path : str
         Absolute path where data is stored on the daemon host.
-    remote : RemoteConfig or None
-        Remote push configuration. If ``None``, data is kept locally only.
+    remotes : list of RemoteConfig
+        Remote destinations.  Empty list (default) keeps data locally only.
+        Multiple entries are all synced by :class:`SyncService`.
+    sync_interval : int
+        Seconds between periodic syncs to remote destinations.  ``0`` disables
+        the sync service.  Default is ``3600`` (1 hour).
 
     """
 
     local_path: str
-    remote: RemoteConfig | None = None
+    remotes: list[RemoteConfig] = Field(default_factory=list)
+    sync_interval: int = 3600
 
 
 class HistoJob(BaseModel):

--- a/dccd/daemon/health.py
+++ b/dccd/daemon/health.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Health monitoring for the dccd daemon.
+
+Tracks per-job metrics (last run, last success, rows collected, error count),
+persists them to a JSON file, configures a rotating log handler, and sends
+optional webhook alerts when consecutive failures exceed the configured
+threshold.
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.request
+from dataclasses import asdict, dataclass
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import AlertConfig
+
+__all__ = ['HealthMonitor', 'JobMetrics']
+
+logger = logging.getLogger(__name__)
+
+_LOG_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+_LOG_BACKUP_COUNT = 5
+
+
+@dataclass
+class JobMetrics:
+    """ Per-job health metrics, updated after every execution attempt.
+
+    ``errors_count`` is a *consecutive* failure counter: it resets to 0
+    whenever :meth:`HealthMonitor.record_success` is called, so it reflects
+    the current streak of failures rather than a lifetime total.
+
+    Parameters
+    ----------
+    last_run_at : float or None
+        Unix timestamp of the most recent execution attempt (success or failure).
+    last_success_at : float or None
+        Unix timestamp of the most recent successful execution.
+        ``None`` until the first success.
+    rows_collected : int
+        Cumulative number of rows saved across all successful runs.
+    errors_count : int
+        Number of *consecutive* failures since the last success.
+        Resets to 0 on the next successful run.
+
+    """
+
+    last_run_at: float | None = None
+    last_success_at: float | None = None
+    rows_collected: int = 0
+    errors_count: int = 0
+
+
+class HealthMonitor:
+    """ Monitor job health, persist metrics, and send webhook alerts.
+
+    ``HealthMonitor`` serves three purposes:
+
+    1. **Rotating log** — attaches a :class:`~logging.handlers.RotatingFileHandler`
+       (10 MB × 5 backups) to the *root* logger on construction, so every
+       ``logging`` call anywhere in the process lands in
+       ``{local_path}/.dccd/dccd.log`` in addition to the console.
+    2. **Per-job metrics** — :meth:`record_success` / :meth:`record_failure`
+       update a :class:`JobMetrics` entry for each ``(exchange, pair)`` key and
+       flush the full metrics dict to ``{local_path}/.dccd/metrics.json`` after
+       each call.  The JSON file is reloaded on startup, so metrics survive
+       daemon restarts.
+    3. **Webhook alerts** — when ``errors_count`` reaches
+       ``alerts.max_consecutive_errors``, a JSON POST is sent to
+       ``alerts.webhook_url`` (Slack / Discord / generic).  Alerting is
+       completely optional: pass ``AlertConfig()`` with no ``webhook_url`` to
+       disable it.
+
+    Use this class directly when embedding the scheduler in your own process
+    (see :func:`~dccd.daemon.scheduler.run_once` and
+    :func:`~dccd.daemon.scheduler.build_histo_scheduler`).  The ``dccd``
+    CLI commands instantiate it automatically.
+
+    Parameters
+    ----------
+    local_path : str or Path
+        Root data directory (``CollectorConfig.storage.local_path``).
+        The hidden directory ``{local_path}/.dccd/`` is created on init if it
+        does not exist.
+    alerts : AlertConfig
+        Alerting configuration (webhook URL and error threshold).
+
+    Notes
+    -----
+    The rotating log handler is added to the **root** logger, not to the
+    module logger.  All loggers in the process therefore write to the file
+    after :class:`HealthMonitor` is constructed — this is intentional so that
+    APScheduler, WebSocket, and application logs are all captured together.
+
+    Calling :meth:`record_failure` does *not* suppress or re-raise the
+    original exception.  The caller is responsible for exception handling;
+    ``HealthMonitor`` only observes the outcome.
+
+    Examples
+    --------
+    Standalone usage inside a custom scheduler loop:
+
+    >>> from dccd.daemon.config import AlertConfig
+    >>> from dccd.daemon.health import HealthMonitor
+    >>> import tempfile, pathlib
+    >>> with tempfile.TemporaryDirectory() as tmp:
+    ...     alerts = AlertConfig()           # no webhook
+    ...     monitor = HealthMonitor(tmp, alerts)
+    ...     monitor.record_success('binance', 'BTC/USDT', rows=120)
+    ...     monitor.record_success('binance', 'BTC/USDT', rows=95)
+    ...     monitor.record_failure('kraken',  'ETH/USD')
+    ...     m = monitor.get_metrics()
+    ...     print(m['binance/BTC/USDT'].rows_collected)
+    ...     print(m['kraken/ETH/USD'].errors_count)
+    215
+    1
+
+    """
+
+    def __init__(self, local_path: str | Path, alerts: AlertConfig) -> None:
+        self._dir = Path(local_path) / '.dccd'
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._metrics_file = self._dir / 'metrics.json'
+        self._alerts = alerts
+        self._metrics: dict[str, JobMetrics] = {}
+        self._load_metrics()
+        self._setup_logging()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def record_success(self, exchange: str, pair: str, rows: int = 0) -> None:
+        """ Record a successful job execution.
+
+        Parameters
+        ----------
+        exchange : str
+            Exchange name (e.g. ``'binance'``).
+        pair : str
+            Trading pair (e.g. ``'BTC/USDT'``).
+        rows : int, optional
+            Number of data rows collected, default 0.
+
+        """
+        key = self._key(exchange, pair)
+        m = self._metrics.setdefault(key, JobMetrics())
+        now = time.time()
+        m.last_run_at = now
+        m.last_success_at = now
+        m.rows_collected += rows
+        m.errors_count = 0
+        self._save_metrics()
+        logger.debug('health: success %s %s rows=%d', exchange, pair, rows)
+
+    def record_failure(self, exchange: str, pair: str) -> None:
+        """ Record a failed job execution.
+
+        Parameters
+        ----------
+        exchange : str
+            Exchange name.
+        pair : str
+            Trading pair.
+
+        """
+        key = self._key(exchange, pair)
+        m = self._metrics.setdefault(key, JobMetrics())
+        m.last_run_at = time.time()
+        m.errors_count += 1
+        self._save_metrics()
+        logger.warning('health: failure %s %s errors=%d', exchange, pair, m.errors_count)
+        if (self._alerts.webhook_url
+                and m.errors_count >= self._alerts.max_consecutive_errors):
+            self._send_alert(exchange, pair, m.errors_count)
+
+    def get_metrics(self) -> dict[str, JobMetrics]:
+        """ Return a snapshot of the current metrics dict.
+
+        Returns
+        -------
+        dict of str to JobMetrics
+            Keys are ``'{exchange}/{pair}'`` strings.
+
+        """
+        return dict(self._metrics)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _key(exchange: str, pair: str) -> str:
+        return f'{exchange}/{pair}'
+
+    def _send_alert(self, exchange: str, pair: str, errors_count: int) -> None:
+        text = (
+            f':warning: dccd: {errors_count} consecutive errors '
+            f'on {exchange} {pair}'
+        )
+        payload = json.dumps({'text': text}).encode()
+        req = urllib.request.Request(
+            self._alerts.webhook_url,  # type: ignore[arg-type]
+            data=payload,
+            headers={'Content-Type': 'application/json'},
+        )
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            logger.info('health: alert sent for %s %s', exchange, pair)
+        except Exception:
+            logger.exception('health: failed to send alert for %s %s', exchange, pair)
+
+    def _save_metrics(self) -> None:
+        data = {k: asdict(v) for k, v in self._metrics.items()}
+        self._metrics_file.write_text(json.dumps(data, indent=2))
+
+    def _load_metrics(self) -> None:
+        if self._metrics_file.exists():
+            try:
+                data = json.loads(self._metrics_file.read_text())
+                self._metrics = {k: JobMetrics(**v) for k, v in data.items()}
+            except Exception:
+                logger.warning('health: could not load metrics from %s', self._metrics_file)
+
+    def _setup_logging(self) -> None:
+        log_file = self._dir / 'dccd.log'
+        handler = RotatingFileHandler(
+            log_file,
+            maxBytes=_LOG_MAX_BYTES,
+            backupCount=_LOG_BACKUP_COUNT,
+        )
+        handler.setFormatter(
+            logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+        )
+        logging.getLogger().addHandler(handler)

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -24,6 +24,7 @@ from dccd.histo_dl.okx import FromOKX
 
 if TYPE_CHECKING:
     from dccd.daemon.config import CollectorConfig, HistoJob
+    from dccd.daemon.health import HealthMonitor
 
 __all__ = ['build_histo_scheduler', 'run_histo_job', 'run_once']
 
@@ -38,7 +39,8 @@ _HISTO_CLASSES: dict[str, type[ImportDataCryptoCurrencies]] = {
 }
 
 
-def run_histo_job(job: HistoJob, pair: str, base_path: str) -> None:
+def run_histo_job(job: HistoJob, pair: str, base_path: str,
+                  health: HealthMonitor | None = None) -> None:
     """ Download and save one (exchange, pair) candle job locally.
 
     Data is saved to ``base_path`` on the daemon host.  Remote sync is
@@ -52,16 +54,28 @@ def run_histo_job(job: HistoJob, pair: str, base_path: str) -> None:
         Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
     base_path : str
         Root directory for local storage (``CollectorConfig.storage.local_path``).
+    health : HealthMonitor or None, optional
+        Health monitor to record success/failure metrics.
 
     """
     crypto, fiat = pair.split('/', 1)
     cls = _HISTO_CLASSES[job.exchange]
-    obj = cls(base_path, crypto, job.span, fiat, form=job.format)
-    obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
-    logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
+    try:
+        obj = cls(base_path, crypto, job.span, fiat, form=job.format)
+        obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
+        _data = getattr(obj, 'data', None)
+        rows = len(_data) if _data is not None else 0
+        logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
+        if health:
+            health.record_success(job.exchange, pair, rows)
+    except Exception:
+        if health:
+            health.record_failure(job.exchange, pair)
+        raise
 
 
-def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
+def build_histo_scheduler(config: CollectorConfig,
+                          health: HealthMonitor | None = None) -> BackgroundScheduler:
     """ Build an APScheduler BackgroundScheduler from a CollectorConfig.
 
     One interval job is registered per ``(exchange, pair)`` combination in
@@ -72,6 +86,8 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
     ----------
     config : CollectorConfig
         Daemon configuration.
+    health : HealthMonitor or None, optional
+        Health monitor forwarded to each scheduled job.
 
     Returns
     -------
@@ -96,7 +112,12 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
                 run_histo_job,
                 trigger='interval',
                 seconds=job.span,
-                args=[job, pair, config.storage.local_path],
+                kwargs={
+                    'job': job,
+                    'pair': pair,
+                    'base_path': config.storage.local_path,
+                    'health': health,
+                },
                 id=job_id,
                 name=f'{job.exchange} {pair} {job.span}s',
                 coalesce=True,
@@ -107,7 +128,8 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
     return scheduler
 
 
-def run_once(config: CollectorConfig) -> None:
+def run_once(config: CollectorConfig,
+             health: HealthMonitor | None = None) -> None:
     """ Execute all histo_jobs once and return.
 
     Each ``(exchange, pair)`` combination is run sequentially.  A job
@@ -117,12 +139,14 @@ def run_once(config: CollectorConfig) -> None:
     ----------
     config : CollectorConfig
         Daemon configuration.
+    health : HealthMonitor or None, optional
+        Health monitor forwarded to each job call.
 
     """
     for job in config.histo_jobs:
         for pair in job.pairs:
             try:
-                run_histo_job(job, pair, config.storage.local_path)
+                run_histo_job(job, pair, config.storage.local_path, health=health)
             except Exception:
                 logger.exception(
                     'histo job failed: %s %s', job.exchange, pair

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Historical data scheduler for the dccd daemon.
+
+Wraps APScheduler 3.x BackgroundScheduler to run periodic REST API
+collection jobs defined in a :class:`~dccd.daemon.config.CollectorConfig`.
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from dccd.daemon.storage import RemoteStorage
+from dccd.histo_dl.binance import FromBinance
+from dccd.histo_dl.bybit import FromBybit
+from dccd.histo_dl.coinbase import FromCoinbase
+from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
+from dccd.histo_dl.kraken import FromKraken
+from dccd.histo_dl.okx import FromOKX
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import CollectorConfig, HistoJob
+
+__all__ = ['build_histo_scheduler', 'run_histo_job', 'run_once']
+
+logger = logging.getLogger(__name__)
+
+_HISTO_CLASSES: dict[str, type[ImportDataCryptoCurrencies]] = {
+    'binance': FromBinance,
+    'kraken': FromKraken,
+    'bybit': FromBybit,
+    'okx': FromOKX,
+    'coinbase': FromCoinbase,
+}
+
+
+def run_histo_job(
+    job: HistoJob,
+    pair: str,
+    base_path: str,
+    storage: RemoteStorage,
+) -> None:
+    """ Download and save one (exchange, pair) candle job, then push to remote.
+
+    Parameters
+    ----------
+    job : HistoJob
+        Job configuration (exchange, span, format, by_period).
+    pair : str
+        Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
+    base_path : str
+        Root directory for local storage (``CollectorConfig.storage.local_path``).
+    storage : RemoteStorage
+        Remote storage handler.  :meth:`~RemoteStorage.push` is called after
+        each successful save.
+
+    """
+    crypto, fiat = pair.split('/', 1)
+    cls = _HISTO_CLASSES[job.exchange]
+    obj = cls(base_path, crypto, job.span, fiat, form=job.format)
+    obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
+    storage.push(obj.full_path)
+    logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
+
+
+def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
+    """ Build an APScheduler BackgroundScheduler from a CollectorConfig.
+
+    One interval job is registered per ``(exchange, pair)`` combination in
+    ``config.histo_jobs``.  Each job runs with ``coalesce=True`` and
+    ``max_instances=1`` to prevent overlapping executions.
+
+    Parameters
+    ----------
+    config : CollectorConfig
+        Daemon configuration.
+
+    Returns
+    -------
+    apscheduler.schedulers.background.BackgroundScheduler
+        Configured scheduler, not yet started.
+
+    Examples
+    --------
+    >>> from dccd.daemon.config import load_config
+    >>> from dccd.daemon.scheduler import build_histo_scheduler
+    >>> # config = load_config('config.yml')
+    >>> # scheduler = build_histo_scheduler(config)
+    >>> # scheduler.start()
+
+    """
+    scheduler = BackgroundScheduler()
+    storage = RemoteStorage(config.storage)
+
+    for job in config.histo_jobs:
+        for pair in job.pairs:
+            job_id = f'{job.exchange}_{pair.replace("/", "_")}_{job.span}'
+            scheduler.add_job(
+                run_histo_job,
+                trigger='interval',
+                seconds=job.span,
+                args=[job, pair, config.storage.local_path, storage],
+                id=job_id,
+                name=f'{job.exchange} {pair} {job.span}s',
+                coalesce=True,
+                max_instances=1,
+            )
+            logger.debug('registered job %s', job_id)
+
+    return scheduler
+
+
+def run_once(config: CollectorConfig) -> None:
+    """ Execute all histo_jobs once and return.
+
+    Each ``(exchange, pair)`` combination is run sequentially.  A job
+    failure is logged and skipped — other jobs continue regardless.
+
+    Parameters
+    ----------
+    config : CollectorConfig
+        Daemon configuration.
+
+    """
+    storage = RemoteStorage(config.storage)
+
+    for job in config.histo_jobs:
+        for pair in job.pairs:
+            try:
+                run_histo_job(job, pair, config.storage.local_path, storage)
+            except Exception:
+                logger.exception(
+                    'histo job failed: %s %s', job.exchange, pair
+                )

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
-from dccd.daemon.storage import RemoteStorage
 from dccd.histo_dl.binance import FromBinance
 from dccd.histo_dl.bybit import FromBybit
 from dccd.histo_dl.coinbase import FromCoinbase
@@ -39,13 +38,11 @@ _HISTO_CLASSES: dict[str, type[ImportDataCryptoCurrencies]] = {
 }
 
 
-def run_histo_job(
-    job: HistoJob,
-    pair: str,
-    base_path: str,
-    storage: RemoteStorage,
-) -> None:
-    """ Download and save one (exchange, pair) candle job, then push to remote.
+def run_histo_job(job: HistoJob, pair: str, base_path: str) -> None:
+    """ Download and save one (exchange, pair) candle job locally.
+
+    Data is saved to ``base_path`` on the daemon host.  Remote sync is
+    handled separately by :class:`~dccd.daemon.stream_manager.SyncService`.
 
     Parameters
     ----------
@@ -55,16 +52,12 @@ def run_histo_job(
         Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
     base_path : str
         Root directory for local storage (``CollectorConfig.storage.local_path``).
-    storage : RemoteStorage
-        Remote storage handler.  :meth:`~RemoteStorage.push` is called after
-        each successful save.
 
     """
     crypto, fiat = pair.split('/', 1)
     cls = _HISTO_CLASSES[job.exchange]
     obj = cls(base_path, crypto, job.span, fiat, form=job.format)
     obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
-    storage.push(obj.full_path)
     logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
 
 
@@ -95,7 +88,6 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
 
     """
     scheduler = BackgroundScheduler()
-    storage = RemoteStorage(config.storage)
 
     for job in config.histo_jobs:
         for pair in job.pairs:
@@ -104,7 +96,7 @@ def build_histo_scheduler(config: CollectorConfig) -> BackgroundScheduler:
                 run_histo_job,
                 trigger='interval',
                 seconds=job.span,
-                args=[job, pair, config.storage.local_path, storage],
+                args=[job, pair, config.storage.local_path],
                 id=job_id,
                 name=f'{job.exchange} {pair} {job.span}s',
                 coalesce=True,
@@ -127,12 +119,10 @@ def run_once(config: CollectorConfig) -> None:
         Daemon configuration.
 
     """
-    storage = RemoteStorage(config.storage)
-
     for job in config.histo_jobs:
         for pair in job.pairs:
             try:
-                run_histo_job(job, pair, config.storage.local_path, storage)
+                run_histo_job(job, pair, config.storage.local_path)
             except Exception:
                 logger.exception(
                     'histo job failed: %s %s', job.exchange, pair

--- a/dccd/daemon/storage.py
+++ b/dccd/daemon/storage.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Remote storage abstraction for the dccd daemon.
+
+Wraps rclone to push local data directories to any rclone-supported
+destination (NAS, SFTP, S3, Google Drive, …).
+
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import StorageConfig
+
+__all__ = ['RemoteStorage']
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteStorage:
+    """ Push local data directories to a remote destination via rclone.
+
+    If no remote is configured, :meth:`push` is a silent no-op and data
+    is kept on the daemon host only.
+
+    Parameters
+    ----------
+    config : StorageConfig
+        Storage configuration (local path + optional rclone remote).
+
+    """
+
+    def __init__(self, config: StorageConfig) -> None:
+        self.config = config
+        self._rclone_available: bool | None = None
+
+    def check_rclone(self) -> bool:
+        """ Check whether rclone is available in PATH (result is cached).
+
+        Returns
+        -------
+        bool
+            ``True`` if rclone is found, ``False`` otherwise.
+
+        """
+        if self._rclone_available is None:
+            self._rclone_available = shutil.which('rclone') is not None
+            if not self._rclone_available and self.config.remote is not None:
+                logger.warning(
+                    'rclone not found in PATH — remote sync disabled. '
+                    'Install rclone and ensure it is on your PATH.'
+                )
+        return self._rclone_available
+
+    def push(self, local_path: str | pathlib.Path) -> None:
+        """ Copy *local_path* to the configured remote destination.
+
+        The remote target mirrors the relative directory structure under
+        ``config.local_path``.  For example, if ``local_path`` is
+        ``/data/crypto/Binance/Data/Clean_Data/Hourly/BTCUSDT`` and
+        ``config.local_path`` is ``/data/crypto``, the remote target will
+        be ``<remote>/Binance/Data/Clean_Data/Hourly/BTCUSDT``.
+
+        Parameters
+        ----------
+        local_path : str or pathlib.Path
+            Absolute path of the directory to synchronise.
+
+        Notes
+        -----
+        This method never raises — failures are logged as errors so that
+        a remote-push failure does not interrupt the local collection loop.
+
+        """
+        if self.config.remote is None:
+            return
+
+        if not self.check_rclone():
+            return
+
+        local_abs = pathlib.Path(local_path).resolve()
+        base_abs = pathlib.Path(self.config.local_path).resolve()
+
+        try:
+            rel = local_abs.relative_to(base_abs)
+        except ValueError:
+            logger.error(
+                'push() called with path %s that is not under base %s',
+                local_abs, base_abs,
+            )
+            return
+
+        remote_target = self.config.remote.remote.rstrip('/') + '/' + str(rel)
+
+        result = subprocess.run(
+            ['rclone', 'copy', str(local_abs), remote_target],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        if result.returncode != 0:
+            logger.error(
+                'rclone copy failed (%s → %s): %s',
+                local_abs, remote_target, result.stderr.strip(),
+            )

--- a/dccd/daemon/storage.py
+++ b/dccd/daemon/storage.py
@@ -25,15 +25,15 @@ logger = logging.getLogger(__name__)
 
 
 class RemoteStorage:
-    """ Push local data directories to a remote destination via rclone.
+    """ Push local data directories to remote destinations via rclone.
 
-    If no remote is configured, :meth:`push` is a silent no-op and data
+    If no remotes are configured, :meth:`push` is a silent no-op and data
     is kept on the daemon host only.
 
     Parameters
     ----------
     config : StorageConfig
-        Storage configuration (local path + optional rclone remote).
+        Storage configuration (local path + optional rclone remotes).
 
     """
 
@@ -50,9 +50,11 @@ class RemoteStorage:
             ``True`` if rclone is found, ``False`` otherwise.
 
         """
+        if not self.config.remotes:
+            return False
         if self._rclone_available is None:
             self._rclone_available = shutil.which('rclone') is not None
-            if not self._rclone_available and self.config.remote is not None:
+            if not self._rclone_available and self.config.remotes:
                 logger.warning(
                     'rclone not found in PATH — remote sync disabled. '
                     'Install rclone and ensure it is on your PATH.'
@@ -60,13 +62,14 @@ class RemoteStorage:
         return self._rclone_available
 
     def push(self, local_path: str | pathlib.Path) -> None:
-        """ Copy *local_path* to the configured remote destination.
+        """ Copy *local_path* to all configured remote destinations.
 
         The remote target mirrors the relative directory structure under
         ``config.local_path``.  For example, if ``local_path`` is
-        ``/data/crypto/Binance/Data/Clean_Data/Hourly/BTCUSDT`` and
-        ``config.local_path`` is ``/data/crypto``, the remote target will
-        be ``<remote>/Binance/Data/Clean_Data/Hourly/BTCUSDT``.
+        ``/data/crypto/Binance`` and ``config.local_path`` is ``/data/crypto``,
+        the target will be ``<remote>/Binance``.  If ``local_path`` equals
+        ``config.local_path`` (root sync), the contents are copied directly
+        into each remote root.
 
         Parameters
         ----------
@@ -79,7 +82,7 @@ class RemoteStorage:
         a remote-push failure does not interrupt the local collection loop.
 
         """
-        if self.config.remote is None:
+        if not self.config.remotes:
             return
 
         if not self.check_rclone():
@@ -97,17 +100,19 @@ class RemoteStorage:
             )
             return
 
-        remote_target = self.config.remote.remote.rstrip('/') + '/' + str(rel)
+        for remote_cfg in self.config.remotes:
+            root = remote_cfg.remote.rstrip('/')
+            remote_target = root if str(rel) == '.' else f'{root}/{rel}'
 
-        result = subprocess.run(
-            ['rclone', 'copy', str(local_abs), remote_target],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-
-        if result.returncode != 0:
-            logger.error(
-                'rclone copy failed (%s → %s): %s',
-                local_abs, remote_target, result.stderr.strip(),
+            result = subprocess.run(
+                ['rclone', 'copy', str(local_abs), remote_target],
+                capture_output=True,
+                text=True,
+                timeout=300,
             )
+
+            if result.returncode != 0:
+                logger.error(
+                    'rclone copy failed (%s → %s): %s',
+                    local_abs, remote_target, result.stderr.strip(),
+                )

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 # Exchange class registry
 # ---------------------------------------------------------------------------
 
-_STREAM_CLASSES: dict[str, type[ContinuousDownloader]] = {
+_STREAM_CLASSES: dict[str, Any] = {
     'binance':  DownloadBinanceData,
     'bybit':    DownloadBybitData,
     'kraken':   DownloadKrakenData,

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Real-time stream manager and periodic sync service for the dccd daemon.
+
+:class:`SyncService` runs a background thread that pushes the entire local
+data directory to all configured remotes at a fixed interval.
+
+:class:`StreamManager` starts one background thread per ``(exchange, pair)``
+combination (or per ``(exchange, pair, channel)`` for Bitfinex/Bitmex) and
+restarts them automatically on failure.
+
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+from dccd.continuous_dl.binance import DownloadBinanceData
+from dccd.continuous_dl.bitfinex import DownloadBitfinexData
+from dccd.continuous_dl.bitmex import DownloadBitmexData
+from dccd.continuous_dl.bybit import DownloadBybitData
+from dccd.continuous_dl.exchange import ContinuousDownloader
+from dccd.continuous_dl.kraken import DownloadKrakenData
+from dccd.continuous_dl.okx import DownloadOKXData
+from dccd.daemon.storage import RemoteStorage
+from dccd.process_data import set_marketdepth, set_orders, set_trades
+from dccd.tools.io import IODataBase
+
+if TYPE_CHECKING:
+    from dccd.daemon.config import CollectorConfig, StorageConfig, StreamJob
+
+__all__ = ['StreamManager', 'SyncService']
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exchange class registry
+# ---------------------------------------------------------------------------
+
+_STREAM_CLASSES: dict[str, type[ContinuousDownloader]] = {
+    'binance':  DownloadBinanceData,
+    'bybit':    DownloadBybitData,
+    'kraken':   DownloadKrakenData,
+    'okx':      DownloadOKXData,
+    'bitfinex': DownloadBitfinexData,
+    'bitmex':   DownloadBitmexData,
+}
+
+# Bitfinex/Bitmex use one WS connection per channel → one thread per channel.
+# Other exchanges bundle all channels in one connection → one thread per pair.
+_PER_CHANNEL_EXCHANGES = frozenset({'bitfinex', 'bitmex'})
+
+# Channel name mappings for legacy exchanges
+_BITFINEX_CHANNEL: dict[str, str] = {'trades': 'trades', 'book': 'book'}
+_BITMEX_CHANNEL:   dict[str, str] = {'trades': 'trade',  'book': 'orderBookL2_25'}
+
+_RESTART_DELAY = 30  # seconds between stream restarts after a crash
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _format_pair(exchange: str, pair: str) -> str:
+    """ Convert ``'BTC/USDT'`` to the exchange-specific pair format.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name (lowercase).
+    pair : str
+        Trading pair in ``'CRYPTO/FIAT'`` format.
+
+    Returns
+    -------
+    str
+        Exchange-specific pair string.
+
+    Raises
+    ------
+    ValueError
+        If *exchange* is not supported for streaming.
+
+    """
+    crypto, fiat = pair.split('/', 1)
+    if exchange in ('binance', 'bybit'):
+        return crypto + fiat
+    if exchange == 'kraken':
+        return pair
+    if exchange == 'okx':
+        return f'{crypto}-{fiat}'
+    if exchange == 'bitfinex':
+        fiat_bf = 'UST' if fiat == 'USDT' else fiat
+        return f't{crypto}{fiat_bf}'
+    if exchange == 'bitmex':
+        xbt = 'XBT' if crypto == 'BTC' else crypto
+        return xbt + fiat
+    raise ValueError(f'exchange {exchange!r} is not supported for streaming')
+
+
+def _process_fn(channels: list[str]) -> Any:
+    """ Return the appropriate ``process_data`` function for *channels*.
+
+    Parameters
+    ----------
+    channels : list of str
+        Channel names (``'trades'``, ``'book'``, …).
+
+    Returns
+    -------
+    callable
+        One of :func:`~dccd.process_data.set_trades`,
+        :func:`~dccd.process_data.set_marketdepth`,
+        :func:`~dccd.process_data.set_orders`.
+
+    """
+    has_trades = 'trades' in channels
+    has_book   = 'book'   in channels
+    if has_trades and has_book:
+        return set_orders
+    if has_trades:
+        return set_trades
+    if has_book:
+        return set_marketdepth
+    return set_orders
+
+
+def _connect_kwargs(exchange: str, pair: str, channels: list[str]) -> dict[str, Any]:
+    """ Return keyword arguments to pass to ``downloader._connect()``.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange name.
+    pair : str
+        Trading pair in ``'CRYPTO/FIAT'`` format.
+    channels : list of str
+        Channel(s) for this thread (singleton for Bitfinex/Bitmex).
+
+    Returns
+    -------
+    dict
+        Empty for exchanges that embed subscription in ``__init__``;
+        channel/symbol kwargs for Bitfinex; ``args`` string for Bitmex.
+
+    """
+    ch = channels[0]
+    if exchange == 'bitfinex':
+        return {'channel': _BITFINEX_CHANNEL.get(ch, ch),
+                'symbol':  _format_pair('bitfinex', pair)}
+    if exchange == 'bitmex':
+        bch = _BITMEX_CHANNEL.get(ch, ch)
+        return {'args': f'{bch}:{_format_pair("bitmex", pair)}'}
+    return {}
+
+
+def _iter_tasks(job: StreamJob) -> Iterator[tuple[str, list[str]]]:
+    """ Yield ``(pair, channels)`` for each thread to create.
+
+    Bitfinex and Bitmex have one WS connection per channel, so each
+    ``(pair, channel)`` pair gets its own thread.  All other exchanges
+    handle multiple channels in one connection.
+
+    Parameters
+    ----------
+    job : StreamJob
+        Stream job configuration.
+
+    Yields
+    ------
+    pair : str
+    channels : list of str
+
+    """
+    if job.exchange in _PER_CHANNEL_EXCHANGES:
+        for pair in job.pairs:
+            for ch in job.channels:
+                yield pair, [ch]
+    else:
+        for pair in job.pairs:
+            yield pair, job.channels
+
+
+# ---------------------------------------------------------------------------
+# SyncService
+# ---------------------------------------------------------------------------
+
+class SyncService:
+    """ Periodically push the entire local data directory to all remotes.
+
+    This is the single point of truth for remote synchronisation.  Neither
+    histo jobs nor stream threads push data themselves — they save locally
+    and rely on this service to replicate to remote destinations.
+
+    Parameters
+    ----------
+    config : StorageConfig
+        Storage configuration (``remotes`` list + ``sync_interval``).
+
+    Notes
+    -----
+    If ``config.remotes`` is empty or ``config.sync_interval`` is 0, the
+    service is a no-op and no background thread is started.
+
+    """
+
+    def __init__(self, config: StorageConfig) -> None:
+        self.config = config
+        self._storage = RemoteStorage(config)
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """ Start the background sync thread (idempotent). """
+        if not self.config.remotes or self.config.sync_interval <= 0:
+            logger.info(
+                'SyncService disabled (remotes=%d, sync_interval=%d)',
+                len(self.config.remotes), self.config.sync_interval,
+            )
+            return
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True, name='sync-service',
+        )
+        self._thread.start()
+        logger.info('SyncService started (interval=%ds)', self.config.sync_interval)
+
+    def stop(self) -> None:
+        """ Signal the sync thread to stop at the next interval boundary. """
+        self._stop.set()
+
+    def sync_now(self) -> None:
+        """ Push ``local_path`` to all remotes immediately (blocking). """
+        self._storage.push(self.config.local_path)
+
+    def _loop(self) -> None:
+        while not self._stop.wait(timeout=self.config.sync_interval):
+            try:
+                self.sync_now()
+            except Exception:
+                logger.exception('SyncService: sync failed')
+
+
+# ---------------------------------------------------------------------------
+# StreamManager
+# ---------------------------------------------------------------------------
+
+class StreamManager:
+    """ Manage real-time WebSocket collection jobs.
+
+    Starts one background thread per ``(exchange, pair)`` (or per
+    ``(exchange, pair, channel)`` for Bitfinex/Bitmex).  Each thread
+    runs indefinitely and is automatically restarted after a crash.
+    A :class:`SyncService` instance pushes data to remotes periodically.
+
+    Parameters
+    ----------
+    config : CollectorConfig
+        Daemon configuration (``stream_jobs`` + ``storage``).
+
+    """
+
+    def __init__(self, config: CollectorConfig) -> None:
+        self.config = config
+        self._threads:     dict[str, threading.Thread]     = {}
+        self._downloaders: dict[str, ContinuousDownloader] = {}
+        self._stop_event = threading.Event()
+        self._sync = SyncService(config.storage)
+
+    def start(self) -> None:
+        """ Start the sync service and all stream threads. """
+        self._sync.start()
+        for job in self.config.stream_jobs:
+            for pair, channels in _iter_tasks(job):
+                ch_tag = '_'.join(channels)
+                key = f'{job.exchange}_{pair.replace("/", "_")}_{ch_tag}'
+                t = threading.Thread(
+                    target=self._run_forever,
+                    args=(job, pair, channels),
+                    name=key,
+                    daemon=True,
+                )
+                self._threads[key] = t
+                t.start()
+                logger.info('stream started: %s %s channels=%s', job.exchange, pair, channels)
+
+    def stop(self) -> None:
+        """ Signal all streams and the sync service to stop. """
+        self._stop_event.set()
+        self._sync.stop()
+        for dl in self._downloaders.values():
+            dl.until = time.time()
+            dl.is_connect = False
+
+    # ------------------------------------------------------------------
+    # Thread body
+    # ------------------------------------------------------------------
+
+    def _run_forever(self, job: StreamJob, pair: str, channels: list[str]) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._run_once(job, pair, channels)
+            except Exception:
+                logger.exception('stream crashed: %s %s', job.exchange, pair)
+            if not self._stop_event.is_set():
+                self._stop_event.wait(timeout=_RESTART_DELAY)
+
+    def _run_once(self, job: StreamJob, pair: str, channels: list[str]) -> None:
+        cls = _STREAM_CLASSES[job.exchange]
+
+        # Bitfinex/Bitmex do not take pair in __init__; they receive it
+        # via _connect() kwargs.  All other exchanges set the pair in __init__.
+        if job.exchange in _PER_CHANNEL_EXCHANGES:
+            downloader: ContinuousDownloader = cls(
+                time_step=job.time_step, until=0,
+            )
+            # self.parser must be initialised before _loop() / on_message()
+            ch_map = _BITFINEX_CHANNEL if job.exchange == 'bitfinex' else _BITMEX_CHANNEL
+            ch_key = ch_map.get(channels[0], channels[0])
+            downloader.parser = downloader.get_parser(ch_key)  # type: ignore[attr-defined]
+        else:
+            downloader = cls(
+                pair=_format_pair(job.exchange, pair),
+                time_step=job.time_step,
+                until=0,
+            )
+
+        ch_tag = '_'.join(channels)
+        key = f'{job.exchange}_{pair.replace("/", "_")}_{ch_tag}'
+        self._downloaders[key] = downloader
+
+        xch = job.exchange.capitalize()
+        save_path = (
+            f'{self.config.storage.local_path.rstrip("/")}'
+            f'/{xch}/Data/WS_Data/{job.time_step}s/{pair.replace("/", "_")}'
+        )
+
+        downloader.set_process_data(_process_fn(channels))
+        downloader.set_saver(IODataBase(save_path, method='csv'))
+
+        conn_kw = _connect_kwargs(job.exchange, pair, channels)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(asyncio.gather(
+                downloader._connect(**conn_kw),
+                downloader._loop(),
+            ))
+        finally:
+            loop.close()
+            self._downloaders.pop(key, None)
+            logger.info('stream ended: %s %s', job.exchange, pair)

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -34,6 +34,7 @@ from dccd.tools.io import IODataBase
 
 if TYPE_CHECKING:
     from dccd.daemon.config import CollectorConfig, StorageConfig, StreamJob
+    from dccd.daemon.health import HealthMonitor
 
 __all__ = ['StreamManager', 'SyncService']
 
@@ -265,8 +266,10 @@ class StreamManager:
 
     """
 
-    def __init__(self, config: CollectorConfig) -> None:
+    def __init__(self, config: CollectorConfig,
+                 health: HealthMonitor | None = None) -> None:
         self.config = config
+        self._health = health
         self._threads:     dict[str, threading.Thread]     = {}
         self._downloaders: dict[str, ContinuousDownloader] = {}
         self._stop_event = threading.Event()
@@ -305,8 +308,12 @@ class StreamManager:
         while not self._stop_event.is_set():
             try:
                 self._run_once(job, pair, channels)
+                if self._health:
+                    self._health.record_success(job.exchange, pair)
             except Exception:
                 logger.exception('stream crashed: %s %s', job.exchange, pair)
+                if self._health:
+                    self._health.record_failure(job.exchange, pair)
             if not self._stop_event.is_set():
                 self._stop_event.wait(timeout=_RESTART_DELAY)
 

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -11,7 +11,7 @@
 .. currentmodule:: dccd.histo_dl.binance
 
 .. autoclass:: FromBinance
-   :members: import_data, save, get_data
+   :members: import_data, save, get_data, import_trades, save_trades, import_orderbook, save_orderbook
    :show-inheritance:
 
 """
@@ -82,6 +82,10 @@ class FromBinance(ImportDataCryptoCurrencies):
     import_data
     save
     get_data
+    import_trades
+    save_trades
+    import_orderbook
+    save_orderbook
 
     """
 
@@ -145,6 +149,35 @@ class FromBinance(ImportDataCryptoCurrencies):
         } for e in text]
 
         return data
+
+    def _import_trades(self, start: int, end: int) -> list[dict[str, Any]]:
+        param = {
+            'symbol': self.pair,
+            'startTime': start * 1000,
+            'endTime': end * 1000,
+            'limit': 1000,
+        }
+        r = self._fetch('https://api.binance.com/api/v3/aggTrades', param)
+        return [{
+            'tid': int(e['a']),
+            'timestamp': float(e['T']) / 1000,
+            'price': float(e['p']),
+            'amount': float(e['q']),
+            'type': 'sell' if e['m'] else 'buy',
+        } for e in r.json()]
+
+    def _import_orderbook(self, depth: int = 50) -> list[dict[str, Any]]:
+        r = self._fetch(
+            'https://api.binance.com/api/v3/depth',
+            {'symbol': self.pair, 'limit': depth},
+        )
+        book = r.json()
+        result = []
+        for bid in book['bids']:
+            result.append({'side': 'bid', 'price': bid[0], 'amount': float(bid[1]), 'count': None})
+        for ask in book['asks']:
+            result.append({'side': 'ask', 'price': ask[0], 'amount': float(ask[1]), 'count': None})
+        return result
 
     def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from Binance for specific time interval.

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -85,6 +85,25 @@ class FromBinance(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Binance pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USDT'``).
+
+        Returns
+        -------
+        str
+            Concatenated pair (e.g. ``'BTCUSDT'``).
+
+        """
+        if crypto == 'XBT':
+            crypto = 'BTC'
+        return crypto + fiat
+
     def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
         """ Initialize object. """
         if fiat in ['EUR', 'USD']:
@@ -94,14 +113,11 @@ class FromBinance(ImportDataCryptoCurrencies):
             )
             self.fiat = fiat = 'USDT'
 
-        if crypto == 'XBT':
-            crypto = 'BTC'
-
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Binance', fiat, form
         )
 
-        self.pair = crypto + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Binance/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -6,7 +6,7 @@
 .. currentmodule:: dccd.histo_dl.bybit
 
 .. autoclass:: FromBybit
-   :members: import_data, save, get_data
+   :members: import_data, save, get_data, import_trades, save_trades, import_orderbook, save_orderbook
    :show-inheritance:
 
 """
@@ -100,6 +100,10 @@ class FromBybit(ImportDataCryptoCurrencies):
     import_data
     save
     get_data
+    import_trades
+    save_trades
+    import_orderbook
+    save_orderbook
 
     """
 
@@ -156,6 +160,41 @@ class FromBybit(ImportDataCryptoCurrencies):
         } for e in text]
 
         return data
+
+    def _import_trades(self, start: int, end: int) -> list[dict[str, Any]]:
+        """ Fetch the most recent trades from Bybit (recent data only).
+
+        Notes
+        -----
+        The Bybit public REST API returns up to 1 000 of the most recent trades
+        regardless of ``start``/``end``.  Historical trades are not available
+        via this endpoint.
+
+        """
+        r = self._fetch(
+            'https://api.bybit.com/v5/market/recent-trade',
+            {'category': 'spot', 'symbol': self.pair, 'limit': 1000},
+        )
+        return [{
+            'tid': None,
+            'timestamp': float(e['time']) / 1000,
+            'price': float(e['price']),
+            'amount': float(e['size']),
+            'type': 'buy' if e['side'] == 'Buy' else 'sell',
+        } for e in r.json()['result']['list']]
+
+    def _import_orderbook(self, depth: int = 50) -> list[dict[str, Any]]:
+        r = self._fetch(
+            'https://api.bybit.com/v5/market/orderbook',
+            {'category': 'spot', 'symbol': self.pair, 'limit': depth},
+        )
+        book = r.json()['result']
+        result = []
+        for bid in book['b']:
+            result.append({'side': 'bid', 'price': bid[0], 'amount': float(bid[1]), 'count': None})
+        for ask in book['a']:
+            result.append({'side': 'ask', 'price': ask[0], 'amount': float(ask[1]), 'count': None})
+        return result
 
     def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from Bybit for a specific time interval.

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -103,12 +103,29 @@ class FromBybit(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Bybit pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USDT'``).
+
+        Returns
+        -------
+        str
+            Concatenated pair (e.g. ``'BTCUSDT'``).
+
+        """
+        return crypto + fiat
+
     def __init__(self, path, crypto, span, fiat='USDT', form='xlsx'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Bybit', fiat, form
         )
-        self.pair = crypto + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Bybit/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -11,7 +11,7 @@
 .. currentmodule:: dccd.histo_dl.coinbase
 
 .. autoclass:: FromCoinbase
-   :members: import_data, save, get_data
+   :members: import_data, save, get_data, import_trades, save_trades, import_orderbook, save_orderbook
    :show-inheritance:
 
 """
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 # Import built-in packages
+from datetime import datetime, timezone
 from typing import Any
 
 # Import third party packages
@@ -80,6 +81,10 @@ class FromCoinbase(ImportDataCryptoCurrencies):
     import_data
     save
     get_data
+    import_trades
+    save_trades
+    import_orderbook
+    save_orderbook
 
     """
 
@@ -136,6 +141,47 @@ class FromCoinbase(ImportDataCryptoCurrencies):
         } for e in text]
 
         return data
+
+    def _import_trades(self, start: int, end: int) -> list[dict[str, Any]]:
+        """ Fetch recent trades from Coinbase (recent data only).
+
+        Notes
+        -----
+        The Coinbase Exchange public REST API returns up to 100 recent trades.
+        Deep historical trades are not available without authenticated
+        pagination.
+
+        """
+        r = self._fetch(
+            f'https://api.exchange.coinbase.com/products/{self.pair}/trades',
+            {'limit': 100},
+        )
+        result = []
+        for e in r.json():
+            ts = datetime.fromisoformat(
+                e['time'].replace('Z', '+00:00')
+            ).replace(tzinfo=timezone.utc).timestamp()
+            result.append({
+                'tid': int(e['trade_id']),
+                'timestamp': float(ts),
+                'price': float(e['price']),
+                'amount': float(e['size']),
+                'type': e['side'],
+            })
+        return result
+
+    def _import_orderbook(self, depth: int = 50) -> list[dict[str, Any]]:
+        r = self._fetch(
+            f'https://api.exchange.coinbase.com/products/{self.pair}/book',
+            {'level': 2},
+        )
+        book = r.json()
+        result = []
+        for bid in book['bids']:
+            result.append({'side': 'bid', 'price': bid[0], 'amount': float(bid[1]), 'count': int(bid[2]) if len(bid) > 2 else None})
+        for ask in book['asks']:
+            result.append({'side': 'ask', 'price': ask[0], 'amount': float(ask[1]), 'count': int(ask[2]) if len(ask) > 2 else None})
+        return result
 
     def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from Coinbase for specific time interval.

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -83,14 +83,31 @@ class FromCoinbase(ImportDataCryptoCurrencies):
 
     """
 
-    def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
-        """ Initialize object. """
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Coinbase pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USD'``).
+
+        Returns
+        -------
+        str
+            Dash-separated pair (e.g. ``'BTC-USD'``).
+
+        """
         if crypto == 'XBT':
             crypto = 'BTC'
+        return crypto + '-' + fiat
+
+    def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
+        """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Coinbase', fiat, form
         )
-        self.pair = crypto + '-' + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Coinbase/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/histo_dl/exchange.py
+++ b/dccd/histo_dl/exchange.py
@@ -31,7 +31,7 @@ import requests
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 # Import local packages
-from dccd.models import OHLCBar
+from dccd.models import OHLCBar, OrderBookEntry, Trade
 from dccd.tools.date_time import TS_to_date, date_to_TS, span_to_str, str_to_span
 
 if TYPE_CHECKING:
@@ -86,12 +86,20 @@ class ImportDataCryptoCurrencies(ABC):
         Path to save data.
     form : str
         Format to save data.
+    trades_df : pd.DataFrame
+        Trades data after calling :meth:`import_trades`.
+    orderbook_df : pd.DataFrame
+        Order book snapshot after calling :meth:`import_orderbook`.
 
     Methods
     -------
     import_data
     save
     get_data
+    import_trades
+    save_trades
+    import_orderbook
+    save_orderbook
 
     """
 
@@ -105,7 +113,11 @@ class ImportDataCryptoCurrencies(ABC):
         self.pair = str(crypto + fiat)
         self.full_path = self.path + '/' + platform + '/Data/Clean_Data/'
         self.full_path += str(self.per) + '/' + self.pair
+        self.trades_path = self.path + '/' + platform + '/Data/Trades/' + self.pair
+        self.orderbook_path = self.path + '/' + platform + '/Data/OrderBook/' + self.pair
         self.last_df = pd.DataFrame()
+        self.trades_df: pd.DataFrame = pd.DataFrame()
+        self.orderbook_df: pd.DataFrame = pd.DataFrame()
         self.form = form
         self.start: int = 0
         self.end: int = 0
@@ -385,6 +397,256 @@ class ImportDataCryptoCurrencies(ABC):
     @abstractmethod
     def _import_data(self, start: int | str, end: int | str) -> list[dict[str, Any]]:
         """ Fetch raw data from the exchange (implemented by subclasses). """
+
+    # ------------------------------------------------------------------
+    # Trades — public API
+    # ------------------------------------------------------------------
+
+    def import_trades(
+        self, start: int | str = 0, end: int | str = 'now'
+    ) -> ImportDataCryptoCurrencies:
+        """ Fetch individual trades for a time window.
+
+        Downloads executed trades from the exchange REST API, validates each
+        record, and stores the result in :attr:`trades_df`.  Use
+        :meth:`save_trades` to persist to disk.
+
+        Parameters
+        ----------
+        start : int or str, optional
+            Start of the time window.  Accepts a Unix timestamp (int), a date
+            string ``'yyyy-mm-dd hh:mm:ss'``, or ``0`` (default, meaning "as
+            far back as the API allows").
+        end : int or str, optional
+            End of the time window.  ``'now'`` (default) resolves to the
+            current UTC time.  Accepts a Unix timestamp or date string.
+
+        Returns
+        -------
+        ImportDataCryptoCurrencies
+            Returns ``self`` for method chaining.
+
+        Notes
+        -----
+        Exchanges vary in how much history they expose:
+
+        - **Binance** and **Kraken** provide full paginated history.
+        - **OKX** exposes several months of history via cursor pagination.
+        - **Bybit** returns the ~1 000 most recent trades regardless of
+          ``start``/``end``.
+        - **Coinbase** returns up to 100 recent trades (cursor-based,
+          no deep history).
+
+        """
+        _start: int | float = date_to_TS(start) if isinstance(start, str) else start
+        if end == 'now':
+            _end: int | float = time.time()
+        elif isinstance(end, str):
+            _end = date_to_TS(end)
+        else:
+            _end = end
+        data = self._import_trades(int(_start), int(_end))
+        return self._sort_trades(data)
+
+    def _import_trades(self, start: int, end: int) -> list[dict[str, Any]]:
+        """ Fetch raw trades from the exchange (override in subclasses).
+
+        Parameters
+        ----------
+        start : int
+            Start Unix timestamp (seconds).
+        end : int
+            End Unix timestamp (seconds).
+
+        Returns
+        -------
+        list of dict
+            Each dict must contain: ``tid``, ``timestamp``, ``price``,
+            ``amount``, ``type``.
+
+        Raises
+        ------
+        NotImplementedError
+            If the subclass has not implemented this method.
+
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__} does not implement _import_trades'
+        )
+
+    def _sort_trades(self, data: list[dict[str, Any]]) -> ImportDataCryptoCurrencies:
+        """ Validate, sort, and deduplicate raw trade records.
+
+        Parameters
+        ----------
+        data : list of dict
+            Raw trade records as returned by :meth:`_import_trades`.
+
+        Returns
+        -------
+        ImportDataCryptoCurrencies
+            Returns ``self`` to allow method chaining.
+
+        """
+        validated = [Trade(**d).model_dump() for d in data]
+        df = pd.DataFrame(validated).rename(columns={'timestamp': 'TS'})
+        df = df.sort_values('TS').reset_index(drop=True)
+        if not df.empty and df['tid'].notna().any():
+            df = df.drop_duplicates(subset='tid', keep='last').reset_index(drop=True)
+        self.trades_df = df
+        return self
+
+    def save_trades(
+        self, form: str = 'csv', by_period: str = 'M'
+    ) -> ImportDataCryptoCurrencies:
+        """ Save :attr:`trades_df` grouped by period to :attr:`trades_path`.
+
+        Files are named ``trades_{crypto}{fiat}_{period}.{form}``.  No
+        forward-fill is applied — trades are sparse event data.
+
+        Parameters
+        ----------
+        form : {'csv', 'parquet'}, optional
+            Output format, default ``'csv'``.
+        by_period : {'Y', 'M', 'D'}, optional
+            Period label for file grouping, default ``'M'``.
+
+        Returns
+        -------
+        ImportDataCryptoCurrencies
+            Returns ``self`` to allow method chaining.
+
+        """
+        if self.trades_df.empty:
+            return self
+        pathlib.Path(self.trades_path).mkdir(parents=True, exist_ok=True)
+
+        def _period_label(ts: float) -> str:
+            return TS_to_date(int(ts), form='%' + by_period)
+
+        grouped = self.trades_df.groupby(
+            self.trades_df['TS'].map(_period_label)
+        )
+        for name, group in grouped:
+            fname = (
+                f'{self.trades_path}/trades_{self.crypto}{self.fiat}_{name}.{form}'
+            )
+            if form == 'parquet':
+                group.to_parquet(fname, index=False)
+            else:
+                group.to_csv(fname, index=False)
+        return self
+
+    # ------------------------------------------------------------------
+    # Order book — public API
+    # ------------------------------------------------------------------
+
+    def import_orderbook(self, depth: int = 50) -> ImportDataCryptoCurrencies:
+        """ Fetch the current order book snapshot at a given depth.
+
+        Downloads the bid/ask ladder from the exchange REST API, validates
+        each level, and stores the result in :attr:`orderbook_df`.  Use
+        :meth:`save_orderbook` to persist to disk.
+
+        Parameters
+        ----------
+        depth : int, optional
+            Number of price levels to fetch per side (bids + asks), default
+            50.  Maximum varies by exchange.
+
+        Returns
+        -------
+        ImportDataCryptoCurrencies
+            Returns ``self`` for method chaining.
+
+        Notes
+        -----
+        Order book REST endpoints return a **current snapshot** only.
+        Historical order book data is not available via public APIs.
+
+        """
+        data = self._import_orderbook(depth)
+        return self._sort_orderbook(data)
+
+    def _import_orderbook(self, depth: int) -> list[dict[str, Any]]:
+        """ Fetch the raw order book from the exchange (override in subclasses).
+
+        Parameters
+        ----------
+        depth : int
+            Number of price levels per side.
+
+        Returns
+        -------
+        list of dict
+            Each dict must contain: ``side``, ``price``, ``amount``, ``count``.
+
+        Raises
+        ------
+        NotImplementedError
+            If the subclass has not implemented this method.
+
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__} does not implement _import_orderbook'
+        )
+
+    def _sort_orderbook(self, data: list[dict[str, Any]]) -> ImportDataCryptoCurrencies:
+        """ Validate and sort raw order book levels.
+
+        Bids are sorted descending by price; asks ascending.
+
+        Parameters
+        ----------
+        data : list of dict
+            Raw order book levels as returned by :meth:`_import_orderbook`.
+
+        Returns
+        -------
+        ImportDataCryptoCurrencies
+            Returns ``self`` to allow method chaining.
+
+        """
+        validated = [OrderBookEntry(**d).model_dump() for d in data]
+        df = pd.DataFrame(validated)
+        df['_p'] = df['price'].astype(float)
+        bids = df[df['side'] == 'bid'].sort_values('_p', ascending=False)
+        asks = df[df['side'] == 'ask'].sort_values('_p', ascending=True)
+        self.orderbook_df = (
+            pd.concat([bids, asks]).drop('_p', axis=1).reset_index(drop=True)
+        )
+        return self
+
+    def save_orderbook(self, form: str = 'csv') -> ImportDataCryptoCurrencies:
+        """ Save :attr:`orderbook_df` as a timestamped snapshot file.
+
+        Files are named ``orderbook_{crypto}{fiat}_{unix_ts}.{form}``.
+
+        Parameters
+        ----------
+        form : {'csv', 'parquet'}, optional
+            Output format, default ``'csv'``.
+
+        Returns
+        -------
+        ImportDataCryptoCurrencies
+            Returns ``self`` to allow method chaining.
+
+        """
+        if self.orderbook_df.empty:
+            return self
+        pathlib.Path(self.orderbook_path).mkdir(parents=True, exist_ok=True)
+        ts = int(time.time())
+        fname = (
+            f'{self.orderbook_path}/orderbook_{self.crypto}{self.fiat}_{ts}.{form}'
+        )
+        if form == 'parquet':
+            self.orderbook_df.to_parquet(fname, index=False)
+        else:
+            self.orderbook_df.to_csv(fname, index=False)
+        return self
+
+    # ------------------------------------------------------------------
 
     def set_hierarchy(self, liste: list[str]) -> None:
         """ Override the default save path with a custom directory hierarchy.

--- a/dccd/histo_dl/kraken.py
+++ b/dccd/histo_dl/kraken.py
@@ -11,7 +11,7 @@
 .. currentmodule:: dccd.histo_dl.kraken
 
 .. autoclass:: FromKraken
-   :members: import_data, save, get_data
+   :members: import_data, save, get_data, import_trades, save_trades, import_orderbook, save_orderbook
    :show-inheritance:
 
 """
@@ -78,6 +78,10 @@ class FromKraken(ImportDataCryptoCurrencies):
     import_data
     save
     get_data
+    import_trades
+    save_trades
+    import_orderbook
+    save_orderbook
 
     """
 
@@ -155,6 +159,33 @@ class FromKraken(ImportDataCryptoCurrencies):
         } for e in text]
 
         return data
+
+    def _import_trades(self, start: int, end: int) -> list[dict[str, Any]]:
+        r = self._fetch(
+            'https://api.kraken.com/0/public/Trades',
+            {'pair': self.pair, 'since': start},
+        )
+        trades = r.json()['result'][self.pair]
+        return [{
+            'tid': None,
+            'timestamp': float(e[2]),
+            'price': float(e[0]),
+            'amount': float(e[1]),
+            'type': 'buy' if e[3] == 'b' else 'sell',
+        } for e in trades if float(e[2]) <= end]
+
+    def _import_orderbook(self, depth: int = 50) -> list[dict[str, Any]]:
+        r = self._fetch(
+            'https://api.kraken.com/0/public/Depth',
+            {'pair': self.pair, 'count': depth},
+        )
+        book = r.json()['result'][self.pair]
+        result = []
+        for bid in book['bids']:
+            result.append({'side': 'bid', 'price': str(bid[0]), 'amount': float(bid[1]), 'count': None})
+        for ask in book['asks']:
+            result.append({'side': 'ask', 'price': str(ask[0]), 'amount': float(ask[1]), 'count': None})
+        return result
 
     def import_data(
         self, start: int | str = 'last', end: int | str | None = None

--- a/dccd/histo_dl/kraken.py
+++ b/dccd/histo_dl/kraken.py
@@ -81,22 +81,46 @@ class FromKraken(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the Kraken pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols using common names (e.g. ``'BTC'``, ``'USD'``).
+
+        Returns
+        -------
+        str
+            Kraken pair string, e.g. ``'XXBTZUSD'``, ``'BCHUSD'``, or
+            ``'XXMRXXBT'`` for cross-crypto pairs.
+
+        Notes
+        -----
+        Rules applied in order:
+
+        1. ``'BTC'`` is renamed to ``'XBT'`` (Kraken convention).
+        2. ``'BCH'`` and ``'DASH'`` are exempt from the X/Z prefix scheme.
+        3. Major fiats (EUR, USD, CAD, JPY, GBP) use ``X<crypto>Z<fiat>``.
+        4. All other fiats (incl. crypto quoted in crypto) use
+           ``X<crypto>X<fiat>``.
+
+        """
+        if crypto == 'BTC':
+            crypto = 'XBT'
+        if crypto in ('BCH', 'DASH'):
+            return crypto + fiat
+        if fiat not in ('EUR', 'USD', 'CAD', 'JPY', 'GBP'):
+            return 'X' + crypto + 'X' + fiat
+        return 'X' + crypto + 'Z' + fiat
+
     def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'Kraken', fiat=fiat, form=form
         )
-        if crypto == 'BTC':
-            crypto = 'XBT'
-
-        if crypto == 'BCH' or crypto == 'DASH':
-            self.pair = crypto + fiat
-
-        elif fiat not in ['EUR', 'USD', 'CAD', 'JPY', 'GBP']:
-            self.pair = 'X' + crypto + 'X' + fiat
-
-        else:
-            self.pair = 'X' + crypto + 'Z' + fiat
+        self.pair = self.format_pair(crypto, fiat)
 
     def _import_data(
         self, start: int | str = 'last', end: int | str | None = None

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -103,12 +103,29 @@ class FromOKX(ImportDataCryptoCurrencies):
 
     """
 
+    @staticmethod
+    def format_pair(crypto: str, fiat: str) -> str:
+        """ Return the OKX pair symbol for *crypto* and *fiat*.
+
+        Parameters
+        ----------
+        crypto, fiat : str
+            Asset symbols (e.g. ``'BTC'``, ``'USDT'``).
+
+        Returns
+        -------
+        str
+            Dash-separated pair (e.g. ``'BTC-USDT'``).
+
+        """
+        return crypto + '-' + fiat
+
     def __init__(self, path, crypto, span, fiat='USDT', form='xlsx'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
             self, path, crypto, span, 'OKX', fiat, form
         )
-        self.pair = crypto + '-' + fiat
+        self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/OKX/Data/Clean_Data/'
         self.full_path += self.per + '/' + self.crypto + self.fiat
 

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -6,7 +6,7 @@
 .. currentmodule:: dccd.histo_dl.okx
 
 .. autoclass:: FromOKX
-   :members: import_data, save, get_data
+   :members: import_data, save, get_data, import_trades, save_trades, import_orderbook, save_orderbook
    :show-inheritance:
 
 """
@@ -100,6 +100,10 @@ class FromOKX(ImportDataCryptoCurrencies):
     import_data
     save
     get_data
+    import_trades
+    save_trades
+    import_orderbook
+    save_orderbook
 
     """
 
@@ -155,6 +159,34 @@ class FromOKX(ImportDataCryptoCurrencies):
         } for e in text]
 
         return data
+
+    def _import_trades(self, start: int, end: int) -> list[dict[str, Any]]:
+        r = self._fetch(
+            'https://www.okx.com/api/v5/market/trades',
+            {'instId': self.pair, 'limit': 500},
+        )
+        return [{
+            'tid': int(e['tradeId']),
+            'timestamp': float(e['ts']) / 1000,
+            'price': float(e['px']),
+            'amount': float(e['sz']),
+            'type': e['side'],
+        } for e in r.json()['data']]
+
+    def _import_orderbook(self, depth: int = 50) -> list[dict[str, Any]]:
+        r = self._fetch(
+            'https://www.okx.com/api/v5/market/books',
+            {'instId': self.pair, 'sz': depth},
+        )
+        book = r.json()['data'][0]
+        result = []
+        for bid in book['bids']:
+            count = int(bid[3]) if bid[3] else None
+            result.append({'side': 'bid', 'price': bid[0], 'amount': float(bid[1]), 'count': count})
+        for ask in book['asks']:
+            count = int(ask[3]) if ask[3] else None
+            result.append({'side': 'ask', 'price': ask[0], 'amount': float(ask[1]), 'count': count})
+        return result
 
     def import_data(self, start: int | str = 'last', end: int | str = 'now') -> ImportDataCryptoCurrencies:
         """ Download data from OKX for a specific time interval.

--- a/dccd/models.py
+++ b/dccd/models.py
@@ -37,12 +37,13 @@ class OHLCBar(BaseModel):
 
 
 class Trade(BaseModel):
-    """ Individual trade returned by WebSocket streams.
+    """ Individual trade from WebSocket streams or REST history endpoints.
 
     Parameters
     ----------
-    tid : int
-        Trade ID.
+    tid : int or None
+        Trade ID.  ``None`` when the exchange does not provide an integer ID
+        (e.g. Kraken, Bybit).
     timestamp : float
         Unix timestamp (seconds).
     price : float
@@ -50,11 +51,11 @@ class Trade(BaseModel):
     amount : float
         Trade size (base asset).
     type : str, optional
-        'buy' or 'sell'.
+        ``'buy'`` or ``'sell'``.
 
     """
 
-    tid: int
+    tid: int | None = None
     timestamp: float
     price: float
     amount: float
@@ -62,19 +63,23 @@ class Trade(BaseModel):
 
 
 class OrderBookEntry(BaseModel):
-    """ Single order book entry from WebSocket streams.
+    """ Single order book level from REST snapshot or WebSocket streams.
 
     Parameters
     ----------
+    side : str
+        ``'bid'`` or ``'ask'``.
     price : str
-        Price level as string key.
-    count : int
-        Number of orders at this level.
+        Price level as a string (preserves precision).
     amount : float
-        Total size at this level.
+        Total quantity available at this level.
+    count : int or None
+        Number of open orders at this level.  ``None`` when the exchange does
+        not provide this information (e.g. Binance, Kraken).
 
     """
 
+    side: str
     price: str
-    count: int
     amount: float
+    count: int | None = None

--- a/dccd/tests/conftest.py
+++ b/dccd/tests/conftest.py
@@ -71,6 +71,124 @@ def mock_okx(monkeypatch):
     monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
 
 
+# ---------------------------------------------------------------------------
+# Trades mocks
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_binance_trades(monkeypatch):
+    payload = [
+        {'a': 1, 'T': _TS * 1000, 'p': '50000', 'q': '0.1', 'm': False},
+        {'a': 2, 'T': (_TS + 1) * 1000, 'p': '50100', 'q': '0.2', 'm': True},
+    ]
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_kraken_trades(monkeypatch):
+    payload = {
+        'result': {
+            'XXBTZUSD': [
+                ['50000', '0.1', float(_TS), 'b', 'l', '', 1],
+                ['50100', '0.2', float(_TS + 1), 's', 'l', '', 2],
+            ],
+            'last': str(_TS + 1),
+        }
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_bybit_trades(monkeypatch):
+    payload = {
+        'result': {
+            'list': [
+                {'time': str(_TS * 1000), 'price': '50000', 'size': '0.1', 'side': 'Buy'},
+                {'time': str((_TS + 1) * 1000), 'price': '50100', 'size': '0.2', 'side': 'Sell'},
+            ]
+        }
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_okx_trades(monkeypatch):
+    payload = {
+        'data': [
+            {'tradeId': '1001', 'ts': str(_TS * 1000), 'px': '50000', 'sz': '0.1', 'side': 'buy'},
+            {'tradeId': '1002', 'ts': str((_TS + 1) * 1000), 'px': '50100', 'sz': '0.2', 'side': 'sell'},
+        ]
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_coinbase_trades(monkeypatch):
+    payload = [
+        {'trade_id': 1, 'time': '2025-05-01T00:00:00Z', 'price': '50000', 'size': '0.1', 'side': 'buy'},
+        {'trade_id': 2, 'time': '2025-05-01T00:00:01Z', 'price': '50100', 'size': '0.2', 'side': 'sell'},
+    ]
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+# ---------------------------------------------------------------------------
+# Order book mocks
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_binance_depth(monkeypatch):
+    payload = {
+        'bids': [['50000', '1.0'], ['49900', '2.0']],
+        'asks': [['50100', '0.5'], ['50200', '1.5']],
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_kraken_depth(monkeypatch):
+    payload = {
+        'result': {
+            'XXBTZUSD': {
+                'bids': [['50000', '1.0', _TS], ['49900', '2.0', _TS]],
+                'asks': [['50100', '0.5', _TS], ['50200', '1.5', _TS]],
+            }
+        }
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_bybit_orderbook(monkeypatch):
+    payload = {
+        'result': {
+            'b': [['50000', '1.0'], ['49900', '2.0']],
+            'a': [['50100', '0.5'], ['50200', '1.5']],
+        }
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_okx_books(monkeypatch):
+    payload = {
+        'data': [{
+            'bids': [['50000', '1.0', '0', '2'], ['49900', '2.0', '0', '3']],
+            'asks': [['50100', '0.5', '0', '1'], ['50200', '1.5', '0', '4']],
+            'ts': str(_TS * 1000),
+        }]
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
+@pytest.fixture
+def mock_coinbase_book(monkeypatch):
+    payload = {
+        'bids': [['50000', '1.0', 2], ['49900', '2.0', 1]],
+        'asks': [['50100', '0.5', 1], ['50200', '1.5', 3]],
+    }
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_response(payload))
+
+
 @pytest.fixture
 def mock_http_500(monkeypatch):
     """Simulate an HTTP 500 response whose body is not valid JSON."""

--- a/dccd/tests/test_binance.py
+++ b/dccd/tests/test_binance.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromBinance as fb
+from dccd.histo_dl.binance import FromBinance
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC',  'USDT', 'BTCUSDT'),
+    ('ETH',  'USDT', 'ETHUSDT'),
+    ('XBT',  'USDT', 'BTCUSDT'),  # XBT alias → BTC
+])
+def test_format_pair(crypto, fiat, expected):
+    assert FromBinance.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_binance.py
+++ b/dccd/tests/test_binance.py
@@ -9,6 +9,7 @@ from dccd import FromBinance as fb
 from dccd.histo_dl.binance import FromBinance
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+TRADE_KEYS = ['tid', 'timestamp', 'price', 'amount', 'type']
 
 
 @pytest.mark.parametrize('crypto,fiat,expected', [
@@ -51,6 +52,28 @@ def test_malformed_response_raises(loader, monkeypatch):
     monkeypatch.setattr("requests.get", lambda *a, **kw: _mock_bad())
     with pytest.raises((KeyError, TypeError, ValueError)):
         loader._import_data(start=0)
+
+
+def test_import_trades(loader, mock_binance_trades):
+    data = loader._import_trades(start=0, end=int(time.time()))
+    assert isinstance(data, list)
+    assert len(data) > 0
+    for key in TRADE_KEYS:
+        assert key in data[0]
+
+
+def test_import_orderbook(loader, mock_binance_depth):
+    data = loader._import_orderbook(depth=2)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    sides = {d['side'] for d in data}
+    assert 'bid' in sides
+    assert 'ask' in sides
+
+
+def test_import_trades_http_500_raises(loader, mock_http_500):
+    with pytest.raises(ValueError):
+        loader._import_trades(start=0, end=1)
 
 
 def _mock_bad():

--- a/dccd/tests/test_binance_ws.py
+++ b/dccd/tests/test_binance_ws.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -80,16 +82,25 @@ def test_parser_trades_appends_to_data():
     dl = _make_downloader()
     dl.parser_trades(_TRADE_DATA)
     assert 2000 in dl._data
-    assert len(dl._data[2000]) == 1
-    assert dl._data[2000][0]['price'] == 30000.0
+    assert len(dl._data[2000]['trades']) == 1
+    assert dl._data[2000]['trades'][0]['price'] == 30000.0
 
 
 def test_parser_book_updates_and_removes():
     dl = _make_downloader()
     dl.parser_book(_BOOK_DATA)
-    assert '29990.0' in dl._data[2000]
-    assert dl._data[2000]['29990.0'] == 2.0
-    assert '29980.0' not in dl._data[2000]
+    book = dl._data[2000]['book']
+    assert '29990.0' in book
+    assert book['29990.0'] == 2.0
+    assert '29980.0' not in book
+
+
+def test_parser_book_does_not_overwrite_trades():
+    dl = _make_downloader()
+    dl.parser_trades(_TRADE_DATA)
+    dl.parser_book(_BOOK_DATA)
+    assert len(dl._data[2000]['trades']) == 1
+    assert '29990.0' in dl._data[2000]['book']
 
 
 @pytest.mark.asyncio
@@ -118,3 +129,59 @@ async def test_on_message_unknown_does_nothing():
     await dl.on_message({'stream': 'btcusdt@miniTicker', 'data': {}})
     dl.parser_trades.assert_not_called()
     dl.parser_book.assert_not_called()
+
+
+# =========================================================================== #
+#                        snapshot_ts and checkpoint tests                     #
+# =========================================================================== #
+
+
+@pytest.mark.asyncio
+async def test_anext_adds_snapshot_ts():
+    dl = _make_downloader()
+    dl.ts = 60
+    dl.until = time.time() + 3600
+    dl._data[dl.t] = {'trades': [{'price': 1.0}], 'book': {}}
+    before = int(time.time() * 1000)
+    payload = await dl.__anext__()
+    after = int(time.time() * 1000)
+    assert payload is not None
+    assert before <= payload['snapshot_ts'] <= after
+
+
+def test_checkpoint_save_and_load(tmp_path: Path):
+    dl = _make_downloader()
+    dl._checkpoint_dir = tmp_path
+    dl.pair = 'BTCUSDT'
+    dl.d = {'30000.0': 1.5, '-30010.0': -0.5}
+
+    dl._save_checkpoint()
+
+    dl2 = _make_downloader()
+    dl2._checkpoint_dir = tmp_path
+    dl2.pair = 'BTCUSDT'
+    dl2._load_checkpoint()
+
+    assert dl2.d == {'30000.0': 1.5, '-30010.0': -0.5}
+
+
+def test_checkpoint_no_dir_does_nothing(tmp_path: Path):
+    dl = _make_downloader()
+    dl._checkpoint_dir = None
+    dl.d = {'30000.0': 1.0}
+    dl._save_checkpoint()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_set_trades_saver_stored():
+    dl = _make_downloader()
+    saver = MagicMock()
+    dl.set_trades_saver(saver)
+    assert dl._trades_saver is saver
+
+
+def test_set_book_saver_stored():
+    dl = _make_downloader()
+    saver = MagicMock()
+    dl.set_book_saver(saver)
+    assert dl._book_saver is saver

--- a/dccd/tests/test_bitfinex.py
+++ b/dccd/tests/test_bitfinex.py
@@ -38,8 +38,8 @@ def test_parser_book_add_order():
     dl = _make_downloader()
     data = [0, [100.0, 1, 0.5]]
     dl.parser_book(data)
-    assert '100.0' in dl._data[1000]
-    assert dl._data[1000]['100.0'] == 0.5
+    assert '100.0' in dl._data[1000]['book']
+    assert dl._data[1000]['book']['100.0'] == 0.5
 
 
 def test_parser_book_remove_order():
@@ -47,7 +47,7 @@ def test_parser_book_remove_order():
     dl.d = {'100.0': {'price': '100.0', 'amount': 0.5}}
     data = [0, [100.0, 0, 0.0]]
     dl.parser_book(data)
-    assert '100.0' not in dl._data[1000]
+    assert '100.0' not in dl._data[1000]['book']
 
 
 def test_parser_raw_trades_skips_tu():

--- a/dccd/tests/test_bitmex.py
+++ b/dccd/tests/test_bitmex.py
@@ -60,7 +60,7 @@ def test_parser_book_partial_populates():
     dl.parser_book(_PARTIAL_MSG)
     assert dl.start is True
     assert 1 in dl.d
-    assert dl._data[1000][30000.0] == 10
+    assert dl._data[1000]['book'][30000.0] == 10
 
 
 def test_parser_book_delete_removes_entry():
@@ -68,22 +68,22 @@ def test_parser_book_delete_removes_entry():
     dl.parser_book(_PARTIAL_MSG)
     dl.parser_book(_DELETE_MSG)
     assert 1 not in dl.d
-    assert 30000.0 not in dl._data[1000]
+    assert 30000.0 not in dl._data[1000]['book']
 
 
 def test_parser_book_update_changes_amount():
     dl = _make_downloader()
     dl.parser_book(_PARTIAL_MSG)
     dl.parser_book(_UPDATE_MSG)
-    assert dl._data[1000][30000.0] == 20
+    assert dl._data[1000]['book'][30000.0] == 20
 
 
 def test_parser_trades_aggregates_in_same_timestep():
     dl = _make_downloader()
     dl.parser_trades(_TRADE_MSG)
-    assert len(dl._data[1000]) == 2
+    assert len(dl._data[1000]['trades']) == 2
     dl.parser_trades(_TRADE_MSG)
-    assert len(dl._data[1000]) == 4
+    assert len(dl._data[1000]['trades']) == 4
 
 
 @pytest.mark.asyncio

--- a/dccd/tests/test_bybit.py
+++ b/dccd/tests/test_bybit.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromBybit
+from dccd.histo_dl.bybit import FromBybit as _FromBybit
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USDT', 'BTCUSDT'),
+    ('ETH', 'USDT', 'ETHUSDT'),
+    ('SOL', 'BTC',  'SOLBTC'),
+])
+def test_format_pair(crypto, fiat, expected):
+    assert _FromBybit.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_bybit.py
+++ b/dccd/tests/test_bybit.py
@@ -9,6 +9,7 @@ from dccd import FromBybit
 from dccd.histo_dl.bybit import FromBybit as _FromBybit
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+TRADE_KEYS = ['tid', 'timestamp', 'price', 'amount', 'type']
 
 
 @pytest.mark.parametrize('crypto,fiat,expected', [
@@ -52,3 +53,25 @@ def test_malformed_response_raises(loader, monkeypatch):
     monkeypatch.setattr("requests.get", lambda *a, **kw: m)
     with pytest.raises(KeyError):
         loader._import_data(start=0)
+
+
+def test_import_trades(loader, mock_bybit_trades):
+    data = loader._import_trades(start=0, end=int(time.time()))
+    assert isinstance(data, list)
+    assert len(data) > 0
+    for key in TRADE_KEYS:
+        assert key in data[0]
+
+
+def test_import_orderbook(loader, mock_bybit_orderbook):
+    data = loader._import_orderbook(depth=2)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    sides = {d['side'] for d in data}
+    assert 'bid' in sides
+    assert 'ask' in sides
+
+
+def test_import_trades_http_500_raises(loader, mock_http_500):
+    with pytest.raises(ValueError):
+        loader._import_trades(start=0, end=1)

--- a/dccd/tests/test_bybit_ws.py
+++ b/dccd/tests/test_bybit_ws.py
@@ -71,18 +71,19 @@ def test_parser_trades_appends_to_data():
     dl = _make_downloader()
     dl.parser_trades(_TRADE_MSG)
     assert 2000 in dl._data
-    assert len(dl._data[2000]) == 2
-    assert dl._data[2000][0]['price'] == 30000.0
+    assert len(dl._data[2000]['trades']) == 2
+    assert dl._data[2000]['trades'][0]['price'] == 30000.0
 
 
 def test_parser_book_updates_and_removes():
     dl = _make_downloader()
     dl.parser_book(_BOOK_MSG)
+    book = dl._data[2000]['book']
     # qty > 0 → kept
-    assert '29990.0' in dl._data[2000]
-    assert dl._data[2000]['29990.0'] == 2.0
+    assert '29990.0' in book
+    assert book['29990.0'] == 2.0
     # qty == 0 → removed from book
-    assert '29980.0' not in dl._data[2000]
+    assert '29980.0' not in book
 
 
 @pytest.mark.asyncio

--- a/dccd/tests/test_coinbase.py
+++ b/dccd/tests/test_coinbase.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromCoinbase as fc
+from dccd.histo_dl.coinbase import FromCoinbase
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USD',  'BTC-USD'),
+    ('ETH', 'EUR',  'ETH-EUR'),
+    ('XBT', 'USD',  'BTC-USD'),  # XBT alias → BTC
+])
+def test_format_pair(crypto, fiat, expected):
+    assert FromCoinbase.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_coinbase.py
+++ b/dccd/tests/test_coinbase.py
@@ -9,6 +9,7 @@ from dccd import FromCoinbase as fc
 from dccd.histo_dl.coinbase import FromCoinbase
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+TRADE_KEYS = ['tid', 'timestamp', 'price', 'amount', 'type']
 
 
 @pytest.mark.parametrize('crypto,fiat,expected', [
@@ -48,3 +49,25 @@ def test_malformed_response_raises(loader, monkeypatch):
     monkeypatch.setattr("requests.get", lambda *a, **kw: m)
     with pytest.raises((TypeError, ValueError)):
         loader._import_data(start=0)
+
+
+def test_import_trades(loader, mock_coinbase_trades):
+    data = loader._import_trades(start=0, end=int(time.time()))
+    assert isinstance(data, list)
+    assert len(data) > 0
+    for key in TRADE_KEYS:
+        assert key in data[0]
+
+
+def test_import_orderbook(loader, mock_coinbase_book):
+    data = loader._import_orderbook(depth=2)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    sides = {d['side'] for d in data}
+    assert 'bid' in sides
+    assert 'ask' in sides
+
+
+def test_import_trades_http_500_raises(loader, mock_http_500):
+    with pytest.raises(ValueError):
+        loader._import_trades(start=0, end=1)

--- a/dccd/tests/test_daemon_cli.py
+++ b/dccd/tests/test_daemon_cli.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""Tests for dccd.daemon.cli."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from dccd.daemon.cli import app
+
+runner = CliRunner()
+
+_MINIMAL_CONFIG = {
+    'storage': {'local_path': '/tmp/dccd_test_data'},
+    'histo_jobs': [
+        {'exchange': 'binance', 'pairs': ['BTC/USDT'], 'span': 3600},
+    ],
+}
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path) -> Path:
+    p = tmp_path / 'config.yml'
+    p.write_text(yaml.dump(_MINIMAL_CONFIG))
+    return p
+
+
+def test_validate_ok(config_file: Path) -> None:
+    result = runner.invoke(app, ['validate', '--config', str(config_file)])
+    assert result.exit_code == 0
+    assert 'valid' in result.output.lower()
+    assert 'binance' not in result.output  # summary is counts, not exchange names
+
+
+def test_validate_missing_file(tmp_path: Path) -> None:
+    result = runner.invoke(app, ['validate', '--config', str(tmp_path / 'no.yml')])
+    assert result.exit_code == 1
+
+
+def test_validate_bad_config(tmp_path: Path) -> None:
+    bad = tmp_path / 'bad.yml'
+    bad.write_text(yaml.dump({'storage': {'local_path': '/tmp'}, 'histo_jobs': []}))
+    result = runner.invoke(app, ['validate', '--config', str(bad)])
+    assert result.exit_code == 1
+
+
+def test_run_calls_run_once(config_file: Path) -> None:
+    with patch('dccd.daemon.health.HealthMonitor') as MockHealth, \
+         patch('dccd.daemon.scheduler.run_once') as mock_run_once:
+        MockHealth.return_value.get_metrics.return_value = {}
+        result = runner.invoke(app, ['run', '--config', str(config_file)])
+    assert result.exit_code == 0
+    mock_run_once.assert_called_once()
+
+
+def test_status_no_metrics(config_file: Path) -> None:
+    result = runner.invoke(app, ['status', '--config', str(config_file)])
+    assert result.exit_code == 0
+    assert 'No metrics yet' in result.output
+
+
+def test_status_shows_table(config_file: Path, tmp_path: Path) -> None:
+    dccd_dir = tmp_path / '.dccd_test_storage' / '.dccd'
+    dccd_dir.mkdir(parents=True)
+    metrics = {
+        'binance/BTC/USDT': {
+            'last_run_at': 1747440000.0,
+            'last_success_at': 1747440000.0,
+            'rows_collected': 100,
+            'errors_count': 0,
+        }
+    }
+    (dccd_dir / 'metrics.json').write_text(json.dumps(metrics))
+
+    cfg = {
+        'storage': {'local_path': str(dccd_dir.parent)},
+        'histo_jobs': [{'exchange': 'binance', 'pairs': ['BTC/USDT'], 'span': 3600}],
+    }
+    cfg_file = tmp_path / 'cfg2.yml'
+    cfg_file.write_text(yaml.dump(cfg))
+
+    result = runner.invoke(app, ['status', '--config', str(cfg_file)])
+    assert result.exit_code == 0
+    assert 'binance/BTC/USDT' in result.output
+    assert '100' in result.output
+
+
+def test_add_histo_job(config_file: Path) -> None:
+    result = runner.invoke(app, [
+        'add',
+        '--exchange', 'kraken',
+        '--pair', 'ETH/USD',
+        '--span', '86400',
+        '--config', str(config_file),
+    ])
+    assert result.exit_code == 0
+    loaded = yaml.safe_load(config_file.read_text())
+    pairs_all = [
+        p for job in loaded['histo_jobs'] for p in job['pairs']
+    ]
+    assert 'ETH/USD' in pairs_all

--- a/dccd/tests/test_daemon_config.py
+++ b/dccd/tests/test_daemon_config.py
@@ -65,12 +65,38 @@ def test_remote_config_parsed():
         **_VALID_CONFIG,
         'storage': {
             'local_path': '/data/',
-            'remote': {'provider': 'rclone', 'remote': 'mynas:crypto/'},
+            'remotes': [{'provider': 'rclone', 'remote': 'mynas:crypto/'}],
         },
     }
     cfg = CollectorConfig.model_validate(data)
-    assert cfg.storage.remote is not None
-    assert cfg.storage.remote.remote == 'mynas:crypto/'
+    assert len(cfg.storage.remotes) == 1
+    assert cfg.storage.remotes[0].remote == 'mynas:crypto/'
+
+
+def test_multiple_remotes_parsed():
+    data = {
+        **_VALID_CONFIG,
+        'storage': {
+            'local_path': '/data/',
+            'remotes': [
+                {'provider': 'rclone', 'remote': 'mynas:crypto/'},
+                {'provider': 'rclone', 'remote': 's3:bucket/crypto/'},
+            ],
+        },
+    }
+    cfg = CollectorConfig.model_validate(data)
+    assert len(cfg.storage.remotes) == 2
+
+
+def test_sync_interval_default():
+    cfg = CollectorConfig.model_validate(_VALID_CONFIG)
+    assert cfg.storage.sync_interval == 3600
+
+
+def test_sync_interval_custom():
+    data = {**_VALID_CONFIG, 'storage': {**_VALID_STORAGE, 'sync_interval': 300}}
+    cfg = CollectorConfig.model_validate(data)
+    assert cfg.storage.sync_interval == 300
 
 
 # ---------------------------------------------------------------------------

--- a/dccd/tests/test_daemon_config.py
+++ b/dccd/tests/test_daemon_config.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import pathlib
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from dccd.daemon.config import (
+    CollectorConfig,
+    load_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_STORAGE = {'local_path': '/data/crypto/'}
+
+_VALID_HISTO_JOB = {
+    'exchange': 'binance',
+    'pairs': ['BTC/USDT', 'ETH/USDT'],
+    'span': 3600,
+    'format': 'parquet',
+    'by_period': 'Y',
+}
+
+_VALID_CONFIG = {
+    'storage': _VALID_STORAGE,
+    'histo_jobs': [_VALID_HISTO_JOB],
+}
+
+
+def _make_config_file(tmp_path: pathlib.Path, data: dict) -> pathlib.Path:
+    p = tmp_path / 'config.yml'
+    p.write_text(yaml.dump(data))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# CollectorConfig — valid cases
+# ---------------------------------------------------------------------------
+
+def test_valid_full_config():
+    cfg = CollectorConfig.model_validate(_VALID_CONFIG)
+    assert cfg.storage.local_path == '/data/crypto/'
+    assert len(cfg.histo_jobs) == 1
+    assert cfg.histo_jobs[0].exchange == 'binance'
+    assert cfg.histo_jobs[0].pairs == ['BTC/USDT', 'ETH/USDT']
+    assert cfg.histo_jobs[0].span == 3600
+
+
+def test_default_values_applied():
+    cfg = CollectorConfig.model_validate(_VALID_CONFIG)
+    assert cfg.stream_jobs == []
+    assert cfg.alerts.webhook_url is None
+    assert cfg.alerts.max_consecutive_errors == 3
+    assert cfg.histo_jobs[0].format == 'parquet'
+    assert cfg.histo_jobs[0].by_period == 'Y'
+
+
+def test_remote_config_parsed():
+    data = {
+        **_VALID_CONFIG,
+        'storage': {
+            'local_path': '/data/',
+            'remote': {'provider': 'rclone', 'remote': 'mynas:crypto/'},
+        },
+    }
+    cfg = CollectorConfig.model_validate(data)
+    assert cfg.storage.remote is not None
+    assert cfg.storage.remote.remote == 'mynas:crypto/'
+
+
+# ---------------------------------------------------------------------------
+# HistoJob — validation errors
+# ---------------------------------------------------------------------------
+
+def test_unknown_exchange_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'exchange': 'poloniex'}]}
+    with pytest.raises(ValidationError, match='Unknown exchange'):
+        CollectorConfig.model_validate(data)
+
+
+def test_span_too_small_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'span': 30}]}
+    with pytest.raises(ValidationError, match='span must be >= 60'):
+        CollectorConfig.model_validate(data)
+
+
+def test_unsupported_format_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'format': 'json'}]}
+    with pytest.raises(ValidationError, match='Unknown format'):
+        CollectorConfig.model_validate(data)
+
+
+def test_pair_missing_slash_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'pairs': ['BTCUSDT']}]}
+    with pytest.raises(ValidationError, match="CRYPTO/FIAT"):
+        CollectorConfig.model_validate(data)
+
+
+def test_empty_pairs_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'pairs': []}]}
+    with pytest.raises(ValidationError, match="must not be empty"):
+        CollectorConfig.model_validate(data)
+
+
+def test_invalid_by_period_raises():
+    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'by_period': 'W'}]}
+    with pytest.raises(ValidationError, match='Unknown by_period'):
+        CollectorConfig.model_validate(data)
+
+
+def test_no_jobs_raises():
+    data = {'storage': _VALID_STORAGE}
+    with pytest.raises(ValidationError, match='at least one job'):
+        CollectorConfig.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+def test_load_config_valid(tmp_path):
+    p = _make_config_file(tmp_path, _VALID_CONFIG)
+    cfg = load_config(p)
+    assert isinstance(cfg, CollectorConfig)
+    assert cfg.histo_jobs[0].exchange == 'binance'
+
+
+def test_load_config_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_config(tmp_path / 'nonexistent.yml')
+
+
+def test_load_config_invalid_yaml(tmp_path):
+    p = tmp_path / 'bad.yml'
+    p.write_text(': invalid: yaml: {')
+    with pytest.raises(yaml.YAMLError):
+        load_config(p)
+
+
+def test_load_config_validation_error(tmp_path):
+    bad = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'span': 10}]}
+    p = _make_config_file(tmp_path, bad)
+    with pytest.raises(ValidationError):
+        load_config(p)

--- a/dccd/tests/test_daemon_health.py
+++ b/dccd/tests/test_daemon_health.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""Tests for dccd.daemon.health."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dccd.daemon.config import AlertConfig
+from dccd.daemon.health import HealthMonitor
+
+
+@pytest.fixture()
+def alert_cfg() -> AlertConfig:
+    return AlertConfig(webhook_url=None, max_consecutive_errors=3)
+
+
+@pytest.fixture()
+def monitor(tmp_path: Path, alert_cfg: AlertConfig) -> HealthMonitor:
+    return HealthMonitor(tmp_path, alert_cfg)
+
+
+def test_record_success_updates_metrics(monitor: HealthMonitor, tmp_path: Path) -> None:
+    monitor.record_success('binance', 'BTC/USDT', rows=10)
+    m = monitor.get_metrics()['binance/BTC/USDT']
+    assert m.last_run_at is not None
+    assert m.last_success_at == m.last_run_at
+    assert m.rows_collected == 10
+    assert m.errors_count == 0
+
+
+def test_record_success_resets_errors(monitor: HealthMonitor) -> None:
+    monitor.record_failure('binance', 'BTC/USDT')
+    monitor.record_failure('binance', 'BTC/USDT')
+    monitor.record_success('binance', 'BTC/USDT')
+    assert monitor.get_metrics()['binance/BTC/USDT'].errors_count == 0
+
+
+def test_record_failure_increments(monitor: HealthMonitor) -> None:
+    monitor.record_failure('kraken', 'ETH/USD')
+    monitor.record_failure('kraken', 'ETH/USD')
+    m = monitor.get_metrics()['kraken/ETH/USD']
+    assert m.errors_count == 2
+    assert m.last_run_at is not None
+    assert m.last_success_at is None
+
+
+def test_record_failure_triggers_webhook(tmp_path: Path) -> None:
+    cfg = AlertConfig(webhook_url='http://example.com/hook', max_consecutive_errors=2)
+    mon = HealthMonitor(tmp_path, cfg)
+
+    with patch('urllib.request.urlopen') as mock_open:
+        mon.record_failure('binance', 'BTC/USDT')
+        mock_open.assert_not_called()
+        mon.record_failure('binance', 'BTC/USDT')
+        mock_open.assert_called_once()
+
+
+def test_no_alert_below_threshold(tmp_path: Path) -> None:
+    cfg = AlertConfig(webhook_url='http://example.com/hook', max_consecutive_errors=5)
+    mon = HealthMonitor(tmp_path, cfg)
+    with patch('urllib.request.urlopen') as mock_open:
+        for _ in range(4):
+            mon.record_failure('binance', 'BTC/USDT')
+        mock_open.assert_not_called()
+
+
+def test_metrics_persist_reload(tmp_path: Path, alert_cfg: AlertConfig) -> None:
+    mon1 = HealthMonitor(tmp_path, alert_cfg)
+    mon1.record_success('binance', 'BTC/USDT', rows=42)
+    mon1.record_failure('kraken', 'ETH/USD')
+
+    mon2 = HealthMonitor(tmp_path, alert_cfg)
+    metrics = mon2.get_metrics()
+    assert metrics['binance/BTC/USDT'].rows_collected == 42
+    assert metrics['kraken/ETH/USD'].errors_count == 1
+
+
+def test_rotating_log_created(monitor: HealthMonitor, tmp_path: Path) -> None:
+    log_file = tmp_path / '.dccd' / 'dccd.log'
+    assert log_file.exists()

--- a/dccd/tests/test_daemon_scheduler.py
+++ b/dccd/tests/test_daemon_scheduler.py
@@ -7,7 +7,6 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from dccd.daemon.config import CollectorConfig, HistoJob, StorageConfig
 from dccd.daemon.scheduler import build_histo_scheduler, run_histo_job, run_once
-from dccd.daemon.storage import RemoteStorage
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -22,10 +21,6 @@ def _make_config(histo_jobs=None, tmp_path=None):
             HistoJob(exchange='kraken', pairs=['BTC/USD'], span=86400),
         ],
     )
-
-
-def _make_storage(tmp_path):
-    return RemoteStorage(StorageConfig(local_path=str(tmp_path)))
 
 
 # ---------------------------------------------------------------------------
@@ -83,34 +78,31 @@ def test_run_histo_job_calls_chain(tmp_path):
     import dccd.daemon.scheduler as sched_mod
 
     job = HistoJob(exchange='binance', pairs=['BTC/USDT'], span=3600)
-    storage = MagicMock(spec=RemoteStorage)
     mock_cls, mock_obj = _mock_exchange_cls(str(tmp_path / 'Binance'))
 
     original = sched_mod._HISTO_CLASSES.copy()
     sched_mod._HISTO_CLASSES['binance'] = mock_cls
     try:
-        run_histo_job(job, 'BTC/USDT', str(tmp_path), storage)
+        run_histo_job(job, 'BTC/USDT', str(tmp_path))
     finally:
         sched_mod._HISTO_CLASSES.update(original)
 
     mock_cls.assert_called_once_with(str(tmp_path), 'BTC', 3600, 'USDT', form='parquet')
     mock_obj.import_data.assert_called_once_with('last', 'now')
     mock_obj.save.assert_called_once_with(form='parquet', by_period='Y')
-    storage.push.assert_called_once_with(str(tmp_path / 'Binance'))
 
 
 def test_run_histo_job_splits_pair_correctly(tmp_path):
     import dccd.daemon.scheduler as sched_mod
 
     job = HistoJob(exchange='okx', pairs=['ETH/USDT'], span=3600)
-    storage = MagicMock(spec=RemoteStorage)
     mock_cls, mock_obj = _mock_exchange_cls('/tmp')
     mock_obj.full_path = '/tmp'
 
     original = sched_mod._HISTO_CLASSES.copy()
     sched_mod._HISTO_CLASSES['okx'] = mock_cls
     try:
-        run_histo_job(job, 'ETH/USDT', str(tmp_path), storage)
+        run_histo_job(job, 'ETH/USDT', str(tmp_path))
     finally:
         sched_mod._HISTO_CLASSES.update(original)
 

--- a/dccd/tests/test_daemon_scheduler.py
+++ b/dccd/tests/test_daemon_scheduler.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from unittest.mock import MagicMock, patch
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from dccd.daemon.config import CollectorConfig, HistoJob, StorageConfig
+from dccd.daemon.scheduler import build_histo_scheduler, run_histo_job, run_once
+from dccd.daemon.storage import RemoteStorage
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_config(histo_jobs=None, tmp_path=None):
+    path = str(tmp_path) if tmp_path else '/data/crypto/'
+    return CollectorConfig(
+        storage=StorageConfig(local_path=path),
+        histo_jobs=histo_jobs or [
+            HistoJob(exchange='binance', pairs=['BTC/USDT', 'ETH/USDT'], span=3600),
+            HistoJob(exchange='kraken', pairs=['BTC/USD'], span=86400),
+        ],
+    )
+
+
+def _make_storage(tmp_path):
+    return RemoteStorage(StorageConfig(local_path=str(tmp_path)))
+
+
+# ---------------------------------------------------------------------------
+# build_histo_scheduler
+# ---------------------------------------------------------------------------
+
+def test_scheduler_type(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    scheduler = build_histo_scheduler(cfg)
+    assert isinstance(scheduler, BackgroundScheduler)
+
+
+def test_scheduler_job_count(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    scheduler = build_histo_scheduler(cfg)
+    jobs = scheduler.get_jobs()
+    # 2 pairs (binance) + 1 pair (kraken) = 3 jobs
+    assert len(jobs) == 3
+
+
+def test_scheduler_job_ids(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    scheduler = build_histo_scheduler(cfg)
+    ids = {j.id for j in scheduler.get_jobs()}
+    assert 'binance_BTC_USDT_3600' in ids
+    assert 'binance_ETH_USDT_3600' in ids
+    assert 'kraken_BTC_USD_86400' in ids
+
+
+def test_scheduler_interval_seconds(tmp_path):
+    cfg = _make_config(
+        histo_jobs=[HistoJob(exchange='bybit', pairs=['BTC/USDT'], span=900)],
+        tmp_path=tmp_path,
+    )
+    scheduler = build_histo_scheduler(cfg)
+    job = scheduler.get_jobs()[0]
+    assert job.trigger.interval.total_seconds() == 900
+
+
+# ---------------------------------------------------------------------------
+# run_histo_job
+# ---------------------------------------------------------------------------
+
+def _mock_exchange_cls(tmp_path_str):
+    """Return a mock exchange class and instance pair."""
+    mock_obj = MagicMock()
+    mock_obj.import_data.return_value = mock_obj
+    mock_obj.save.return_value = mock_obj
+    mock_obj.full_path = tmp_path_str
+    mock_cls = MagicMock(return_value=mock_obj)
+    return mock_cls, mock_obj
+
+
+def test_run_histo_job_calls_chain(tmp_path):
+    import dccd.daemon.scheduler as sched_mod
+
+    job = HistoJob(exchange='binance', pairs=['BTC/USDT'], span=3600)
+    storage = MagicMock(spec=RemoteStorage)
+    mock_cls, mock_obj = _mock_exchange_cls(str(tmp_path / 'Binance'))
+
+    original = sched_mod._HISTO_CLASSES.copy()
+    sched_mod._HISTO_CLASSES['binance'] = mock_cls
+    try:
+        run_histo_job(job, 'BTC/USDT', str(tmp_path), storage)
+    finally:
+        sched_mod._HISTO_CLASSES.update(original)
+
+    mock_cls.assert_called_once_with(str(tmp_path), 'BTC', 3600, 'USDT', form='parquet')
+    mock_obj.import_data.assert_called_once_with('last', 'now')
+    mock_obj.save.assert_called_once_with(form='parquet', by_period='Y')
+    storage.push.assert_called_once_with(str(tmp_path / 'Binance'))
+
+
+def test_run_histo_job_splits_pair_correctly(tmp_path):
+    import dccd.daemon.scheduler as sched_mod
+
+    job = HistoJob(exchange='okx', pairs=['ETH/USDT'], span=3600)
+    storage = MagicMock(spec=RemoteStorage)
+    mock_cls, mock_obj = _mock_exchange_cls('/tmp')
+    mock_obj.full_path = '/tmp'
+
+    original = sched_mod._HISTO_CLASSES.copy()
+    sched_mod._HISTO_CLASSES['okx'] = mock_cls
+    try:
+        run_histo_job(job, 'ETH/USDT', str(tmp_path), storage)
+    finally:
+        sched_mod._HISTO_CLASSES.update(original)
+
+    mock_cls.assert_called_once_with(str(tmp_path), 'ETH', 3600, 'USDT', form='parquet')
+
+
+# ---------------------------------------------------------------------------
+# run_once
+# ---------------------------------------------------------------------------
+
+def test_run_once_executes_all_jobs(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+
+    with patch('dccd.daemon.scheduler.run_histo_job') as mock_job:
+        run_once(cfg)
+
+    assert mock_job.call_count == 3  # BTC/USDT, ETH/USDT (binance) + BTC/USD (kraken)
+
+
+def test_run_once_job_failure_does_not_stop_others(tmp_path):
+    cfg = _make_config(tmp_path=tmp_path)
+    call_log = []
+
+    def _side_effect(job, pair, *args, **kwargs):
+        call_log.append(pair)
+        if pair == 'BTC/USDT' and job.exchange == 'binance':
+            raise RuntimeError('network error')
+
+    with patch('dccd.daemon.scheduler.run_histo_job', side_effect=_side_effect):
+        run_once(cfg)  # must not raise
+
+    assert 'ETH/USDT' in call_log
+    assert 'BTC/USD' in call_log
+
+
+def test_run_once_logs_exception_on_failure(tmp_path, caplog):
+    cfg = _make_config(
+        histo_jobs=[HistoJob(exchange='binance', pairs=['BTC/USDT'], span=3600)],
+        tmp_path=tmp_path,
+    )
+
+    import logging
+    with patch('dccd.daemon.scheduler.run_histo_job', side_effect=ValueError('boom')):
+        with caplog.at_level(logging.ERROR, logger='dccd.daemon.scheduler'):
+            run_once(cfg)
+
+    assert 'histo job failed' in caplog.text

--- a/dccd/tests/test_daemon_storage.py
+++ b/dccd/tests/test_daemon_storage.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from unittest.mock import MagicMock, patch
+
+from dccd.daemon.config import RemoteConfig, StorageConfig
+from dccd.daemon.storage import RemoteStorage
+
+
+def _storage(tmp_path, remote=None):
+    cfg = StorageConfig(local_path=str(tmp_path), remote=remote)
+    return RemoteStorage(cfg)
+
+
+def _remote():
+    return RemoteConfig(provider='rclone', remote='mynas:crypto/')
+
+
+# ---------------------------------------------------------------------------
+# push() without remote — no-op
+# ---------------------------------------------------------------------------
+
+def test_push_no_remote_never_calls_subprocess(tmp_path):
+    s = _storage(tmp_path)
+    sub_dir = tmp_path / 'Binance'
+    sub_dir.mkdir()
+    with patch('subprocess.run') as mock_run:
+        s.push(sub_dir)
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# check_rclone()
+# ---------------------------------------------------------------------------
+
+def test_check_rclone_found(tmp_path):
+    s = _storage(tmp_path, _remote())
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        assert s.check_rclone() is True
+
+
+def test_check_rclone_not_found_logs_warning(tmp_path, caplog):
+    s = _storage(tmp_path, _remote())
+    import logging
+    with patch('shutil.which', return_value=None):
+        with caplog.at_level(logging.WARNING, logger='dccd.daemon.storage'):
+            result = s.check_rclone()
+    assert result is False
+    assert 'rclone not found' in caplog.text
+
+
+def test_check_rclone_cached(tmp_path):
+    s = _storage(tmp_path, _remote())
+    with patch('shutil.which', return_value='/usr/bin/rclone') as mock_which:
+        s.check_rclone()
+        s.check_rclone()
+    mock_which.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# push() with remote + rclone present
+# ---------------------------------------------------------------------------
+
+def test_push_calls_rclone_with_correct_args(tmp_path):
+    s = _storage(tmp_path, _remote())
+    sub_dir = tmp_path / 'Binance' / 'Data'
+    sub_dir.mkdir(parents=True)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(sub_dir)
+
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args[0] == 'rclone'
+    assert args[1] == 'copy'
+    assert args[2] == str(sub_dir.resolve())
+    assert args[3] == 'mynas:crypto/Binance/Data'
+
+
+def test_push_remote_no_trailing_slash(tmp_path):
+    remote = RemoteConfig(provider='rclone', remote='mynas:crypto')  # no trailing /
+    s = _storage(tmp_path, remote)
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(sub_dir)
+
+    dest = mock_run.call_args[0][0][3]
+    assert dest == 'mynas:crypto/sub'
+
+
+# ---------------------------------------------------------------------------
+# push() with rclone not found
+# ---------------------------------------------------------------------------
+
+def test_push_rclone_absent_does_not_call_subprocess(tmp_path):
+    s = _storage(tmp_path, _remote())
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    with patch('shutil.which', return_value=None):
+        with patch('subprocess.run') as mock_run:
+            s.push(sub_dir)
+
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# push() when rclone returns non-zero exit code
+# ---------------------------------------------------------------------------
+
+def test_push_rclone_failure_logs_error_no_exception(tmp_path, caplog):
+    s = _storage(tmp_path, _remote())
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stderr = 'connection refused'
+
+    import logging
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result):
+            with caplog.at_level(logging.ERROR, logger='dccd.daemon.storage'):
+                s.push(sub_dir)  # must NOT raise
+
+    assert 'rclone copy failed' in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# push() with path outside base
+# ---------------------------------------------------------------------------
+
+def test_push_path_outside_base_logs_error(tmp_path, caplog):
+    s = _storage(tmp_path, _remote())
+    outside = tmp_path.parent / 'other'
+    outside.mkdir(exist_ok=True)
+
+    import logging
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run') as mock_run:
+            with caplog.at_level(logging.ERROR, logger='dccd.daemon.storage'):
+                s.push(outside)
+
+    mock_run.assert_not_called()
+    assert 'not under base' in caplog.text

--- a/dccd/tests/test_daemon_storage.py
+++ b/dccd/tests/test_daemon_storage.py
@@ -7,8 +7,8 @@ from dccd.daemon.config import RemoteConfig, StorageConfig
 from dccd.daemon.storage import RemoteStorage
 
 
-def _storage(tmp_path, remote=None):
-    cfg = StorageConfig(local_path=str(tmp_path), remote=remote)
+def _storage(tmp_path, remotes=None):
+    cfg = StorageConfig(local_path=str(tmp_path), remotes=remotes or [])
     return RemoteStorage(cfg)
 
 
@@ -16,8 +16,12 @@ def _remote():
     return RemoteConfig(provider='rclone', remote='mynas:crypto/')
 
 
+def _remotes(*paths):
+    return [RemoteConfig(provider='rclone', remote=p) for p in paths]
+
+
 # ---------------------------------------------------------------------------
-# push() without remote — no-op
+# push() without remotes — no-op
 # ---------------------------------------------------------------------------
 
 def test_push_no_remote_never_calls_subprocess(tmp_path):
@@ -34,13 +38,13 @@ def test_push_no_remote_never_calls_subprocess(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_check_rclone_found(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     with patch('shutil.which', return_value='/usr/bin/rclone'):
         assert s.check_rclone() is True
 
 
 def test_check_rclone_not_found_logs_warning(tmp_path, caplog):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     import logging
     with patch('shutil.which', return_value=None):
         with caplog.at_level(logging.WARNING, logger='dccd.daemon.storage'):
@@ -50,19 +54,25 @@ def test_check_rclone_not_found_logs_warning(tmp_path, caplog):
 
 
 def test_check_rclone_cached(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     with patch('shutil.which', return_value='/usr/bin/rclone') as mock_which:
         s.check_rclone()
         s.check_rclone()
     mock_which.assert_called_once()
 
 
+def test_check_rclone_no_remotes_returns_false(tmp_path):
+    s = _storage(tmp_path)
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        assert s.check_rclone() is False
+
+
 # ---------------------------------------------------------------------------
-# push() with remote + rclone present
+# push() with single remote + rclone present
 # ---------------------------------------------------------------------------
 
 def test_push_calls_rclone_with_correct_args(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     sub_dir = tmp_path / 'Binance' / 'Data'
     sub_dir.mkdir(parents=True)
 
@@ -82,8 +92,7 @@ def test_push_calls_rclone_with_correct_args(tmp_path):
 
 
 def test_push_remote_no_trailing_slash(tmp_path):
-    remote = RemoteConfig(provider='rclone', remote='mynas:crypto')  # no trailing /
-    s = _storage(tmp_path, remote)
+    s = _storage(tmp_path, [RemoteConfig(provider='rclone', remote='mynas:crypto')])
     sub_dir = tmp_path / 'sub'
     sub_dir.mkdir()
 
@@ -99,11 +108,51 @@ def test_push_remote_no_trailing_slash(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# push() with multiple remotes
+# ---------------------------------------------------------------------------
+
+def test_push_multiple_remotes_calls_rclone_twice(tmp_path):
+    s = _storage(tmp_path, _remotes('mynas:crypto/', 's3:bucket/crypto/'))
+    sub_dir = tmp_path / 'sub'
+    sub_dir.mkdir()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(sub_dir)
+
+    assert mock_run.call_count == 2
+    dests = [call[0][0][3] for call in mock_run.call_args_list]
+    assert 'mynas:crypto/sub' in dests
+    assert 's3:bucket/crypto/sub' in dests
+
+
+# ---------------------------------------------------------------------------
+# push() root path (path == local_path)
+# ---------------------------------------------------------------------------
+
+def test_push_root_path_uses_remote_root(tmp_path):
+    s = _storage(tmp_path, [_remote()])
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('shutil.which', return_value='/usr/bin/rclone'):
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            s.push(tmp_path)
+
+    dest = mock_run.call_args[0][0][3]
+    assert dest == 'mynas:crypto'
+
+
+# ---------------------------------------------------------------------------
 # push() with rclone not found
 # ---------------------------------------------------------------------------
 
 def test_push_rclone_absent_does_not_call_subprocess(tmp_path):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     sub_dir = tmp_path / 'sub'
     sub_dir.mkdir()
 
@@ -119,7 +168,7 @@ def test_push_rclone_absent_does_not_call_subprocess(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_push_rclone_failure_logs_error_no_exception(tmp_path, caplog):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     sub_dir = tmp_path / 'sub'
     sub_dir.mkdir()
 
@@ -141,7 +190,7 @@ def test_push_rclone_failure_logs_error_no_exception(tmp_path, caplog):
 # ---------------------------------------------------------------------------
 
 def test_push_path_outside_base_logs_error(tmp_path, caplog):
-    s = _storage(tmp_path, _remote())
+    s = _storage(tmp_path, [_remote()])
     outside = tmp_path.parent / 'other'
     outside.mkdir(exist_ok=True)
 

--- a/dccd/tests/test_daemon_stream_manager.py
+++ b/dccd/tests/test_daemon_stream_manager.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dccd.daemon.config import CollectorConfig, StorageConfig, StreamJob
+from dccd.daemon.stream_manager import (
+    StreamManager,
+    SyncService,
+    _connect_kwargs,
+    _format_pair,
+    _iter_tasks,
+    _process_fn,
+)
+from dccd.process_data import set_marketdepth, set_orders, set_trades
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _storage_cfg(tmp_path, remotes=None, sync_interval=3600):
+    remotes = remotes or []
+    return StorageConfig(
+        local_path=str(tmp_path),
+        remotes=remotes,
+        sync_interval=sync_interval,
+    )
+
+
+def _stream_job(exchange='binance', pairs=None, channels=None, time_step=60):
+    return StreamJob(
+        exchange=exchange,
+        pairs=pairs or ['BTC/USDT'],
+        channels=channels or ['trades', 'book'],
+        time_step=time_step,
+    )
+
+
+def _make_config(tmp_path, jobs=None, remotes=None):
+    return CollectorConfig(
+        storage=_storage_cfg(tmp_path, remotes=remotes),
+        stream_jobs=jobs or [_stream_job()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_pair
+# ---------------------------------------------------------------------------
+
+def test_format_pair_binance():
+    assert _format_pair('binance', 'BTC/USDT') == 'BTCUSDT'
+
+
+def test_format_pair_bybit():
+    assert _format_pair('bybit', 'ETH/USDT') == 'ETHUSDT'
+
+
+def test_format_pair_kraken():
+    assert _format_pair('kraken', 'BTC/USD') == 'BTC/USD'
+
+
+def test_format_pair_okx():
+    assert _format_pair('okx', 'BTC/USDT') == 'BTC-USDT'
+
+
+def test_format_pair_bitfinex_usd():
+    assert _format_pair('bitfinex', 'BTC/USD') == 'tBTCUSD'
+
+
+def test_format_pair_bitfinex_usdt():
+    assert _format_pair('bitfinex', 'BTC/USDT') == 'tBTCUST'
+
+
+def test_format_pair_bitmex_btc():
+    assert _format_pair('bitmex', 'BTC/USD') == 'XBTUSD'
+
+
+def test_format_pair_bitmex_eth():
+    assert _format_pair('bitmex', 'ETH/USD') == 'ETHUSD'
+
+
+def test_format_pair_unsupported_raises():
+    with pytest.raises(ValueError, match='not supported'):
+        _format_pair('poloniex', 'BTC/USDT')
+
+
+# ---------------------------------------------------------------------------
+# _process_fn
+# ---------------------------------------------------------------------------
+
+def test_process_fn_trades():
+    assert _process_fn(['trades']) is set_trades
+
+
+def test_process_fn_book():
+    assert _process_fn(['book']) is set_marketdepth
+
+
+def test_process_fn_both():
+    assert _process_fn(['trades', 'book']) is set_orders
+
+
+def test_process_fn_fallback():
+    assert _process_fn(['kline']) is set_orders
+
+
+# ---------------------------------------------------------------------------
+# _connect_kwargs
+# ---------------------------------------------------------------------------
+
+def test_connect_kwargs_binance():
+    assert _connect_kwargs('binance', 'BTC/USDT', ['trades']) == {}
+
+
+def test_connect_kwargs_kraken():
+    assert _connect_kwargs('kraken', 'BTC/USD', ['trades', 'book']) == {}
+
+
+def test_connect_kwargs_bitfinex_trades():
+    kw = _connect_kwargs('bitfinex', 'BTC/USD', ['trades'])
+    assert kw == {'channel': 'trades', 'symbol': 'tBTCUSD'}
+
+
+def test_connect_kwargs_bitmex_book():
+    kw = _connect_kwargs('bitmex', 'BTC/USD', ['book'])
+    assert kw == {'args': 'orderBookL2_25:XBTUSD'}
+
+
+# ---------------------------------------------------------------------------
+# _iter_tasks
+# ---------------------------------------------------------------------------
+
+def test_iter_tasks_binance_single_thread_for_all_channels():
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades', 'book'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 1
+    pair, channels = tasks[0]
+    assert pair == 'BTC/USDT'
+    assert 'trades' in channels and 'book' in channels
+
+
+def test_iter_tasks_bitfinex_one_thread_per_channel():
+    job = _stream_job(exchange='bitfinex', pairs=['BTC/USD'], channels=['trades', 'book'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 2
+    channel_lists = [ch for _, ch in tasks]
+    assert ['trades'] in channel_lists
+    assert ['book'] in channel_lists
+
+
+def test_iter_tasks_bitmex_one_thread_per_channel():
+    job = _stream_job(exchange='bitmex', pairs=['BTC/USD'], channels=['trades', 'book'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 2
+
+
+def test_iter_tasks_multiple_pairs():
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT', 'ETH/USDT'], channels=['trades'])
+    tasks = list(_iter_tasks(job))
+    assert len(tasks) == 2
+
+
+# ---------------------------------------------------------------------------
+# SyncService
+# ---------------------------------------------------------------------------
+
+def test_sync_service_no_remotes_no_thread(tmp_path):
+    svc = SyncService(_storage_cfg(tmp_path, remotes=[], sync_interval=60))
+    svc.start()
+    assert svc._thread is None
+
+
+def test_sync_service_sync_interval_zero_no_thread(tmp_path):
+    from dccd.daemon.config import RemoteConfig
+    svc = SyncService(_storage_cfg(
+        tmp_path,
+        remotes=[RemoteConfig(provider='rclone', remote='mynas:crypto/')],
+        sync_interval=0,
+    ))
+    svc.start()
+    assert svc._thread is None
+
+
+def test_sync_service_stop_sets_event(tmp_path):
+    svc = SyncService(_storage_cfg(tmp_path))
+    svc.stop()
+    assert svc._stop.is_set()
+
+
+def test_sync_service_sync_now_calls_push(tmp_path):
+    from dccd.daemon.config import RemoteConfig
+    svc = SyncService(_storage_cfg(
+        tmp_path,
+        remotes=[RemoteConfig(provider='rclone', remote='mynas:crypto/')],
+    ))
+    with patch.object(svc._storage, 'push') as mock_push:
+        svc.sync_now()
+    mock_push.assert_called_once_with(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# StreamManager.start / stop
+# ---------------------------------------------------------------------------
+
+def test_stream_manager_start_creates_threads(tmp_path):
+    cfg = _make_config(tmp_path, jobs=[
+        _stream_job(exchange='binance', pairs=['BTC/USDT', 'ETH/USDT']),
+    ])
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):  # don't actually run
+        with patch.object(mgr._sync, 'start'):
+            mgr.start()
+
+    assert len(mgr._threads) == 2
+
+
+def test_stream_manager_start_starts_sync(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):
+        with patch.object(mgr._sync, 'start') as mock_sync_start:
+            mgr.start()
+
+    mock_sync_start.assert_called_once()
+
+
+def test_stream_manager_bitfinex_two_channels_two_threads(tmp_path):
+    cfg = _make_config(tmp_path, jobs=[
+        _stream_job(exchange='bitfinex', pairs=['BTC/USD'], channels=['trades', 'book']),
+    ])
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):
+        with patch.object(mgr._sync, 'start'):
+            mgr.start()
+
+    assert len(mgr._threads) == 2
+
+
+def test_stream_manager_stop_sets_event(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    with patch.object(mgr._sync, 'stop'):
+        mgr.stop()
+    assert mgr._stop_event.is_set()
+
+
+def test_stream_manager_stop_signals_downloaders(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+
+    dl = MagicMock()
+    dl.until = time.time() + 9999
+    dl.is_connect = True
+    mgr._downloaders['fake'] = dl
+
+    with patch.object(mgr._sync, 'stop'):
+        mgr.stop()
+
+    assert dl.is_connect is False
+    assert dl.until <= time.time()
+
+
+# ---------------------------------------------------------------------------
+# StreamManager._run_forever
+# ---------------------------------------------------------------------------
+
+def test_run_forever_stops_immediately_if_stop_set(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    mgr._stop_event.set()
+
+    with patch.object(mgr, '_run_once') as mock_once:
+        mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'])
+
+    mock_once.assert_not_called()
+
+
+def test_run_forever_restarts_on_exception(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    call_count = 0
+
+    def _side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError('crash')
+        mgr._stop_event.set()  # stop after second call
+
+    with patch.object(mgr, '_run_once', side_effect=_side_effect):
+        with patch.object(mgr._stop_event, 'wait', return_value=False):
+            mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'])
+
+    assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# StreamManager._run_once (unit, mocked downloader)
+# ---------------------------------------------------------------------------
+
+def _patch_stream_classes(exchange, mock_cls):
+    """Context manager that replaces one entry in _STREAM_CLASSES."""
+    import dccd.daemon.stream_manager as sm
+    original = sm._STREAM_CLASSES.copy()
+    sm._STREAM_CLASSES[exchange] = mock_cls
+    return original
+
+
+def test_run_once_configures_downloader(tmp_path):
+    import dccd.daemon.stream_manager as sm
+
+    job = _stream_job(exchange='binance', channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    mock_obj = MagicMock()
+    mock_cls = MagicMock(return_value=mock_obj)
+
+    original = sm._STREAM_CLASSES.copy()
+    sm._STREAM_CLASSES['binance'] = mock_cls
+    try:
+        with patch('asyncio.new_event_loop') as mock_loop_fn, \
+             patch('asyncio.set_event_loop'), \
+             patch('asyncio.gather'):
+            mock_loop = MagicMock()
+            mock_loop_fn.return_value = mock_loop
+            mock_loop.run_until_complete.side_effect = None
+            mgr._run_once(job, 'BTC/USDT', ['trades'])
+    finally:
+        sm._STREAM_CLASSES.update(original)
+
+    mock_cls.assert_called_once_with(pair='BTCUSDT', time_step=60, until=0)
+    mock_obj.set_process_data.assert_called_once_with(set_trades)
+    mock_obj.set_saver.assert_called_once()
+
+
+def test_run_once_bitfinex_sets_parser(tmp_path):
+    import dccd.daemon.stream_manager as sm
+
+    job = _stream_job(exchange='bitfinex', channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    mock_obj = MagicMock()
+    mock_obj.get_parser.return_value = MagicMock()
+    mock_cls = MagicMock(return_value=mock_obj)
+
+    original = sm._STREAM_CLASSES.copy()
+    sm._STREAM_CLASSES['bitfinex'] = mock_cls
+    try:
+        with patch('asyncio.new_event_loop') as mock_loop_fn, \
+             patch('asyncio.set_event_loop'), \
+             patch('asyncio.gather'):
+            mock_loop = MagicMock()
+            mock_loop_fn.return_value = mock_loop
+            mock_loop.run_until_complete.side_effect = None
+            mgr._run_once(job, 'BTC/USD', ['trades'])
+    finally:
+        sm._STREAM_CLASSES.update(original)
+
+    mock_obj.get_parser.assert_called_once_with('trades')
+    assert mock_obj.parser is mock_obj.get_parser.return_value

--- a/dccd/tests/test_kraken.py
+++ b/dccd/tests/test_kraken.py
@@ -6,8 +6,25 @@ import time
 import pytest
 
 from dccd import FromKraken as fk
+from dccd.histo_dl.kraken import FromKraken
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USD',  'XXBTZUSD'),
+    ('BTC', 'EUR',  'XXBTZEUR'),
+    ('BTC', 'CAD',  'XXBTZCAD'),
+    ('BTC', 'JPY',  'XXBTZJPY'),
+    ('BTC', 'GBP',  'XXBTZGBP'),
+    ('BCH', 'EUR',  'BCHEUR'),
+    ('BCH', 'USD',  'BCHUSD'),
+    ('DASH', 'USD', 'DASHUSD'),
+    ('XMR', 'XBT',  'XXMRXXBT'),
+    ('XMR', 'EUR',  'XXMRZEUR'),
+])
+def test_format_pair(crypto, fiat, expected):
+    assert FromKraken.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_kraken.py
+++ b/dccd/tests/test_kraken.py
@@ -9,6 +9,7 @@ from dccd import FromKraken as fk
 from dccd.histo_dl.kraken import FromKraken
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+TRADE_KEYS = ['tid', 'timestamp', 'price', 'amount', 'type']
 
 
 @pytest.mark.parametrize('crypto,fiat,expected', [
@@ -55,3 +56,25 @@ def test_malformed_response_raises(loader, monkeypatch):
     monkeypatch.setattr("requests.get", lambda *a, **kw: m)
     with pytest.raises(KeyError):
         loader._import_data(start=0)
+
+
+def test_import_trades(loader, mock_kraken_trades):
+    data = loader._import_trades(start=0, end=int(time.time()))
+    assert isinstance(data, list)
+    assert len(data) > 0
+    for key in TRADE_KEYS:
+        assert key in data[0]
+
+
+def test_import_orderbook(loader, mock_kraken_depth):
+    data = loader._import_orderbook(depth=2)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    sides = {d['side'] for d in data}
+    assert 'bid' in sides
+    assert 'ask' in sides
+
+
+def test_import_trades_http_500_raises(loader, mock_http_500):
+    with pytest.raises(ValueError):
+        loader._import_trades(start=0, end=1)

--- a/dccd/tests/test_kraken_ws.py
+++ b/dccd/tests/test_kraken_ws.py
@@ -97,24 +97,25 @@ def test_parser_trades_appends_to_data():
     dl = _make_downloader()
     dl.parser_trades(_TRADE_DATA)
     assert 2000 in dl._data
-    assert len(dl._data[2000]) == 2
-    assert dl._data[2000][0]['price'] == 30000.0
+    assert len(dl._data[2000]['trades']) == 2
+    assert dl._data[2000]['trades'][0]['price'] == 30000.0
 
 
 def test_parser_book_updates_and_removes():
     dl = _make_downloader()
     msg = {'channel': 'book', 'type': 'snapshot', 'data': _BOOK_DATA}
     dl.parser_book(msg)
-    assert '29990.0' in dl._data[2000]
-    assert dl._data[2000]['29990.0'] == 2.0
-    assert '29980.0' not in dl._data[2000]
+    book = dl._data[2000]['book']
+    assert '29990.0' in book
+    assert book['29990.0'] == 2.0
+    assert '29980.0' not in book
 
 
 def test_parser_kline_appends():
     dl = _make_downloader()
     dl.parser_kline(_KLINE_DATA)
     assert 2000 in dl._data
-    assert dl._data[2000][0]['open'] == 30000.0
+    assert dl._data[2000]['trades'][0]['open'] == 30000.0
 
 
 @pytest.mark.asyncio

--- a/dccd/tests/test_models.py
+++ b/dccd/tests/test_models.py
@@ -43,5 +43,11 @@ def test_trade_type_optional():
 
 
 def test_orderbookentry_valid():
-    e = OrderBookEntry(price='50000', count=3, amount=1.5)
+    e = OrderBookEntry(side='bid', price='50000', count=3, amount=1.5)
     assert e.price == '50000'
+    assert e.side == 'bid'
+
+
+def test_orderbookentry_count_optional():
+    e = OrderBookEntry(side='ask', price='50100', amount=0.5)
+    assert e.count is None

--- a/dccd/tests/test_okx.py
+++ b/dccd/tests/test_okx.py
@@ -9,6 +9,7 @@ from dccd import FromOKX
 from dccd.histo_dl.okx import FromOKX as _FromOKX
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+TRADE_KEYS = ['tid', 'timestamp', 'price', 'amount', 'type']
 
 
 @pytest.mark.parametrize('crypto,fiat,expected', [
@@ -52,3 +53,25 @@ def test_malformed_response_raises(loader, monkeypatch):
     monkeypatch.setattr("requests.get", lambda *a, **kw: m)
     with pytest.raises(KeyError):
         loader._import_data(start=0)
+
+
+def test_import_trades(loader, mock_okx_trades):
+    data = loader._import_trades(start=0, end=int(time.time()))
+    assert isinstance(data, list)
+    assert len(data) > 0
+    for key in TRADE_KEYS:
+        assert key in data[0]
+
+
+def test_import_orderbook(loader, mock_okx_books):
+    data = loader._import_orderbook(depth=2)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    sides = {d['side'] for d in data}
+    assert 'bid' in sides
+    assert 'ask' in sides
+
+
+def test_import_trades_http_500_raises(loader, mock_http_500):
+    with pytest.raises(ValueError):
+        loader._import_trades(start=0, end=1)

--- a/dccd/tests/test_okx.py
+++ b/dccd/tests/test_okx.py
@@ -6,8 +6,18 @@ import time
 import pytest
 
 from dccd import FromOKX
+from dccd.histo_dl.okx import FromOKX as _FromOKX
 
 OHLC_KEYS = ['date', 'open', 'high', 'low', 'close', 'volume', 'quoteVolume']
+
+
+@pytest.mark.parametrize('crypto,fiat,expected', [
+    ('BTC', 'USDT', 'BTC-USDT'),
+    ('ETH', 'USDT', 'ETH-USDT'),
+    ('SOL', 'BTC',  'SOL-BTC'),
+])
+def test_format_pair(crypto, fiat, expected):
+    assert _FromOKX.format_pair(crypto, fiat) == expected
 
 
 @pytest.fixture

--- a/dccd/tests/test_okx_ws.py
+++ b/dccd/tests/test_okx_ws.py
@@ -92,8 +92,8 @@ def test_parser_trades_appends_to_data():
     dl = _make_downloader()
     dl.parser_trades(_TRADE_DATA)
     assert 2000 in dl._data
-    assert len(dl._data[2000]) == 2
-    assert dl._data[2000][0]['price'] == 42219.9
+    assert len(dl._data[2000]['trades']) == 2
+    assert dl._data[2000]['trades'][0]['price'] == 42219.9
 
 
 def test_parser_book_updates_and_removes():
@@ -101,16 +101,17 @@ def test_parser_book_updates_and_removes():
     msg = {'arg': {'channel': 'books50-l2-tbt'}, 'action': 'snapshot',
            'data': _BOOK_DATA}
     dl.parser_book(msg)
-    assert '41006.8' in dl._data[2000]
+    book = dl._data[2000]['book']
+    assert '41006.8' in book
     # zero-qty bid should be removed
-    assert '0' not in dl._data[2000]
+    assert '0' not in book
 
 
 def test_parser_kline_appends():
     dl = _make_downloader()
     dl.parser_kline(_KLINE_DATA)
     assert 2000 in dl._data
-    assert dl._data[2000][0]['open'] == 42000.0
+    assert dl._data[2000]['trades'][0]['open'] == 42000.0
 
 
 @pytest.mark.asyncio

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -15,11 +15,15 @@ periodically syncs all local data to one or more remote destinations via rclone.
 Quick start
 -----------
 
-1. Install the daemon extra::
+1. Install the daemon extra:
+
+   .. code-block:: bash
 
        pip install "dccd[daemon]"
 
-2. Write a configuration file (see :ref:`daemon-config`)::
+2. Write a configuration file (see :ref:`daemon-config`):
+
+   .. code-block:: yaml
 
        storage:
          local_path: /data/crypto/
@@ -41,7 +45,9 @@ Quick start
            channels: [trades, book]
            time_step: 60
 
-3. Run a one-shot collection, then start the daemon::
+3. Run a one-shot collection, then start the daemon:
+
+   .. code-block:: python
 
        from dccd.daemon.config import load_config
        from dccd.daemon.scheduler import run_once, build_histo_scheduler

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -11,9 +11,11 @@ The daemon module provides an autonomous, server-side data collector.
 It reads a declarative YAML configuration, runs historical REST jobs on a
 schedule (APScheduler), opens WebSocket streams for real-time collection, and
 periodically syncs all local data to one or more remote destinations via rclone.
+Per-job metrics and a rotating log file are maintained by
+:class:`~dccd.daemon.health.HealthMonitor`.
 
-Quick start
------------
+Quick start (CLI)
+-----------------
 
 1. Install the daemon extra:
 
@@ -35,35 +37,80 @@ Quick start
        histo_jobs:
          - exchange: binance
            pairs: [BTC/USDT, ETH/USDT]
-           span: 3600
+           span: 3600          # candle interval in seconds
            format: parquet
-           by_period: Y
+           by_period: Y        # one file per year
 
+       # Optional real-time streams
        stream_jobs:
          - exchange: binance
            pairs: [BTC/USDT]
            channels: [trades, book]
            time_step: 60
 
-3. Run a one-shot collection, then start the daemon:
+       # Optional webhook alerts on consecutive failures
+       alerts:
+         webhook_url: "https://hooks.slack.com/services/..."
+         max_consecutive_errors: 3
 
-   .. code-block:: python
+3. Validate, run once, then start the daemon:
 
-       from dccd.daemon.config import load_config
-       from dccd.daemon.scheduler import run_once, build_histo_scheduler
-       from dccd.daemon.stream_manager import StreamManager
+   .. code-block:: bash
 
-       config = load_config('config.yml')
+       # Check config without running anything
+       dccd validate --config config.yml
+       # Config: config.yml
+       #   storage.local_path : /data/crypto/
+       #   remotes            : 1
+       #   histo_jobs         : 1
+       #   stream_jobs        : 1
+       # Config is valid.
 
        # One-shot: download all histo jobs once and exit
-       run_once(config)
+       dccd run --config config.yml
+       # Done. successes=2 failures=0
 
-       # Daemon: start periodic histo scheduler + WebSocket streams
-       scheduler = build_histo_scheduler(config)
-       scheduler.start()
+       # Continuous daemon (block until Ctrl-C / SIGTERM)
+       dccd start --config config.yml
 
-       mgr = StreamManager(config)
-       mgr.start()
+       # Inspect per-job health after the daemon has run
+       dccd status --config config.yml
+       # job                      last_run          last_success       rows  errors
+       # -------------------------------------------------------------------------
+       # binance/BTC/USDT         2026-05-17 10:00  2026-05-17 10:00   1200       0
+       # binance/ETH/USDT         2026-05-17 10:00  2026-05-17 10:00    980       0
+
+       # Add a new histo job to an existing config in-place
+       dccd add --exchange kraken --pair ETH/USD --span 86400 --config config.yml
+
+Python API
+----------
+
+Use the components directly when you need to embed the daemon inside your
+own process or customise startup/shutdown logic.  The script
+:file:`examples/daemon_example.py` shows the full wiring:
+
+.. code-block:: python
+
+    from dccd.daemon.config import load_config
+    from dccd.daemon.health import HealthMonitor
+    from dccd.daemon.scheduler import build_histo_scheduler, run_once
+    from dccd.daemon.stream_manager import StreamManager
+
+    config  = load_config('config.yml')
+    health  = HealthMonitor(config.storage.local_path, config.alerts)
+
+    # --- one-shot mode (cron-friendly) ---
+    run_once(config, health=health)
+
+    # --- or continuous mode ---
+    scheduler  = build_histo_scheduler(config, health=health)
+    stream_mgr = StreamManager(config, health=health)
+    scheduler.start()
+    stream_mgr.start()
+    # … wait for stop signal …
+    scheduler.shutdown(wait=False)
+    stream_mgr.stop()
 
 .. _daemon-config:
 
@@ -100,6 +147,15 @@ Stream manager
    stream_manager.StreamManager -- manage real-time WebSocket collection jobs
    stream_manager.SyncService -- periodically push local data to all remote destinations
 
+Health monitoring
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   health.HealthMonitor -- track per-job metrics, write rotating logs, send webhook alerts
+   health.JobMetrics -- per-job health metrics dataclass
+
 Storage
 -------
 
@@ -107,3 +163,11 @@ Storage
    :toctree: generated/
 
    storage.RemoteStorage -- push local data directories to remote destinations via rclone
+
+CLI
+---
+
+.. autosummary::
+   :toctree: generated/
+
+   cli.app -- typer application (``dccd`` entrypoint)

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -1,0 +1,103 @@
+-----------------------------------------
+ Daemon (:mod:`dccd.daemon`)
+-----------------------------------------
+
+.. automodule:: dccd.daemon
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:
+
+The daemon module provides an autonomous, server-side data collector.
+It reads a declarative YAML configuration, runs historical REST jobs on a
+schedule (APScheduler), opens WebSocket streams for real-time collection, and
+periodically syncs all local data to one or more remote destinations via rclone.
+
+Quick start
+-----------
+
+1. Install the daemon extra::
+
+       pip install "dccd[daemon]"
+
+2. Write a configuration file (see :ref:`daemon-config`)::
+
+       storage:
+         local_path: /data/crypto/
+         remotes:
+           - provider: rclone
+             remote: "mynas:crypto/"
+         sync_interval: 3600
+
+       histo_jobs:
+         - exchange: binance
+           pairs: [BTC/USDT, ETH/USDT]
+           span: 3600
+           format: parquet
+           by_period: Y
+
+       stream_jobs:
+         - exchange: binance
+           pairs: [BTC/USDT]
+           channels: [trades, book]
+           time_step: 60
+
+3. Run a one-shot collection, then start the daemon::
+
+       from dccd.daemon.config import load_config
+       from dccd.daemon.scheduler import run_once, build_histo_scheduler
+       from dccd.daemon.stream_manager import StreamManager
+
+       config = load_config('config.yml')
+
+       # One-shot: download all histo jobs once and exit
+       run_once(config)
+
+       # Daemon: start periodic histo scheduler + WebSocket streams
+       scheduler = build_histo_scheduler(config)
+       scheduler.start()
+
+       mgr = StreamManager(config)
+       mgr.start()
+
+.. _daemon-config:
+
+Configuration
+-------------
+
+.. autosummary::
+   :toctree: generated/
+
+   config.load_config -- load and validate a YAML configuration file
+   config.CollectorConfig -- root configuration model
+   config.StorageConfig -- local storage path and remote sync settings
+   config.RemoteConfig -- one rclone remote destination
+   config.HistoJob -- historical (REST) data collection job
+   config.StreamJob -- real-time (WebSocket) data collection job
+   config.AlertConfig -- optional webhook alerting settings
+
+Scheduler
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   scheduler.build_histo_scheduler -- build an APScheduler BackgroundScheduler from config
+   scheduler.run_histo_job -- download and save one (exchange, pair) candle job
+   scheduler.run_once -- execute all histo_jobs once and return
+
+Stream manager
+--------------
+
+.. autosummary::
+   :toctree: generated/
+
+   stream_manager.StreamManager -- manage real-time WebSocket collection jobs
+   stream_manager.SyncService -- periodically push local data to all remote destinations
+
+Storage
+-------
+
+.. autosummary::
+   :toctree: generated/
+
+   storage.RemoteStorage -- push local data directories to remote destinations via rclone

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -86,14 +86,18 @@ Supported exchanges
 Presentation
 ------------
 
-The ``dccd`` package provides two main methods to download data:
+The ``dccd`` package provides three ways to download data:
 
-- **Continuous Downloader** :mod:`dccd.continuous_dl`:
-   Stream real-time data (order book, trades, OHLCV) via WebSocket with automatic
-   reconnection. Supports Binance, Bitfinex, Bitmex, Bybit, Kraken, and OKX.
 - **Historical Downloader** :mod:`dccd.histo_dl`:
    Download OHLCV data via REST APIs with chunked requests and incremental updates.
    Supports Binance, Coinbase, Kraken, Bybit, and OKX.
+- **Continuous Downloader** :mod:`dccd.continuous_dl`:
+   Stream real-time data (order book, trades, OHLCV) via WebSocket with automatic
+   reconnection. Supports Binance, Bitfinex, Bitmex, Bybit, Kraken, and OKX.
+- **Daemon** :mod:`dccd.daemon`:
+   Autonomous, server-side collector driven by a YAML config.  Runs REST jobs on a
+   schedule (APScheduler), opens WebSocket streams, and syncs data to remote
+   destinations (NAS, S3, SFTP, …) via rclone.
 
 Contents
 --------
@@ -114,5 +118,6 @@ Contents
    histo_dl.kraken
    histo_dl.bybit
    histo_dl.okx
+   daemon
    process_data
    tools

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,14 +8,18 @@ Installation
 ------------
 
 From pip:
-   $ pip install dccd
+
+.. code-block:: bash
+
+   pip install dccd
 
 From source:
-   $ git clone https://github.com/ArthurBernard/Download_Crypto_Currencies_Data.git
 
-   $ cd Download_Crypto_Currencies_Data
+.. code-block:: bash
 
-   $ pip install -e .
+   git clone https://github.com/ArthurBernard/Download_Crypto_Currencies_Data.git
+   cd Download_Crypto_Currencies_Data
+   pip install -e .
 
 Supported exchanges
 -------------------

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -1,0 +1,81 @@
+# dccd daemon — example configuration
+#
+# Copy this file, adapt it to your setup, and pass it to the daemon:
+#   dccd validate --config config.yml    # check without running
+#   dccd run --once --config config.yml  # run all jobs once and exit
+#   dccd start --config config.yml       # run as a daemon
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+storage:
+  # Root directory on the daemon host where data files are written.
+  local_path: /data/crypto/
+
+  # Optional: push data to a remote after each save.
+  # Requires rclone (https://rclone.org) installed on the daemon host and
+  # a named remote configured with `rclone config`.
+  #
+  # Examples:
+  #   mynas:crypto/         → NAS / Freebox via SMB or SFTP
+  #   mypc:data/crypto/     → local PC via SFTP (OpenSSH)
+  #   s3:mybucket/crypto/   → Amazon S3
+  #   gdrive:crypto/        → Google Drive
+  #
+  # Remove this block to keep data on the daemon host only.
+  remote:
+    provider: rclone
+    remote: "mynas:crypto/"   # rclone remote name + path
+
+
+# ---------------------------------------------------------------------------
+# Historical (REST API) jobs
+# ---------------------------------------------------------------------------
+# Each job polls one exchange at a fixed interval and saves OHLCV candles.
+# One file per period (by_period) is created under:
+#   {local_path}/{Exchange}/Data/Clean_Data/{span_label}/{pair}/
+histo_jobs:
+
+  - exchange: binance          # one of: binance, kraken, bybit, okx, coinbase
+    pairs:
+      - BTC/USDT               # 'CRYPTO/FIAT' format
+      - ETH/USDT
+    span: 3600                 # candle interval in seconds (>= 60)
+    format: parquet            # one of: parquet, csv, xlsx
+    by_period: Y               # file grouping: Y (year), M (month), D (day)
+
+  - exchange: kraken
+    pairs:
+      - BTC/USD
+      - ETH/USD
+    span: 86400                # daily candles
+    format: parquet
+    by_period: Y
+
+  - exchange: bybit
+    pairs:
+      - BTC/USDT
+    span: 900                  # 15-minute candles
+    format: csv
+    by_period: M               # one file per month
+
+
+# ---------------------------------------------------------------------------
+# Real-time (WebSocket) jobs  [not yet implemented — reserved for task 4.4]
+# ---------------------------------------------------------------------------
+# stream_jobs:
+#   - exchange: binance
+#     pairs:
+#       - BTC/USDT
+#     channels:
+#       - trades
+#       - book
+#     time_step: 60            # snapshot interval in seconds
+
+
+# ---------------------------------------------------------------------------
+# Alerts  (optional)
+# ---------------------------------------------------------------------------
+# alerts:
+#   webhook_url: "https://hooks.slack.com/services/T.../B.../..."
+#   max_consecutive_errors: 3  # send alert after N consecutive failures

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -12,20 +12,26 @@ storage:
   # Root directory on the daemon host where data files are written.
   local_path: /data/crypto/
 
-  # Optional: push data to a remote after each save.
+  # Optional: push data to one or more remotes after each sync cycle.
   # Requires rclone (https://rclone.org) installed on the daemon host and
-  # a named remote configured with `rclone config`.
+  # named remotes configured with `rclone config`.
   #
-  # Examples:
+  # Supported destinations (examples):
   #   mynas:crypto/         → NAS / Freebox via SMB or SFTP
   #   mypc:data/crypto/     → local PC via SFTP (OpenSSH)
   #   s3:mybucket/crypto/   → Amazon S3
   #   gdrive:crypto/        → Google Drive
   #
   # Remove this block to keep data on the daemon host only.
-  remote:
-    provider: rclone
-    remote: "mynas:crypto/"   # rclone remote name + path
+  remotes:
+    - provider: rclone
+      remote: "mynas:crypto/"       # primary destination (NAS / Freebox)
+    # - provider: rclone
+    #   remote: "s3:mybucket/crypto/"  # secondary destination (S3 backup)
+
+  # Interval in seconds between sync cycles (default: 3600 = 1 hour).
+  # Set to 0 to disable remote sync entirely.
+  sync_interval: 3600
 
 
 # ---------------------------------------------------------------------------
@@ -61,10 +67,14 @@ histo_jobs:
 
 
 # ---------------------------------------------------------------------------
-# Real-time (WebSocket) jobs  [not yet implemented — reserved for task 4.4]
+# Real-time (WebSocket) jobs
 # ---------------------------------------------------------------------------
+# Each job opens one WebSocket connection per pair (or per pair+channel for
+# Bitfinex/Bitmex) and saves snapshots every time_step seconds under:
+#   {local_path}/{Exchange}/Data/WS_Data/{time_step}s/{pair}/
+#
 # stream_jobs:
-#   - exchange: binance
+#   - exchange: binance        # one of: binance, kraken, bybit, okx, bitfinex, bitmex
 #     pairs:
 #       - BTC/USDT
 #     channels:

--- a/examples/daemon_example.py
+++ b/examples/daemon_example.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Programmatic daemon usage — without the CLI.
+
+This script shows how to wire the daemon components together in pure Python.
+It is the equivalent of ``dccd start --config config.yml`` but gives you full
+control over each component: useful when embedding the daemon inside a larger
+process or when you need custom startup/shutdown logic.
+
+Components
+----------
+- :func:`~dccd.daemon.config.load_config` — parse and validate the YAML config
+- :class:`~dccd.daemon.health.HealthMonitor` — rotating log + metrics JSON
+- :func:`~dccd.daemon.scheduler.build_histo_scheduler` — APScheduler for REST jobs
+- :class:`~dccd.daemon.stream_manager.StreamManager` — WebSocket threads
+- :func:`~dccd.daemon.scheduler.run_once` — one-shot alternative to the scheduler
+
+Prerequisites
+-------------
+    pip install "dccd[daemon]"
+    # Copy and adapt examples/config.example.yml to config.yml
+    # (or point CONFIG_PATH to any valid YAML config)
+
+"""
+
+import logging
+import signal
+import threading
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(name)s %(levelname)s %(message)s',
+)
+
+CONFIG_PATH = 'config.yml'
+
+# ---------------------------------------------------------------------------
+# 1. Load and validate the YAML configuration
+# ---------------------------------------------------------------------------
+from dccd.daemon.config import load_config
+
+config = load_config(CONFIG_PATH)
+print(f'Loaded config: {len(config.histo_jobs)} histo jobs, '
+      f'{len(config.stream_jobs)} stream jobs')
+
+# ---------------------------------------------------------------------------
+# 2. Initialise the health monitor
+#
+#    Creates {local_path}/.dccd/ with:
+#      - dccd.log  (rotating, 10 MB × 5 files)
+#      - metrics.json (updated after every job execution)
+#    Optional webhook alerts are configured in config.alerts.
+# ---------------------------------------------------------------------------
+from dccd.daemon.health import HealthMonitor
+
+health = HealthMonitor(config.storage.local_path, config.alerts)
+
+# ---------------------------------------------------------------------------
+# 3a. One-shot run: execute every histo_job once, then return
+#
+#     Use this in a cron job or for an initial backfill.
+#     Failed jobs are logged and skipped; others continue.
+# ---------------------------------------------------------------------------
+from dccd.daemon.scheduler import run_once
+
+# run_once(config, health=health)   # uncomment for one-shot mode
+
+# ---------------------------------------------------------------------------
+# 3b. Continuous daemon: scheduler + stream manager
+#
+#     build_histo_scheduler() creates an APScheduler BackgroundScheduler
+#     with one interval job per (exchange, pair) defined in histo_jobs.
+#
+#     StreamManager starts one background thread per (exchange, pair) for
+#     every stream_job; threads restart automatically on crash.
+# ---------------------------------------------------------------------------
+from dccd.daemon.scheduler import build_histo_scheduler
+from dccd.daemon.stream_manager import StreamManager
+
+scheduler = build_histo_scheduler(config, health=health)
+stream_mgr = StreamManager(config, health=health)
+
+# ---------------------------------------------------------------------------
+# 4. Graceful shutdown on SIGINT / SIGTERM
+# ---------------------------------------------------------------------------
+stop_event = threading.Event()
+
+
+def _shutdown(signum, frame):
+    print('\nShutting down daemon…')
+    stop_event.set()
+
+
+signal.signal(signal.SIGINT, _shutdown)
+signal.signal(signal.SIGTERM, _shutdown)
+
+# ---------------------------------------------------------------------------
+# 5. Start and block
+# ---------------------------------------------------------------------------
+print('Starting daemon. Press Ctrl-C to stop.')
+scheduler.start()
+stream_mgr.start()
+
+stop_event.wait()
+
+scheduler.shutdown(wait=False)
+stream_mgr.stop()
+
+# ---------------------------------------------------------------------------
+# 6. Print a final metrics snapshot
+# ---------------------------------------------------------------------------
+metrics = health.get_metrics()
+print(f'\nFinal metrics ({len(metrics)} jobs):')
+for key, m in metrics.items():
+    print(f'  {key:30s}  rows={m.rows_collected:6d}  errors={m.errors_count}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "2.1.0"
+version = "2.2.0"
 description = "Download Crypto Currency Data from different exchanges."
 readme = "README.rst"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
 
 [project.optional-dependencies]
 io = ["pyarrow>=13", "polars>=0.20"]
-dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0"]
+daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4"]
+dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
 doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,12 @@ dependencies = [
 
 [project.optional-dependencies]
 io = ["pyarrow>=13", "polars>=0.20"]
-daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4"]
-dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
+daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12"]
+dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12"]
 doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
+
+[project.scripts]
+dccd = "dccd.daemon.cli:app"
 
 [project.urls]
 Homepage = "https://github.com/ArthurBernard/Download_Crypto_Currencies_Data"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 io = ["pyarrow>=13", "polars>=0.20"]
 daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4"]
 dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
-doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton"]
+doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
 
 [project.urls]
 Homepage = "https://github.com/ArthurBernard/Download_Crypto_Currencies_Data"


### PR DESCRIPTION
## v2.2.0

### Added

- **REST trades** (`import_trades`) and **order book snapshots** (`import_orderbook`) for all five exchanges — Binance and Kraken support full paginated history; Bybit and Coinbase return recent-only snapshots (#31)
- **`dccd` daemon** — autonomous server-side collector driven by a YAML config: scheduler (APScheduler), stream manager (WebSocket threads + auto-restart), multi-remote storage sync via rclone, health monitor with rotating logs and webhook alerts, `dccd` CLI (`validate`, `run`, `start`, `status`, `add`) (#25, #26, #28, #30)
- `OrderBookEntry.side` field; `Trade.tid` and `OrderBookEntry.count` made optional (#31)

### Changed

- `format_pair(crypto, fiat)` extracted as a testable static method on each REST class (#29)
- `continuous_dl` base class unified: `_push_trades`, `_push_book_updates`, crash-recovery checkpoint, `snapshot_ts` injected into every payload (#28, #29)

### Full changelog
See [CHANGELOG.md](https://github.com/ArthurBernard/Download_Crypto_Currencies_Data/blob/master/CHANGELOG.md).