### PR TITLE
feat: centralized settings (data_path, timezone) in config.yml

### DIFF
--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -20,6 +20,7 @@ __all__ = [
     'AlertConfig',
     'HistoJob',
     'RemoteConfig',
+    'SettingsConfig',
     'StorageConfig',
     'StreamJob',
     'load_config',
@@ -33,6 +34,39 @@ SUPPORTED_STREAM_EXCHANGES: frozenset[str] = frozenset(
 )
 SUPPORTED_FORMATS: frozenset[str] = frozenset({'xlsx', 'csv', 'parquet'})
 SUPPORTED_BY_PERIOD: frozenset[str] = frozenset({'Y', 'M', 'D'})
+
+
+class SettingsConfig(BaseModel):
+    """ Global local settings shared by the daemon and the backfill command.
+
+    Parameters
+    ----------
+    data_path : str
+        Root directory for all local data files.  Default ``'./data/crypto'``.
+    timezone : str
+        Timezone used to interpret date strings and label output files.
+        ``'local'`` (default) uses the system timezone, ``'UTC'`` uses UTC,
+        any other value is an IANA name (e.g. ``'Europe/Paris'``).
+
+    """
+
+    data_path: str = './data/crypto'
+    timezone: str = 'local'
+
+    @field_validator('timezone')
+    @classmethod
+    def _validate_timezone(cls, v: str) -> str:
+        if v.upper() in ('LOCAL', 'UTC'):
+            return v
+        try:
+            from zoneinfo import ZoneInfo
+            ZoneInfo(v)
+        except KeyError:
+            raise ValueError(
+                f"Unknown timezone {v!r}. "
+                "Use 'local', 'UTC', or an IANA name like 'Europe/Paris'."
+            )
+        return v
 
 
 class RemoteConfig(BaseModel):
@@ -56,8 +90,9 @@ class StorageConfig(BaseModel):
 
     Parameters
     ----------
-    local_path : str
-        Absolute path where data is stored on the daemon host.
+    local_path : str, optional
+        Root data directory.  When omitted, :attr:`SettingsConfig.data_path`
+        is used (propagated by :class:`CollectorConfig`'s validator).
     remotes : list of RemoteConfig
         Remote destinations.  Empty list (default) keeps data locally only.
         Multiple entries are all synced by :class:`SyncService`.
@@ -67,7 +102,7 @@ class StorageConfig(BaseModel):
 
     """
 
-    local_path: str
+    local_path: str = ''
     remotes: list[RemoteConfig] = Field(default_factory=list)
     sync_interval: int = 3600
 
@@ -204,8 +239,11 @@ class CollectorConfig(BaseModel):
 
     Parameters
     ----------
+    settings : SettingsConfig
+        Global local settings (data path, timezone).
     storage : StorageConfig
-        Local (and optional remote) storage settings.
+        Remote storage configuration.  ``local_path`` defaults to
+        ``settings.data_path`` when not set explicitly.
     histo_jobs : list of HistoJob
         REST API polling jobs.
     stream_jobs : list of StreamJob
@@ -215,10 +253,17 @@ class CollectorConfig(BaseModel):
 
     """
 
-    storage: StorageConfig
+    settings: SettingsConfig = Field(default_factory=SettingsConfig)
+    storage: StorageConfig = Field(default_factory=StorageConfig)
     histo_jobs: list[HistoJob] = Field(default_factory=list)
     stream_jobs: list[StreamJob] = Field(default_factory=list)
     alerts: AlertConfig = Field(default_factory=AlertConfig)
+
+    @model_validator(mode='after')
+    def _propagate_data_path(self) -> 'CollectorConfig':
+        if not self.storage.local_path:
+            self.storage.local_path = self.settings.data_path
+        return self
 
     @model_validator(mode='after')
     def _at_least_one_job(self) -> 'CollectorConfig':

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -40,6 +40,7 @@ _HISTO_CLASSES: dict[str, type[ImportDataCryptoCurrencies]] = {
 
 
 def run_histo_job(job: HistoJob, pair: str, base_path: str,
+                  tz: str = 'local',
                   health: HealthMonitor | None = None) -> None:
     """ Download and save one (exchange, pair) candle job locally.
 
@@ -54,6 +55,8 @@ def run_histo_job(job: HistoJob, pair: str, base_path: str,
         Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
     base_path : str
         Root directory for local storage (``CollectorConfig.storage.local_path``).
+    tz : str, optional
+        Timezone for file labelling (``CollectorConfig.settings.timezone``).
     health : HealthMonitor or None, optional
         Health monitor to record success/failure metrics.
 
@@ -61,7 +64,7 @@ def run_histo_job(job: HistoJob, pair: str, base_path: str,
     crypto, fiat = pair.split('/', 1)
     cls = _HISTO_CLASSES[job.exchange]
     try:
-        obj = cls(base_path, crypto, job.span, fiat, form=job.format)
+        obj = cls(base_path, crypto, job.span, fiat, form=job.format, tz=tz)
         obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
         _data = getattr(obj, 'data', None)
         rows = len(_data) if _data is not None else 0
@@ -116,6 +119,7 @@ def build_histo_scheduler(config: CollectorConfig,
                     'job': job,
                     'pair': pair,
                     'base_path': config.storage.local_path,
+                    'tz': config.settings.timezone,
                     'health': health,
                 },
                 id=job_id,
@@ -146,7 +150,8 @@ def run_once(config: CollectorConfig,
     for job in config.histo_jobs:
         for pair in job.pairs:
             try:
-                run_histo_job(job, pair, config.storage.local_path, health=health)
+                run_histo_job(job, pair, config.storage.local_path,
+                              tz=config.settings.timezone, health=health)
             except Exception:
                 logger.exception(
                     'histo job failed: %s %s', job.exchange, pair

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -108,7 +108,7 @@ class FromBinance(ImportDataCryptoCurrencies):
             crypto = 'BTC'
         return crypto + fiat
 
-    def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
+    def __init__(self, path, crypto, span, fiat='USD', form='xlsx', tz='local'):
         """ Initialize object. """
         if fiat in ['EUR', 'USD']:
             _logger.warning(
@@ -118,7 +118,7 @@ class FromBinance(ImportDataCryptoCurrencies):
             self.fiat = fiat = 'USDT'
 
         ImportDataCryptoCurrencies.__init__(
-            self, path, crypto, span, 'Binance', fiat, form
+            self, path, crypto, span, 'Binance', fiat, form, tz=tz
         )
 
         self.pair = self.format_pair(crypto, fiat)

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -124,10 +124,10 @@ class FromBybit(ImportDataCryptoCurrencies):
         """
         return crypto + fiat
 
-    def __init__(self, path, crypto, span, fiat='USDT', form='xlsx'):
+    def __init__(self, path, crypto, span, fiat='USDT', form='xlsx', tz='local'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
-            self, path, crypto, span, 'Bybit', fiat, form
+            self, path, crypto, span, 'Bybit', fiat, form, tz=tz
         )
         self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Bybit/Data/Clean_Data/'

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -107,10 +107,10 @@ class FromCoinbase(ImportDataCryptoCurrencies):
             crypto = 'BTC'
         return crypto + '-' + fiat
 
-    def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
+    def __init__(self, path, crypto, span, fiat='USD', form='xlsx', tz='local'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
-            self, path, crypto, span, 'Coinbase', fiat, form
+            self, path, crypto, span, 'Coinbase', fiat, form, tz=tz
         )
         self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/Coinbase/Data/Clean_Data/'

--- a/dccd/histo_dl/exchange.py
+++ b/dccd/histo_dl/exchange.py
@@ -103,13 +103,14 @@ class ImportDataCryptoCurrencies(ABC):
 
     """
 
-    def __init__(self, path: str, crypto: str, span: int | str, platform: str, fiat: str = 'EUR', form: str = 'xlsx') -> None:
+    def __init__(self, path: str, crypto: str, span: int | str, platform: str, fiat: str = 'EUR', form: str = 'xlsx', tz: str = 'local') -> None:
         """ Initialize object. """
         self.logger = logging.getLogger(__name__)
         self.path = path
         self.crypto = crypto
         self.span, self.per = self._period(span)
         self.fiat = fiat
+        self.tz = tz
         self.pair = str(crypto + fiat)
         self.full_path = self.path + '/' + platform + '/Data/Clean_Data/'
         self.full_path += str(self.per) + '/' + self.pair
@@ -224,7 +225,7 @@ class ImportDataCryptoCurrencies(ABC):
 
         """
         fmt = self._PERIOD_FMT.get(self.by_period, '%' + self.by_period)
-        return TS_to_date(TS, form=fmt)
+        return TS_to_date(TS, form=fmt, tz=self.tz)
 
     def _name_file(self, date: str) -> str:
         """ Build the file stem for a given period label.
@@ -532,7 +533,7 @@ class ImportDataCryptoCurrencies(ABC):
 
         def _period_label(ts: float) -> str:
             fmt = ImportDataCryptoCurrencies._PERIOD_FMT.get(by_period, '%' + by_period)
-            return TS_to_date(int(ts), form=fmt)
+            return TS_to_date(int(ts), form=fmt, tz=self.tz)
 
         grouped = self.trades_df.groupby(
             self.trades_df['TS'].map(_period_label)

--- a/dccd/histo_dl/kraken.py
+++ b/dccd/histo_dl/kraken.py
@@ -119,10 +119,10 @@ class FromKraken(ImportDataCryptoCurrencies):
             return 'X' + crypto + 'X' + fiat
         return 'X' + crypto + 'Z' + fiat
 
-    def __init__(self, path, crypto, span, fiat='USD', form='xlsx'):
+    def __init__(self, path, crypto, span, fiat='USD', form='xlsx', tz='local'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
-            self, path, crypto, span, 'Kraken', fiat=fiat, form=form
+            self, path, crypto, span, 'Kraken', fiat=fiat, form=form, tz=tz
         )
         self.pair = self.format_pair(crypto, fiat)
 

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -124,10 +124,10 @@ class FromOKX(ImportDataCryptoCurrencies):
         """
         return crypto + '-' + fiat
 
-    def __init__(self, path, crypto, span, fiat='USDT', form='xlsx'):
+    def __init__(self, path, crypto, span, fiat='USDT', form='xlsx', tz='local'):
         """ Initialize object. """
         ImportDataCryptoCurrencies.__init__(
-            self, path, crypto, span, 'OKX', fiat, form
+            self, path, crypto, span, 'OKX', fiat, form, tz=tz
         )
         self.pair = self.format_pair(crypto, fiat)
         self.full_path = self.path + '/OKX/Data/Clean_Data/'

--- a/dccd/tests/test_daemon_scheduler.py
+++ b/dccd/tests/test_daemon_scheduler.py
@@ -87,7 +87,7 @@ def test_run_histo_job_calls_chain(tmp_path):
     finally:
         sched_mod._HISTO_CLASSES.update(original)
 
-    mock_cls.assert_called_once_with(str(tmp_path), 'BTC', 3600, 'USDT', form='parquet')
+    mock_cls.assert_called_once_with(str(tmp_path), 'BTC', 3600, 'USDT', form='parquet', tz='local')
     mock_obj.import_data.assert_called_once_with('last', 'now')
     mock_obj.save.assert_called_once_with(form='parquet', by_period='Y')
 
@@ -106,7 +106,7 @@ def test_run_histo_job_splits_pair_correctly(tmp_path):
     finally:
         sched_mod._HISTO_CLASSES.update(original)
 
-    mock_cls.assert_called_once_with(str(tmp_path), 'ETH', 3600, 'USDT', form='parquet')
+    mock_cls.assert_called_once_with(str(tmp_path), 'ETH', 3600, 'USDT', form='parquet', tz='local')
 
 
 # ---------------------------------------------------------------------------

--- a/dccd/tests/test_date_time.py
+++ b/dccd/tests/test_date_time.py
@@ -13,7 +13,12 @@ from dccd.tools.date_time import (
 def test_date_to_TS_roundtrip():
     ts = date_to_TS('2019-01-25 16:01:39')
     assert isinstance(ts, int)
-    assert TS_to_date(ts, local=True) == '2019-01-25 16:01:39'
+    assert TS_to_date(ts) == '2019-01-25 16:01:39'
+
+
+def test_date_to_TS_utc():
+    assert date_to_TS('2019-01-25 16:01:39', tz='UTC') == 1548432099
+    assert TS_to_date(1548432099, tz='UTC') == '2019-01-25 16:01:39'
 
 
 def test_str_to_span_aliases():

--- a/dccd/tools/date_time.py
+++ b/dccd/tools/date_time.py
@@ -11,6 +11,8 @@
 """
 
 # Built-in packages
+import calendar
+import datetime
 import logging
 import time
 
@@ -26,59 +28,75 @@ __all__ = [
 ]
 
 
-def TS_to_date(TS: int, form: str = '%Y-%m-%d %H:%M:%S', local: bool = True) -> str:
+def TS_to_date(TS: int, form: str = '%Y-%m-%d %H:%M:%S', tz: str = 'local') -> str:
     """ Convert timestamp to date in specified format.
 
     Parameters
     ----------
     TS : int
         A timestamp to convert.
-    form : str (default '%Y-%m-%d %H:%M:%S')
-        Time format.
-    local : bool (default is True)
-        Local time is used if true else return UTC time.
+    form : str, optional
+        strftime format string.  Default ``'%Y-%m-%d %H:%M:%S'``.
+    tz : str, optional
+        Timezone to use.  ``'local'`` (default) uses the system timezone,
+        ``'UTC'`` uses UTC, any other value is interpreted as an IANA
+        timezone name (e.g. ``'Europe/Paris'``).
 
     Returns
     -------
-    date : str
-        Date as specified format.
+    str
+        Date formatted according to *form*.
 
     Examples
     --------
-    >>> TS_to_date(1548432099, form='%y-%m-%d %H:%M:%S', local=False)
+    >>> TS_to_date(1548432099, form='%y-%m-%d %H:%M:%S', tz='UTC')
     '19-01-25 16:01:39'
 
     """
-    if local:
-        date = time.localtime(TS)
+    if tz.upper() == 'LOCAL':
+        return time.strftime(form, time.localtime(TS))
+    elif tz.upper() == 'UTC':
+        return time.strftime(form, time.gmtime(TS))
     else:
-        date = time.gmtime(TS)
-    return time.strftime(form, date)
+        from zoneinfo import ZoneInfo
+        dt = datetime.datetime.fromtimestamp(TS, tz=ZoneInfo(tz))
+        return dt.strftime(form)
 
 
-def date_to_TS(date: str, form: str = '%Y-%m-%d %H:%M:%S') -> int:
-    """ Use your local time-zone to convert date in specific format to
-    timestamp.
+def date_to_TS(date: str, form: str = '%Y-%m-%d %H:%M:%S', tz: str = 'local') -> int:
+    """ Convert a date string to a Unix timestamp.
 
     Parameters
     ----------
     date : str
-        A date to convert.
-    form : str (default '%Y-%m-%d %H:%M:%S')
-        Time format.
+        Date string to convert.
+    form : str, optional
+        strftime format string.  Default ``'%Y-%m-%d %H:%M:%S'``.
+    tz : str, optional
+        Timezone used to interpret *date*.  ``'local'`` (default) uses the
+        system timezone, ``'UTC'`` treats the string as UTC, any other value
+        is an IANA timezone name (e.g. ``'Europe/Paris'``).
 
     Returns
     -------
-    TS : int
-        Timestamp of specified date.
+    int
+        Unix timestamp.
 
     Examples
     --------
-    # >>> date_to_TS('19-01-25 16:01:39', form='%y-%m-%d %H:%M:%S')
-    # 1548428499
+    >>> date_to_TS('2019-01-25 16:01:39', tz='UTC')
+    1548432099
 
     """
-    return int(time.mktime(time.strptime(date, form)))
+    t = time.strptime(date, form)
+    if tz.upper() == 'LOCAL':
+        return int(time.mktime(t))
+    elif tz.upper() == 'UTC':
+        return int(calendar.timegm(t))
+    else:
+        from zoneinfo import ZoneInfo
+        dt = datetime.datetime(*t[:6], tzinfo=ZoneInfo(tz))
+        return int(dt.timestamp())
 
 
 # def TS_to_YMD(TS):


### PR DESCRIPTION
## Summary

- Single \`settings:\` block in \`config.yml\` as the source of truth for \`data_path\` and \`timezone\`
- \`backfill.py\` is now fully driven by \`config.yml\`: path, timezone, exchanges, pairs, span, format, by\_period — no hardcoded constants
- Timezone-aware date parsing and file labelling throughout the library

## Changes

- \`dccd/daemon/config.py\` — new \`SettingsConfig\` model; \`storage.local\_path\` now optional (defaults to \`settings.data\_path\`); \`CollectorConfig\` propagates it via model\_validator
- \`dccd/tools/date\_time.py\` — \`TS\_to\_date\` / \`date\_to\_TS\` gain \`tz\` parameter (replaces \`local: bool\`); supports \`'local'\`, \`'UTC'\`, and any IANA timezone name
- \`dccd/histo\_dl/exchange.py\` — \`self.tz\` attribute; \`_set\_by\_period\` and \`save\_trades\` use it for file labelling
- All five exchange subclasses — \`tz\` kwarg forwarded to base class
- \`dccd/daemon/scheduler.py\` — \`run\_histo\_job\` / \`run\_once\` propagate \`settings.timezone\` to exchange objects
- \`config.yml\` — \`settings:\` section added; \`storage.local\_path\` removed (inherited)
- \`scripts/backfill.py\` — rewritten to read everything from config

## Test plan

- [x] 258 tests pass locally
- [ ] CI green