### PR TITLE
fix: suppress Sphinx RST errors from Pydantic BaseModel and typer

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -121,6 +121,27 @@ autodoc_inherit_docstrings = False
 autodoc_typehints = 'none'
 
 # --------------------------------------------------------------------------- #
+#                         Autodoc skip-member hook                            #
+# --------------------------------------------------------------------------- #
+
+import pydantic as _pydantic
+
+_PYDANTIC_BASE_MEMBERS = frozenset(dir(_pydantic.BaseModel))
+
+
+def _skip_pydantic_member(app, what, name, obj, skip, options):
+    """ Skip Pydantic BaseModel methods — their docstrings contain broken RST. """
+    if skip:
+        return True
+    if name in _PYDANTIC_BASE_MEMBERS and name not in ('__init__', '__doc__'):
+        return True
+    return skip
+
+
+def setup(app):
+    app.connect('autodoc-skip-member', _skip_pydantic_member)
+
+# --------------------------------------------------------------------------- #
 #                              Numpydoc config                                #
 # --------------------------------------------------------------------------- #
 

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -167,7 +167,11 @@ Storage
 CLI
 ---
 
-.. autosummary::
-   :toctree: generated/
+The ``dccd`` command is a `typer <https://typer.tiangolo.com/>`_ application
+installed as a console script by ``pip install "dccd[daemon]"``.
+Its commands are documented in the *Quick start* section above.
 
-   cli.app -- typer application (``dccd`` entrypoint)
+.. automodule:: dccd.daemon.cli
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:


### PR DESCRIPTION
Hotfix pour la doc — zéro erreur au build Sphinx.

- `conf.py` — hook `autodoc-skip-member` qui ignore les membres hérités de `pydantic.BaseModel` (leurs docstrings `model_*` contiennent du RST mal formé)
- `daemon.rst` — `cli.app` remplacé par de la prose + `automodule` pour éviter de documenter les internals typer via `autodata`