### PR TITLE
feat: unified DataStore storage layer with new arborescence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/storage.py` — new `DataStore` class: unified read/write interface for OHLC, trades, and orderbook; `save(df)` (merge-on-TS, annual OHLC / daily trades+orderbook), `load(start, end)`, `existing_periods()`, `last_timestamp()`, `missing_intervals()` (stub for 3.2) (#XX)
-- `dccd/tools/date_time.py` — `span_label(span)` converts seconds to short directory labels (``'1m'``, ``'1h'``, ``'1d'``…); `_SPAN_LABEL` mapping exported (#XX)
-- `dccd/tests/test_storage.py` — 23 unit tests for `DataStore` (save/load/merge/missing_intervals/corrupted file recovery) (#XX)
-- `doc/source/storage.rst` — Sphinx page for `DataStore` with directory layout examples (#XX)
+- `dccd/storage.py` — new `DataStore` class: unified read/write interface for OHLC, trades, and orderbook; `save(df)` (merge-on-TS, annual OHLC / daily trades+orderbook), `load(start, end)`, `existing_periods()`, `last_timestamp()`, `missing_intervals()` (stub for 3.2) (#39)
+- `dccd/tools/date_time.py` — `span_label(span)` converts seconds to short directory labels (``'1m'``, ``'1h'``, ``'1d'``…); `_SPAN_LABEL` mapping exported (#39)
+- `dccd/tests/test_storage.py` — 23 unit tests for `DataStore` (save/load/merge/missing_intervals/corrupted file recovery) (#39)
+- `doc/source/storage.rst` — Sphinx page for `DataStore` with directory layout examples (#39)
 
 ### Changed
 
-- New storage arborescence: ``{data_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet``, ``…/trades/{pair}/YYYY-MM-DD.parquet``, ``…/orderbook/{pair}/YYYY-MM-DD.parquet`` — replaces the old ``{Exchange}/Data/Clean_Data/{per}/{pair}/`` layout (#XX)
-- `dccd/histo_dl/exchange.py` — `save()`, `_get_last_date()`, `save_trades()`, `save_orderbook()` now delegate to `DataStore`; removed `last_df`, `_set_by_period`, `_name_file`, `_excel_format` (#XX)
-- `dccd/histo_dl/{binance,bybit,coinbase,okx}.py` — removed `full_path` overrides (base class sets the correct path via `DataStore`) (#XX)
-- `dccd/daemon/backfill.py`, `scheduler.py` — removed `by_period` parameter; `save()` call simplified (#XX)
-- `dccd/daemon/stream_manager.py` — WebSocket save path now built from `DataStore.directory` (#XX)
-- `dccd/daemon/config.py` — `HistoJob.by_period` field removed; granularity is automatic (#XX)
+- New storage arborescence: ``{data_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet``, ``…/trades/{pair}/YYYY-MM-DD.parquet``, ``…/orderbook/{pair}/YYYY-MM-DD.parquet`` — replaces the old ``{Exchange}/Data/Clean_Data/{per}/{pair}/`` layout (#39)
+- `dccd/histo_dl/exchange.py` — `save()`, `_get_last_date()`, `save_trades()`, `save_orderbook()` now delegate to `DataStore`; removed `last_df`, `_set_by_period`, `_name_file`, `_excel_format` (#39)
+- `dccd/histo_dl/{binance,bybit,coinbase,okx}.py` — removed `full_path` overrides (base class sets the correct path via `DataStore`) (#39)
+- `dccd/daemon/backfill.py`, `scheduler.py` — removed `by_period` parameter; `save()` call simplified (#39)
+- `dccd/daemon/stream_manager.py` — WebSocket save path now built from `DataStore.directory` (#39)
+- `dccd/daemon/config.py` — `HistoJob.by_period` field removed; granularity is automatic (#39)
 
 - `dccd/histo_dl/exchange.py` — `save()` now supports `form='parquet'`; previously only `'xlsx'` and `'csv'` were handled (#35)
 - `config.yml` — ready-to-use daemon config for minutely OHLC + real-time orderbook/trades on Binance, Kraken, and Bybit (#35)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/storage.py` — new `DataStore` class: unified read/write interface for OHLC, trades, and orderbook; `save(df)` (merge-on-TS, annual OHLC / daily trades+orderbook), `load(start, end)`, `existing_periods()`, `last_timestamp()`, `missing_intervals()` (stub for 3.2) (#XX)
+- `dccd/tools/date_time.py` — `span_label(span)` converts seconds to short directory labels (``'1m'``, ``'1h'``, ``'1d'``…); `_SPAN_LABEL` mapping exported (#XX)
+- `dccd/tests/test_storage.py` — 23 unit tests for `DataStore` (save/load/merge/missing_intervals/corrupted file recovery) (#XX)
+- `doc/source/storage.rst` — Sphinx page for `DataStore` with directory layout examples (#XX)
+
+### Changed
+
+- New storage arborescence: ``{data_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet``, ``…/trades/{pair}/YYYY-MM-DD.parquet``, ``…/orderbook/{pair}/YYYY-MM-DD.parquet`` — replaces the old ``{Exchange}/Data/Clean_Data/{per}/{pair}/`` layout (#XX)
+- `dccd/histo_dl/exchange.py` — `save()`, `_get_last_date()`, `save_trades()`, `save_orderbook()` now delegate to `DataStore`; removed `last_df`, `_set_by_period`, `_name_file`, `_excel_format` (#XX)
+- `dccd/histo_dl/{binance,bybit,coinbase,okx}.py` — removed `full_path` overrides (base class sets the correct path via `DataStore`) (#XX)
+- `dccd/daemon/backfill.py`, `scheduler.py` — removed `by_period` parameter; `save()` call simplified (#XX)
+- `dccd/daemon/stream_manager.py` — WebSocket save path now built from `DataStore.directory` (#XX)
+- `dccd/daemon/config.py` — `HistoJob.by_period` field removed; granularity is automatic (#XX)
+
 - `dccd/histo_dl/exchange.py` — `save()` now supports `form='parquet'`; previously only `'xlsx'` and `'csv'` were handled (#35)
 - `config.yml` — ready-to-use daemon config for minutely OHLC + real-time orderbook/trades on Binance, Kraken, and Bybit (#35)
 - `dccd/daemon/backfill.py` — `OHLCBackfill` and `KrakenBackfill` strategy classes with shared retry/progress/save loop; `make_job()` factory; `run_backfill()` orchestrator; tqdm progress bars and optional `--parallel` execution (#38)

--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,6 @@ Daemon (autonomous collector) — ``config.yml``:
         pairs: [BTC/USDT, ETH/USDT]
         span: 3600
         format: parquet
-        by_period: Y
 
     stream_jobs:
       - exchange: binance

--- a/dccd/daemon/backfill.py
+++ b/dccd/daemon/backfill.py
@@ -90,9 +90,8 @@ class _BackfillBase(ABC):
     sleep : float
         Minimum seconds to wait between API calls.
     form : str
-        Output format (``'parquet'``, ``'csv'``, ``'xlsx'``).
-    by_period : str
-        File grouping (``'Y'``, ``'M'``, ``'D'``).
+        Output format (accepted for backward compatibility; storage is
+        always Parquet via :class:`~dccd.storage.DataStore`).
 
     """
 
@@ -101,12 +100,10 @@ class _BackfillBase(ABC):
         obj: ImportDataCryptoCurrencies,
         sleep: float,
         form: str,
-        by_period: str,
     ) -> None:
         self.obj = obj
         self.sleep = sleep
         self.form = form
-        self.by_period = by_period
         cls_name = type(obj).__name__[4:]  # strip leading 'From'
         self.label = f'{cls_name:8s} {obj.crypto}/{obj.fiat}'
 
@@ -227,7 +224,7 @@ class _BackfillBase(ABC):
                 continue
 
             if n > 0:
-                self.obj.save(form=self.form, by_period=self.by_period)
+                self.obj.save()
                 n_candles += n
 
             current = self._advance(current, end)
@@ -258,9 +255,7 @@ class OHLCBackfill(_BackfillBase):
     sleep : float
         Seconds to wait between requests.
     form : str
-        Output format.
-    by_period : str
-        File grouping period.
+        Output format (accepted for backward compatibility).
 
     """
 
@@ -270,9 +265,8 @@ class OHLCBackfill(_BackfillBase):
         max_candles: int,
         sleep: float,
         form: str,
-        by_period: str,
     ) -> None:
-        super().__init__(obj, sleep, form, by_period)
+        super().__init__(obj, sleep, form)
         self.max_candles = max_candles
 
     @property
@@ -320,9 +314,7 @@ class KrakenBackfill(_BackfillBase):
     sleep : float
         Seconds to wait between paginated API calls.
     form : str
-        Output format.
-    by_period : str
-        File grouping period.
+        Output format (accepted for backward compatibility).
 
     """
 
@@ -494,7 +486,6 @@ def make_job(
     path: str,
     tz: str,
     form: str,
-    by_period: str,
 ) -> _BackfillBase:
     """Build the appropriate backfill strategy for an (exchange, pair).
 
@@ -511,9 +502,7 @@ def make_job(
     tz : str
         Timezone for date parsing and file labelling.
     form : str
-        Output format.
-    by_period : str
-        File grouping period.
+        Output format (accepted for backward compatibility).
 
     Returns
     -------
@@ -543,14 +532,13 @@ def make_job(
     obj = cls(path, crypto, span, fiat, form=form, tz=tz)
 
     if exchange == _KRAKEN_EXCHANGE:
-        return KrakenBackfill(obj, sleep=sleep, form=form, by_period=by_period)
+        return KrakenBackfill(obj, sleep=sleep, form=form)
 
     return OHLCBackfill(
         obj,
         max_candles=defaults['max_candles'],
         sleep=sleep,
         form=form,
-        by_period=by_period,
     )
 
 
@@ -598,7 +586,7 @@ def run_backfill(
             crypto, fiat = pair.split('/', 1)
             job = make_job(
                 histo_job.exchange, crypto, fiat, histo_job.span,
-                path, tz, histo_job.format, histo_job.by_period,
+                path, tz, histo_job.format,
             )
             if job.obj.full_path in seen_paths:
                 tqdm.write(

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -134,9 +134,9 @@ def backfill(
 ) -> None:
     """ Download the full OHLC history for all histo_jobs in the config.
 
-    Reads exchanges, pairs, span, format, and by_period from the config
-    file.  Resumes from the last saved timestamp for each pair so the
-    command is safe to run repeatedly.
+    Reads exchanges, pairs, span, and format from the config file.
+    Resumes from the last saved timestamp for each pair so the command is
+    safe to run repeatedly.
 
     Kraken uses a trades-based strategy (Kraken's OHLC endpoint does not
     support arbitrary historical windows); all other exchanges use the

--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -16,8 +16,8 @@ import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 __all__ = [
-    'CollectorConfig',
     'AlertConfig',
+    'CollectorConfig',
     'HistoJob',
     'RemoteConfig',
     'SettingsConfig',
@@ -33,7 +33,6 @@ SUPPORTED_STREAM_EXCHANGES: frozenset[str] = frozenset(
     {'binance', 'kraken', 'bybit', 'okx', 'bitfinex', 'bitmex'}
 )
 SUPPORTED_FORMATS: frozenset[str] = frozenset({'xlsx', 'csv', 'parquet'})
-SUPPORTED_BY_PERIOD: frozenset[str] = frozenset({'Y', 'M', 'D'})
 
 
 class SettingsConfig(BaseModel):
@@ -125,8 +124,6 @@ class HistoJob(BaseModel):
         Candle interval in seconds. Must be >= 60.
     format : str
         Output format: ``'xlsx'``, ``'csv'``, or ``'parquet'``.
-    by_period : str
-        File grouping period: ``'Y'`` (year), ``'M'`` (month), ``'D'`` (day).
 
     """
 
@@ -134,7 +131,6 @@ class HistoJob(BaseModel):
     pairs: list[str]
     span: int
     format: str = 'parquet'
-    by_period: str = 'Y'
 
     @field_validator('exchange')
     @classmethod
@@ -171,15 +167,6 @@ class HistoJob(BaseModel):
         if v not in SUPPORTED_FORMATS:
             raise ValueError(
                 f"Unknown format {v!r}. Supported: {sorted(SUPPORTED_FORMATS)}"
-            )
-        return v
-
-    @field_validator('by_period')
-    @classmethod
-    def _validate_by_period(cls, v: str) -> str:
-        if v not in SUPPORTED_BY_PERIOD:
-            raise ValueError(
-                f"Unknown by_period {v!r}. Supported: {sorted(SUPPORTED_BY_PERIOD)}"
             )
         return v
 

--- a/dccd/daemon/scheduler.py
+++ b/dccd/daemon/scheduler.py
@@ -50,7 +50,7 @@ def run_histo_job(job: HistoJob, pair: str, base_path: str,
     Parameters
     ----------
     job : HistoJob
-        Job configuration (exchange, span, format, by_period).
+        Job configuration (exchange, span, format).
     pair : str
         Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
     base_path : str
@@ -65,7 +65,7 @@ def run_histo_job(job: HistoJob, pair: str, base_path: str,
     cls = _HISTO_CLASSES[job.exchange]
     try:
         obj = cls(base_path, crypto, job.span, fiat, form=job.format, tz=tz)
-        obj.import_data('last', 'now').save(form=job.format, by_period=job.by_period)
+        obj.import_data('last', 'now').save()
         _data = getattr(obj, 'data', None)
         rows = len(_data) if _data is not None else 0
         logger.info('histo job done: %s %s span=%s', job.exchange, pair, job.span)
@@ -116,11 +116,11 @@ def build_histo_scheduler(config: CollectorConfig,
                 trigger='interval',
                 seconds=job.span,
                 kwargs={
-                    'job': job,
-                    'pair': pair,
+                    'job':       job,
+                    'pair':      pair,
                     'base_path': config.storage.local_path,
-                    'tz': config.settings.timezone,
-                    'health': health,
+                    'tz':        config.settings.timezone,
+                    'health':    health,
                 },
                 id=job_id,
                 name=f'{job.exchange} {pair} {job.span}s',

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -30,6 +30,7 @@ from dccd.continuous_dl.kraken import DownloadKrakenData
 from dccd.continuous_dl.okx import DownloadOKXData
 from dccd.daemon.storage import RemoteStorage
 from dccd.process_data import set_marketdepth, set_orders, set_trades
+from dccd.storage import DataStore
 from dccd.tools.io import IODataBase
 
 if TYPE_CHECKING:
@@ -341,11 +342,21 @@ class StreamManager:
         key = f'{job.exchange}_{pair.replace("/", "_")}_{ch_tag}'
         self._downloaders[key] = downloader
 
-        xch = job.exchange.capitalize()
-        save_path = (
-            f'{self.config.storage.local_path.rstrip("/")}'
-            f'/{xch}/Data/WS_Data/{job.time_step}s/{pair.replace("/", "_")}'
-        )
+        has_trades = 'trades' in channels
+        has_book   = 'book'   in channels
+        if has_trades and has_book:
+            data_type = 'trades'
+        elif has_trades:
+            data_type = 'trades'
+        else:
+            data_type = 'orderbook'
+        save_path = str(DataStore(
+            self.config.storage.local_path,
+            job.exchange,
+            pair,
+            None,
+            data_type,
+        ).directory)
 
         downloader.set_process_data(_process_fn(channels))
         downloader.set_saver(IODataBase(save_path, method='csv'))

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -122,8 +122,6 @@ class FromBinance(ImportDataCryptoCurrencies):
         )
 
         self.pair = self.format_pair(crypto, fiat)
-        self.full_path = self.path + '/Binance/Data/Clean_Data/'
-        self.full_path += self.per + '/' + self.crypto + self.fiat
 
     def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)

--- a/dccd/histo_dl/binance.py
+++ b/dccd/histo_dl/binance.py
@@ -73,9 +73,8 @@ class FromBinance(ImportDataCryptoCurrencies):
     span : int
         Number of seconds between observations.
     full_path : str
-        Path to save data.
-    form : str
-        Format to save data.
+        Directory managed by :class:`~dccd.storage.DataStore` —
+        ``{path}/binance/ohlc/{pair}/{span}/``.
 
     Methods
     -------

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -94,6 +94,9 @@ class FromBybit(ImportDataCryptoCurrencies):
         Timestamps bounding the download.
     span : int
         Seconds between observations.
+    full_path : str
+        Directory managed by :class:`~dccd.storage.DataStore` —
+        ``{path}/bybit/ohlc/{pair}/{span}/``.
 
     Methods
     -------

--- a/dccd/histo_dl/bybit.py
+++ b/dccd/histo_dl/bybit.py
@@ -130,8 +130,6 @@ class FromBybit(ImportDataCryptoCurrencies):
             self, path, crypto, span, 'Bybit', fiat, form, tz=tz
         )
         self.pair = self.format_pair(crypto, fiat)
-        self.full_path = self.path + '/Bybit/Data/Clean_Data/'
-        self.full_path += self.per + '/' + self.crypto + self.fiat
 
     def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -72,9 +72,8 @@ class FromCoinbase(ImportDataCryptoCurrencies):
     span : int
         Number of seconds between observations.
     full_path : str
-        Path to save data.
-    form : str
-        Format to save data.
+        Directory managed by :class:`~dccd.storage.DataStore` —
+        ``{path}/coinbase/ohlc/{pair}/{span}/``.
 
     Methods
     -------

--- a/dccd/histo_dl/coinbase.py
+++ b/dccd/histo_dl/coinbase.py
@@ -113,8 +113,6 @@ class FromCoinbase(ImportDataCryptoCurrencies):
             self, path, crypto, span, 'Coinbase', fiat, form, tz=tz
         )
         self.pair = self.format_pair(crypto, fiat)
-        self.full_path = self.path + '/Coinbase/Data/Clean_Data/'
-        self.full_path += self.per + '/' + self.crypto + self.fiat
 
     def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)

--- a/dccd/histo_dl/exchange.py
+++ b/dccd/histo_dl/exchange.py
@@ -51,24 +51,29 @@ class ImportDataCryptoCurrencies(ABC):
     Parameters
     ----------
     path : str
-        The path where data will be saved.
+        Root directory where data files are stored.  Data is organised under
+        ``{path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet`` via
+        :class:`~dccd.storage.DataStore`.
     crypto : str
-        The abbreviation of the crypto-currency.
-    span : {int, 'weekly', 'daily', 'hourly'}
-        - If str, periodicity of observation.
-        - If int, number of the seconds between each observation, minimal span\
-            is 60 seconds.
+        The abbreviation of the crypto-currency (e.g. ``'BTC'``).
+    span : int or str
+        Candle interval: if str, a periodicity label (e.g. ``'hourly'``,
+        ``'1h'``); if int, number of seconds (minimum 60).
     platform : str
-        The platform of your choice: 'Binance', 'Kraken', 'Coinbase',
-        'Bybit', 'OKX'.
-    fiat : str
-        A fiat currency or a crypto-currency.
-    form : {'xlsx', 'csv'}
-        Your favorite format. Only 'xlsx' and 'csv' at the moment.
+        Exchange name used for the storage path: ``'Binance'``, ``'Kraken'``,
+        ``'Coinbase'``, ``'Bybit'``, or ``'OKX'``.
+    fiat : str, optional
+        Quote currency (e.g. ``'USDT'``, ``'USD'``).  Default ``'EUR'``.
+    form : str, optional
+        Accepted for backward compatibility; storage format is always Parquet
+        via :class:`~dccd.storage.DataStore`.
+    tz : str, optional
+        Timezone for date parsing.  ``'local'`` (default), ``'UTC'``, or any
+        IANA name.
 
     Notes
     -----
-    Don't use directly this class, use the respective class for each exchange.
+    Do not instantiate this class directly; use the exchange-specific subclass.
 
     See Also
     --------
@@ -77,15 +82,13 @@ class ImportDataCryptoCurrencies(ABC):
     Attributes
     ----------
     pair : str
-        Pair symbol, `crypto + fiat`.
+        Exchange-specific pair string (e.g. ``'BTCUSDT'`` for Binance).
     start, end : int
-        Timestamp to starting and ending download data.
+        Timestamps bounding the last downloaded window.
     span : int
         Number of seconds between observations.
     full_path : str
-        Path to save data.
-    form : str
-        Format to save data.
+        Absolute directory path managed by :class:`~dccd.storage.DataStore`.
     trades_df : pd.DataFrame
         Trades data after calling :meth:`import_trades`.
     orderbook_df : pd.DataFrame
@@ -204,7 +207,7 @@ class ImportDataCryptoCurrencies(ABC):
         return self
 
     def _sort_data(self, data: list[dict[str, Any]]) -> ImportDataCryptoCurrencies:
-        """ Validate, merge, and sort raw OHLCV data against :attr:`last_df`.
+        """ Validate and sort raw OHLCV data into a uniform timestamp grid.
 
         Validates each record through :class:`~dccd.models.OHLCBar`, builds a
         complete timestamp grid from ``self.start`` to ``self.end``, outer-merges

--- a/dccd/histo_dl/exchange.py
+++ b/dccd/histo_dl/exchange.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 # Import built-in packages
 import logging
-import os
 import pathlib
 import time
 from abc import ABC, abstractmethod
@@ -32,7 +31,8 @@ from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponen
 
 # Import local packages
 from dccd.models import OHLCBar, OrderBookEntry, Trade
-from dccd.tools.date_time import TS_to_date, date_to_TS, span_to_str, str_to_span
+from dccd.storage import DataStore
+from dccd.tools.date_time import date_to_TS, span_to_str, str_to_span
 
 if TYPE_CHECKING:
     import polars as pl
@@ -112,11 +112,10 @@ class ImportDataCryptoCurrencies(ABC):
         self.fiat = fiat
         self.tz = tz
         self.pair = str(crypto + fiat)
-        self.full_path = self.path + '/' + platform + '/Data/Clean_Data/'
-        self.full_path += str(self.per) + '/' + self.pair
-        self.trades_path = self.path + '/' + platform + '/Data/Trades/' + self.pair
-        self.orderbook_path = self.path + '/' + platform + '/Data/OrderBook/' + self.pair
-        self.last_df = pd.DataFrame()
+        self._exchange_name = platform.lower()
+        self._canonical_pair = f'{crypto}/{fiat}'
+        self._store = DataStore(path, self._exchange_name, self._canonical_pair, self.span, 'ohlc')
+        self.full_path = str(self._store.directory)
         self.trades_df: pd.DataFrame = pd.DataFrame()
         self.orderbook_df: pd.DataFrame = pd.DataFrame()
         self.form = form
@@ -136,51 +135,19 @@ class ImportDataCryptoCurrencies(ABC):
     def _get_last_date(self) -> int:
         """ Find the timestamp of the last imported observation.
 
-        Scans :attr:`full_path` for saved files and reads the last row of the
-        most-recent file.  Supports ``.xlsx``, ``.csv``, and ``.parquet``
-        formats.  Falls back to ``1325376000`` (2012-01-01 00:00:00 UTC) when
-        the directory is empty or the file extension is not recognised.
+        Delegates to :meth:`~dccd.storage.DataStore.last_timestamp`.
+        Falls back to ``1325376000`` (2012-01-01 00:00:00 UTC) when no data
+        has been saved yet.
 
         Returns
         -------
         int
-            Unix timestamp of the last row in the latest saved file, or
-            ``1325376000`` if no file is found or the format is unsupported.
+            Unix timestamp of the last saved row, or ``1325376000`` if no
+            file is found.
 
         """
-        pathlib.Path(self.full_path).mkdir(parents=True, exist_ok=True)
-
-        if not os.listdir(self.full_path):
-            return 1325376000
-
-        last_file = sorted(os.listdir(self.full_path), reverse=True)[0]
-        ext = last_file.rsplit('.', 1)[-1]
-        full = os.path.join(self.full_path, last_file)
-
-        try:
-            if ext == 'xlsx':
-                self.last_df = pd.read_excel(full)
-            elif ext == 'csv':
-                self.last_df = pd.read_csv(full)
-            elif ext == 'parquet':
-                self.last_df = pd.read_parquet(full)
-            else:
-                self.logger.warning(
-                    'Unsupported file format %s. Starting at 2012-01-01.', ext
-                )
-                return 1325376000
-        except Exception:
-            self.logger.warning(
-                'Corrupted file %s — removing and restarting from previous '
-                'checkpoint.', full
-            )
-            os.remove(full)
-            return self._get_last_date()
-
-        if 'TS' in self.last_df.columns:
-            return int(self.last_df['TS'].iloc[-1])
-
-        return int(self.last_df.index[-1])
+        ts = self._store.last_timestamp()
+        return ts if ts is not None else 1325376000
 
     def _set_time(self, start: int | str, end: int | str) -> tuple[int, int]:
         """ Set the end and start in timestamp if is not yet.
@@ -213,105 +180,27 @@ class ImportDataCryptoCurrencies(ABC):
         return int((_start // self.span) * self.span), \
             int((_end // self.span) * self.span)
 
-    # Maps the public by_period values to unambiguous strftime formats.
-    _PERIOD_FMT: dict[str, str] = {'Y': '%Y', 'M': '%Y-%m', 'D': '%Y-%m-%d'}
+    def save(self, form: str = 'parquet', by_period: str = 'Y') -> ImportDataCryptoCurrencies:
+        """ Save :attr:`df` to disk via :class:`~dccd.storage.DataStore`.
 
-    def _set_by_period(self, TS: int) -> str:
-        """ Convert a timestamp to a period label for grouping files.
-
-        Parameters
-        ----------
-        TS : int
-            Unix timestamp.
-
-        Returns
-        -------
-        str
-            Date string formatted according to :attr:`by_period`
-            (e.g. ``'2024'`` for ``by_period='Y'``,
-            ``'2024-03'`` for ``by_period='M'``).
-
-        """
-        fmt = self._PERIOD_FMT.get(self.by_period, '%' + self.by_period)
-        return TS_to_date(TS, form=fmt, tz=self.tz)
-
-    def _name_file(self, date: str) -> str:
-        """ Build the file stem for a given period label.
+        Data is always written as Parquet, grouped annually.  The *form* and
+        *by_period* parameters are accepted for backward compatibility but
+        ignored — storage format and period granularity are managed by
+        :class:`~dccd.storage.DataStore`.
 
         Parameters
         ----------
-        date : str
-            Period label returned by :meth:`_set_by_period`.
-
-        Returns
-        -------
-        str
-            File stem of the form ``{per}_of_{crypto}{fiat}_in_{date}``.
+        form : str, optional
+            Ignored.  Kept for backward-compatibility.
+        by_period : str, optional
+            Ignored.  Kept for backward-compatibility.
 
         """
-        return self.per + '_of_' + self.crypto + self.fiat + '_in_' + date
-
-    def save(self, form: str = 'xlsx', by_period: str = 'Y') -> ImportDataCryptoCurrencies:
-        """ Save data by period (default is year) in the corresponding format
-        and file.
-
-        Parameters
-        ----------
-        form : {'xlsx', 'csv', 'parquet'}
-            Format to save data.
-        by_period : {'Y', 'M', 'D'}
-            - If 'Y' group data by year.
-            - If 'M' group data by month.
-            - If 'D' group data by day.
-
-        """
-        df = (pd.concat([self.last_df, self.df], sort=True)
-              .drop_duplicates(subset='TS', keep='last')
-              .reset_index(drop=True)
-              .drop('Date', axis=1)
-              .reindex(columns=[
-                  'TS', 'date', 'time', 'close', 'high', 'low', 'open',
-                  'quoteVolume', 'volume', 'weightedAverage'
-              ]))
-        pathlib.Path(self.full_path).mkdir(parents=True, exist_ok=True)
-        self.by_period = by_period
-        grouped = df.set_index('TS', drop=False).groupby(self._set_by_period)
-        for name, group in grouped:
-            path = self.full_path + '/' + self._name_file(name) + '.' + form
-            if form == 'xlsx':
-                self._excel_format(name, form, group)
-            elif form == 'csv':
-                group.to_csv(path)
-            elif form == 'parquet':
-                group.reset_index(drop=True).to_parquet(path, index=False)
-            else:
-                self.logger.warning('Not allowing format: %s', form)
-        return self
-
-    def _excel_format(self, name: str, form: str, group: pd.DataFrame) -> ImportDataCryptoCurrencies:
-        """ Save a grouped DataFrame slice to an Excel file.
-
-        Parameters
-        ----------
-        name : str
-            Period label used to build the file name via :meth:`_name_file`.
-        form : str
-            File extension (e.g. ``'xlsx'``).
-        group : pd.DataFrame
-            Slice of data for the period ``name``.
-
-        Returns
-        -------
-        ImportDataCryptoCurrencies
-            Returns ``self`` to allow method chaining.
-
-        """
-        path = self.full_path + '/' + self._name_file(name) + '.' + form
-        df_group = group.reset_index(drop=True)
-        with pd.ExcelWriter(path, engine='openpyxl') as writer:
-            df_group.to_excel(
-                writer, header=True, index=False, sheet_name='Sheet1'
-            )
+        df = self.df.copy()
+        if 'Date' in df.columns:
+            df = df.drop('Date', axis=1)
+        self._store.save(df)
+        self.full_path = str(self._store.directory)
         return self
 
     def _sort_data(self, data: list[dict[str, Any]]) -> ImportDataCryptoCurrencies:
@@ -515,19 +404,20 @@ class ImportDataCryptoCurrencies(ABC):
         return self
 
     def save_trades(
-        self, form: str = 'csv', by_period: str = 'M'
+        self, form: str = 'parquet', by_period: str = 'D'
     ) -> ImportDataCryptoCurrencies:
-        """ Save :attr:`trades_df` grouped by period to :attr:`trades_path`.
+        """ Save :attr:`trades_df` via :class:`~dccd.storage.DataStore`.
 
-        Files are named ``trades_{crypto}{fiat}_{period}.{form}``.  No
-        forward-fill is applied — trades are sparse event data.
+        Trades are grouped by calendar day and written as Parquet.  The *form*
+        and *by_period* parameters are accepted for backward compatibility but
+        ignored.
 
         Parameters
         ----------
-        form : {'csv', 'parquet'}, optional
-            Output format, default ``'csv'``.
-        by_period : {'Y', 'M', 'D'}, optional
-            Period label for file grouping, default ``'M'``.
+        form : str, optional
+            Ignored.  Kept for backward-compatibility.
+        by_period : str, optional
+            Ignored.  Kept for backward-compatibility.
 
         Returns
         -------
@@ -537,23 +427,8 @@ class ImportDataCryptoCurrencies(ABC):
         """
         if self.trades_df.empty:
             return self
-        pathlib.Path(self.trades_path).mkdir(parents=True, exist_ok=True)
-
-        def _period_label(ts: float) -> str:
-            fmt = ImportDataCryptoCurrencies._PERIOD_FMT.get(by_period, '%' + by_period)
-            return TS_to_date(int(ts), form=fmt, tz=self.tz)
-
-        grouped = self.trades_df.groupby(
-            self.trades_df['TS'].map(_period_label)
-        )
-        for name, group in grouped:
-            fname = (
-                f'{self.trades_path}/trades_{self.crypto}{self.fiat}_{name}.{form}'
-            )
-            if form == 'parquet':
-                group.to_parquet(fname, index=False)
-            else:
-                group.to_csv(fname, index=False)
+        store = DataStore(self.path, self._exchange_name, self._canonical_pair, None, 'trades')
+        store.save(self.trades_df)
         return self
 
     # ------------------------------------------------------------------
@@ -636,15 +511,17 @@ class ImportDataCryptoCurrencies(ABC):
         )
         return self
 
-    def save_orderbook(self, form: str = 'csv') -> ImportDataCryptoCurrencies:
-        """ Save :attr:`orderbook_df` as a timestamped snapshot file.
+    def save_orderbook(self, form: str = 'parquet') -> ImportDataCryptoCurrencies:
+        """ Save :attr:`orderbook_df` via :class:`~dccd.storage.DataStore`.
 
-        Files are named ``orderbook_{crypto}{fiat}_{unix_ts}.{form}``.
+        The snapshot is timestamped with the current UTC time and written into
+        the daily orderbook file.  The *form* parameter is accepted for
+        backward compatibility but ignored.
 
         Parameters
         ----------
-        form : {'csv', 'parquet'}, optional
-            Output format, default ``'csv'``.
+        form : str, optional
+            Ignored.  Kept for backward-compatibility.
 
         Returns
         -------
@@ -654,15 +531,11 @@ class ImportDataCryptoCurrencies(ABC):
         """
         if self.orderbook_df.empty:
             return self
-        pathlib.Path(self.orderbook_path).mkdir(parents=True, exist_ok=True)
-        ts = int(time.time())
-        fname = (
-            f'{self.orderbook_path}/orderbook_{self.crypto}{self.fiat}_{ts}.{form}'
-        )
-        if form == 'parquet':
-            self.orderbook_df.to_parquet(fname, index=False)
-        else:
-            self.orderbook_df.to_csv(fname, index=False)
+        df = self.orderbook_df.copy()
+        if 'TS' not in df.columns:
+            df.insert(0, 'TS', int(time.time()))
+        store = DataStore(self.path, self._exchange_name, self._canonical_pair, None, 'orderbook')
+        store.save(df)
         return self
 
     # ------------------------------------------------------------------
@@ -683,3 +556,5 @@ class ImportDataCryptoCurrencies(ABC):
         self.full_path = self.path
         for elt in liste:
             self.full_path += '/' + elt
+        # Reset the store directory cache so the next save uses full_path.
+        self._store._dir = pathlib.Path(self.full_path)

--- a/dccd/histo_dl/kraken.py
+++ b/dccd/histo_dl/kraken.py
@@ -69,9 +69,8 @@ class FromKraken(ImportDataCryptoCurrencies):
     span : int
         Number of seconds between observations.
     full_path : str
-        Path to save data.
-    form : str
-        Format to save data.
+        Directory managed by :class:`~dccd.storage.DataStore` —
+        ``{path}/kraken/ohlc/{pair}/{span}/``.
 
     Methods
     -------

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -94,6 +94,9 @@ class FromOKX(ImportDataCryptoCurrencies):
         Timestamps bounding the download.
     span : int
         Seconds between observations.
+    full_path : str
+        Directory managed by :class:`~dccd.storage.DataStore` —
+        ``{path}/okx/ohlc/{pair}/{span}/``.
 
     Methods
     -------

--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -130,8 +130,6 @@ class FromOKX(ImportDataCryptoCurrencies):
             self, path, crypto, span, 'OKX', fiat, form, tz=tz
         )
         self.pair = self.format_pair(crypto, fiat)
-        self.full_path = self.path + '/OKX/Data/Clean_Data/'
-        self.full_path += self.per + '/' + self.crypto + self.fiat
 
     def _import_data(self, start: int | str = 'last', end: int | str = 'now') -> list[dict[str, Any]]:
         self.start, self.end = self._set_time(start, end)

--- a/dccd/storage.py
+++ b/dccd/storage.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""Unified data storage for all dccd data types.
+
+:class:`DataStore` is the single point of entry for reading and writing
+crypto data regardless of exchange, data type (OHLC, trades, order book),
+or collection method (REST or WebSocket).
+
+Directory layout
+----------------
+::
+
+    {data_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet
+    {data_path}/{exchange}/trades/{pair}/YYYY-MM-DD.parquet
+    {data_path}/{exchange}/orderbook/{pair}/YYYY-MM-DD.parquet
+
+- *exchange*: lowercase (``'binance'``, ``'kraken'``…)
+- *pair*: ``BTC-USDT`` (slash replaced by hyphen — slash is invalid in paths)
+- *span*: short label ``'1m'``, ``'1h'``, ``'1d'``… (OHLC only)
+- Granularity: **annual** for OHLC, **daily** for trades/orderbook
+
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from dccd.tools.date_time import TS_to_date, span_label
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = ['DataStore']
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_START_TS: int = 1325376000  # 2012-01-01 00:00:00 UTC
+
+
+class DataStore:
+    """Unified read/write interface for a single (exchange, pair, data_type).
+
+    Parameters
+    ----------
+    data_path : str
+        Root directory for all local data files (e.g. ``'/data/crypto'``).
+    exchange : str
+        Exchange name, lowercase (e.g. ``'binance'``).
+    pair : str
+        Trading pair in ``'CRYPTO/FIAT'`` format (e.g. ``'BTC/USDT'``).
+        The slash is converted to a hyphen for the file-system path.
+    span : int or None
+        Candle interval in seconds.  Required for ``data_type='ohlc'``;
+        pass ``None`` for trades and orderbook.
+    data_type : {'ohlc', 'trades', 'orderbook'}
+        Kind of data stored in this instance.
+
+    Attributes
+    ----------
+    directory : pathlib.Path
+        Absolute directory where files are stored.  Created on first access.
+
+    """
+
+    def __init__(
+        self,
+        data_path: str,
+        exchange: str,
+        pair: str,
+        span: int | None,
+        data_type: str = 'ohlc',
+    ) -> None:
+        if data_type not in ('ohlc', 'trades', 'orderbook'):
+            raise ValueError(
+                f"data_type must be 'ohlc', 'trades', or 'orderbook', got {data_type!r}"
+            )
+        if data_type == 'ohlc' and span is None:
+            raise ValueError("span is required for data_type='ohlc'")
+
+        self.data_path = data_path
+        self.exchange = exchange.lower()
+        self._pair_slug = pair.replace('/', '-')
+        self.span = span
+        self.data_type = data_type
+        self._dir: pathlib.Path | None = None
+
+    @property
+    def directory(self) -> pathlib.Path:
+        """Absolute directory for this store (created if absent)."""
+        if self._dir is None:
+            root = pathlib.Path(self.data_path) / self.exchange
+            if self.data_type == 'ohlc':
+                assert self.span is not None
+                self._dir = root / 'ohlc' / self._pair_slug / span_label(self.span)
+            else:
+                self._dir = root / self.data_type / self._pair_slug
+            self._dir.mkdir(parents=True, exist_ok=True)
+        return self._dir
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def save(self, df: pd.DataFrame) -> None:
+        """Write *df* into the appropriate period file(s), merging with existing data.
+
+        OHLC data is grouped by year; trades and orderbook by calendar day.
+        Rows are merged on ``'TS'`` (dedup ``keep='last'``), sorted ascending,
+        and written as Parquet.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Data to persist.  Must contain a ``'TS'`` column (Unix timestamps).
+
+        """
+        if df.empty:
+            return
+
+        if 'TS' not in df.columns:
+            raise ValueError("DataFrame must contain a 'TS' column")
+
+        if self.data_type == 'ohlc':
+            self._save_grouped(df, fmt='%Y')
+        else:
+            self._save_grouped(df, fmt='%Y-%m-%d')
+
+    def _save_grouped(self, df: pd.DataFrame, fmt: str) -> None:
+        groups: dict[str, pd.DataFrame] = {}
+        for ts, row in zip(df['TS'], df.itertuples(index=False)):
+            label = TS_to_date(int(ts), form=fmt, tz='UTC')
+            groups.setdefault(label, []).append(row._asdict())  # type: ignore[attr-defined]
+
+        for label, rows in groups.items():
+            file_path = self.directory / f'{label}.parquet'
+            new = pd.DataFrame(rows)
+            if file_path.exists():
+                try:
+                    existing = pd.read_parquet(file_path)
+                    merged = (
+                        pd.concat([existing, new], ignore_index=True)
+                        .drop_duplicates(subset='TS', keep='last')
+                        .sort_values('TS')
+                        .reset_index(drop=True)
+                    )
+                except Exception:
+                    logger.warning('Corrupted file %s — overwriting.', file_path)
+                    merged = new.drop_duplicates(subset='TS', keep='last').sort_values('TS').reset_index(drop=True)
+            else:
+                merged = new.drop_duplicates(subset='TS', keep='last').sort_values('TS').reset_index(drop=True)
+            merged.to_parquet(file_path, index=False)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def load(
+        self,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> pd.DataFrame:
+        """Load and concatenate all period files covering ``[start, end]``.
+
+        Parameters
+        ----------
+        start : int or None, optional
+            Inclusive lower bound (Unix timestamp).  ``None`` means no lower
+            bound.
+        end : int or None, optional
+            Inclusive upper bound (Unix timestamp).  ``None`` means no upper
+            bound.
+
+        Returns
+        -------
+        pd.DataFrame
+            Concatenated data, sorted by ``'TS'``, filtered to ``[start, end]``.
+            Empty DataFrame if no files are found.
+
+        """
+        files = sorted(self.directory.glob('*.parquet'))
+        if not files:
+            return pd.DataFrame()
+
+        pieces: list[pd.DataFrame] = []
+        for f in files:
+            try:
+                pieces.append(pd.read_parquet(f))
+            except Exception:
+                logger.warning('Skipping corrupted file %s', f)
+
+        if not pieces:
+            return pd.DataFrame()
+
+        df = pd.concat(pieces, ignore_index=True).sort_values('TS').reset_index(drop=True)
+
+        if start is not None:
+            df = df[df['TS'] >= start]
+        if end is not None:
+            df = df[df['TS'] <= end]
+
+        return df.reset_index(drop=True)
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    def existing_periods(self) -> list[str]:
+        """List period labels for all available files.
+
+        Returns
+        -------
+        list of str
+            Sorted list of year strings (``['2024', '2025']``) for OHLC, or
+            date strings (``['2026-05-20', '2026-05-21']``) for trades/orderbook.
+
+        """
+        return sorted(f.stem for f in self.directory.glob('*.parquet'))
+
+    def last_timestamp(self) -> int | None:
+        """Return the last ``TS`` value in the most recent period file.
+
+        Returns
+        -------
+        int or None
+            Unix timestamp of the last row, or ``None`` if no data exists.
+
+        """
+        periods = self.existing_periods()
+        if not periods:
+            return None
+
+        # Iterate from the most recent period backward until a readable file is found.
+        for period in reversed(periods):
+            file_path = self.directory / f'{period}.parquet'
+            try:
+                df = pd.read_parquet(file_path, columns=['TS'])
+                if not df.empty:
+                    return int(df['TS'].max())
+            except Exception:
+                logger.warning('Corrupted file %s — removing.', file_path)
+                file_path.unlink(missing_ok=True)
+
+        return None
+
+    def missing_intervals(self, start: int, end: int) -> list[tuple[int, int]]:
+        """Return intervals within ``[start, end]`` that need to be downloaded.
+
+        In 3.1 this is a stub that always returns ``[(start, end)]`` (current
+        behaviour — resume from last saved point, no gap detection).  Full
+        gap-filling logic is implemented in section 3.2.
+
+        Parameters
+        ----------
+        start : int
+            Desired start timestamp (Unix seconds).
+        end : int
+            Desired end timestamp (Unix seconds).
+
+        Returns
+        -------
+        list of (int, int)
+            List of ``(start, end)`` pairs to download.
+
+        """
+        last = self.last_timestamp()
+        effective_start = max(start, last) if last is not None else start
+        if effective_start >= end:
+            return []
+        return [(effective_start, end)]

--- a/dccd/storage.py
+++ b/dccd/storage.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from dccd.tools.date_time import TS_to_date, span_label
+from dccd.tools.date_time import span_label
 
 if TYPE_CHECKING:
     pass
@@ -131,18 +131,14 @@ class DataStore:
             self._save_grouped(df, fmt='%Y-%m-%d')
 
     def _save_grouped(self, df: pd.DataFrame, fmt: str) -> None:
-        groups: dict[str, pd.DataFrame] = {}
-        for ts, row in zip(df['TS'], df.itertuples(index=False)):
-            label = TS_to_date(int(ts), form=fmt, tz='UTC')
-            groups.setdefault(label, []).append(row._asdict())  # type: ignore[attr-defined]
-
-        for label, rows in groups.items():
+        labels = pd.to_datetime(df['TS'], unit='s', utc=True).dt.strftime(fmt)
+        for label, group_df in df.groupby(labels, sort=False):
             file_path = self.directory / f'{label}.parquet'
-            new = pd.DataFrame(rows)
+            new = group_df.reset_index(drop=True)
             if file_path.exists():
                 try:
                     existing = pd.read_parquet(file_path)
-                    merged = (
+                    new = (
                         pd.concat([existing, new], ignore_index=True)
                         .drop_duplicates(subset='TS', keep='last')
                         .sort_values('TS')
@@ -150,10 +146,10 @@ class DataStore:
                     )
                 except Exception:
                     logger.warning('Corrupted file %s — overwriting.', file_path)
-                    merged = new.drop_duplicates(subset='TS', keep='last').sort_values('TS').reset_index(drop=True)
+                    new = new.drop_duplicates(subset='TS', keep='last').sort_values('TS').reset_index(drop=True)
             else:
-                merged = new.drop_duplicates(subset='TS', keep='last').sort_values('TS').reset_index(drop=True)
-            merged.to_parquet(file_path, index=False)
+                new = new.drop_duplicates(subset='TS', keep='last').sort_values('TS').reset_index(drop=True)
+            new.to_parquet(file_path, index=False)
 
     # ------------------------------------------------------------------
     # Read

--- a/dccd/tests/test_backfill.py
+++ b/dccd/tests/test_backfill.py
@@ -32,7 +32,7 @@ def _make_kraken_job(tmp_path) -> KrakenBackfill:
     obj.fiat = 'USD'
     obj.pair = 'XBTUSD'
     obj.df = None
-    return KrakenBackfill(obj, sleep=0.0, form='parquet', by_period='M')
+    return KrakenBackfill(obj, sleep=0.0, form='parquet')
 
 
 def test_trades_to_ohlc_basic():
@@ -85,7 +85,7 @@ def test_make_job_binance_returns_ohlc(tmp_path):
     mock_obj.fiat = 'USDT'
     with patch('dccd.daemon.scheduler._HISTO_CLASSES',
                {'binance': lambda *a, **kw: mock_obj}):
-        job = make_job('binance', 'BTC', 'USDT', 60, str(tmp_path), 'UTC', 'parquet', 'M')
+        job = make_job('binance', 'BTC', 'USDT', 60, str(tmp_path), 'UTC', 'parquet')
     assert isinstance(job, OHLCBackfill)
     assert job.max_candles == _EXCHANGE_DEFAULTS['binance']['max_candles']
 
@@ -97,13 +97,13 @@ def test_make_job_kraken_returns_kraken_backfill(tmp_path):
     mock_obj.fiat = 'USD'
     with patch('dccd.daemon.scheduler._HISTO_CLASSES',
                {'kraken': lambda *a, **kw: mock_obj}):
-        job = make_job('kraken', 'BTC', 'USD', 60, str(tmp_path), 'UTC', 'parquet', 'M')
+        job = make_job('kraken', 'BTC', 'USD', 60, str(tmp_path), 'UTC', 'parquet')
     assert isinstance(job, KrakenBackfill)
 
 
 def test_make_job_unsupported_exchange(tmp_path):
     with pytest.raises(ValueError, match='Unsupported exchange'):
-        make_job('fakex', 'BTC', 'USD', 60, str(tmp_path), 'UTC', 'parquet', 'M')
+        make_job('fakex', 'BTC', 'USD', 60, str(tmp_path), 'UTC', 'parquet')
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +122,7 @@ def _mock_obj(span=60):
 
 def test_ohlc_backfill_dry_run_no_network():
     obj = _mock_obj()
-    job = OHLCBackfill(obj, max_candles=990, sleep=0.0, form='parquet', by_period='M')
+    job = OHLCBackfill(obj, max_candles=990, sleep=0.0, form='parquet')
     job.run('2026-01-01 00:00:00', dry_run=True)
     obj._get_last_date.assert_not_called()
     obj.import_data.assert_not_called()
@@ -131,7 +131,7 @@ def test_ohlc_backfill_dry_run_no_network():
 
 def test_kraken_backfill_dry_run_no_network():
     obj = _mock_obj()
-    job = KrakenBackfill(obj, sleep=0.0, form='parquet', by_period='M')
+    job = KrakenBackfill(obj, sleep=0.0, form='parquet')
     job.run('2026-01-01 00:00:00', dry_run=True)
     obj._get_last_date.assert_not_called()
     obj._fetch.assert_not_called()

--- a/dccd/tests/test_daemon_config.py
+++ b/dccd/tests/test_daemon_config.py
@@ -23,7 +23,6 @@ _VALID_HISTO_JOB = {
     'pairs': ['BTC/USDT', 'ETH/USDT'],
     'span': 3600,
     'format': 'parquet',
-    'by_period': 'Y',
 }
 
 _VALID_CONFIG = {
@@ -57,7 +56,6 @@ def test_default_values_applied():
     assert cfg.alerts.webhook_url is None
     assert cfg.alerts.max_consecutive_errors == 3
     assert cfg.histo_jobs[0].format == 'parquet'
-    assert cfg.histo_jobs[0].by_period == 'Y'
 
 
 def test_remote_config_parsed():
@@ -132,11 +130,6 @@ def test_empty_pairs_raises():
     with pytest.raises(ValidationError, match="must not be empty"):
         CollectorConfig.model_validate(data)
 
-
-def test_invalid_by_period_raises():
-    data = {**_VALID_CONFIG, 'histo_jobs': [{**_VALID_HISTO_JOB, 'by_period': 'W'}]}
-    with pytest.raises(ValidationError, match='Unknown by_period'):
-        CollectorConfig.model_validate(data)
 
 
 def test_no_jobs_raises():

--- a/dccd/tests/test_daemon_scheduler.py
+++ b/dccd/tests/test_daemon_scheduler.py
@@ -89,7 +89,7 @@ def test_run_histo_job_calls_chain(tmp_path):
 
     mock_cls.assert_called_once_with(str(tmp_path), 'BTC', 3600, 'USDT', form='parquet', tz='local')
     mock_obj.import_data.assert_called_once_with('last', 'now')
-    mock_obj.save.assert_called_once_with(form='parquet', by_period='Y')
+    mock_obj.save.assert_called_once_with()
 
 
 def test_run_histo_job_splits_pair_correctly(tmp_path):

--- a/dccd/tests/test_histo_dl.py
+++ b/dccd/tests/test_histo_dl.py
@@ -1,81 +1,76 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-
-import logging
 import pathlib
 
 import pandas as pd
 
-from dccd.histo_dl.exchange import ImportDataCryptoCurrencies
-
 _FALLBACK_TS = 1325376000  # 2012-01-01 00:00:00 UTC
-
-
-class _ConcreteDownloader(ImportDataCryptoCurrencies):
-    def _import_data(self, start, end):
-        return []
-
-
-def _make_obj(full_path: str) -> ImportDataCryptoCurrencies:
-    obj = _ConcreteDownloader.__new__(_ConcreteDownloader)
-    obj.logger = logging.getLogger(__name__)
-    obj.last_df = pd.DataFrame()
-    obj.full_path = full_path
-    return obj
 
 
 def _sample_df() -> pd.DataFrame:
     return pd.DataFrame({'TS': [1700000000, 1700003600, 1700007200]})
 
 
+# ---------------------------------------------------------------------------
+# _get_last_date — delegates to DataStore.last_timestamp
+# ---------------------------------------------------------------------------
+
 def test_get_last_date_empty_directory(tmp_path):
-    obj = _make_obj(str(tmp_path))
+    from dccd.histo_dl.binance import FromBinance
+
+    obj = FromBinance(str(tmp_path), 'BTC', 60, fiat='USDT')
     assert obj._get_last_date() == _FALLBACK_TS
-
-
-def test_get_last_date_xlsx(tmp_path):
-    df = _sample_df()
-    df.to_excel(tmp_path / 'data_2023.xlsx', index=False)
-    obj = _make_obj(str(tmp_path))
-    assert obj._get_last_date() == 1700007200
-
-
-def test_get_last_date_csv(tmp_path):
-    df = _sample_df()
-    df.to_csv(tmp_path / 'data_2023.csv', index=False)
-    obj = _make_obj(str(tmp_path))
-    assert obj._get_last_date() == 1700007200
 
 
 def test_get_last_date_parquet(tmp_path):
+    from dccd.histo_dl.binance import FromBinance
+
+    obj = FromBinance(str(tmp_path), 'BTC', 60, fiat='USDT')
     df = _sample_df()
-    df.to_parquet(tmp_path / 'data_2023.parquet', index=False)
-    obj = _make_obj(str(tmp_path))
+    df.to_parquet(pathlib.Path(obj.full_path) / '2023.parquet', index=False)
     assert obj._get_last_date() == 1700007200
 
 
-def test_get_last_date_unsupported_format(tmp_path):
-    (tmp_path / 'data.json').write_text('{}')
-    obj = _make_obj(str(tmp_path))
-    assert obj._get_last_date() == _FALLBACK_TS
+def test_get_last_date_corrupted_parquet(tmp_path):
+    from dccd.histo_dl.binance import FromBinance
 
+    obj = FromBinance(str(tmp_path), 'BTC', 60, fiat='USDT')
+    bad = pathlib.Path(obj.full_path) / '2023.parquet'
+    bad.write_bytes(b'not-a-parquet-file')
+    assert obj._get_last_date() == _FALLBACK_TS
+    assert not bad.exists()
+
+
+# ---------------------------------------------------------------------------
+# save — delegates to DataStore, annual Parquet under new arborescence
+# ---------------------------------------------------------------------------
 
 def test_save_parquet(tmp_path):
     from dccd.histo_dl.binance import FromBinance
 
     obj = FromBinance(str(tmp_path), 'BTC', 60, fiat='USDT')
-    obj.last_df = pd.DataFrame()
     data = [{
         'date': 1700000000.0, 'open': 37000.0, 'high': 37010.0,
         'low': 36990.0, 'close': 37005.0, 'volume': 1.5,
         'quoteVolume': 55507.5,
     }]
     obj._sort_data(data)
-    obj.save(form='parquet', by_period='Y')
+    obj.save()
 
     files = list(pathlib.Path(obj.full_path).glob('*.parquet'))
     assert len(files) == 1
     df = pd.read_parquet(files[0])
     assert 'TS' in df.columns
     assert len(df) >= 1
+
+
+def test_save_creates_correct_path(tmp_path):
+    from dccd.histo_dl.binance import FromBinance
+
+    obj = FromBinance(str(tmp_path), 'BTC', 60, fiat='USDT')
+    # New arborescence: {data_path}/binance/ohlc/BTC-USDT/1m/
+    assert 'binance' in obj.full_path
+    assert 'ohlc' in obj.full_path
+    assert 'BTC-USDT' in obj.full_path
+    assert '1m' in obj.full_path

--- a/dccd/tests/test_storage.py
+++ b/dccd/tests/test_storage.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""Tests for dccd.storage.DataStore."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from dccd.storage import DataStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ohlc_df(ts_values: list[int]) -> pd.DataFrame:
+    return pd.DataFrame({
+        'TS': ts_values,
+        'open': [100.0] * len(ts_values),
+        'high': [101.0] * len(ts_values),
+        'low': [99.0] * len(ts_values),
+        'close': [100.5] * len(ts_values),
+        'volume': [1.0] * len(ts_values),
+    })
+
+
+def _trades_df(ts_values: list[int]) -> pd.DataFrame:
+    return pd.DataFrame({
+        'TS': ts_values,
+        'price': [50000.0] * len(ts_values),
+        'amount': [0.1] * len(ts_values),
+    })
+
+
+# ---------------------------------------------------------------------------
+# DataStore.directory — path structure
+# ---------------------------------------------------------------------------
+
+def test_ohlc_directory_structure(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    expected = tmp_path / 'binance' / 'ohlc' / 'BTC-USDT' / '1h'
+    assert store.directory == expected
+    assert store.directory.exists()
+
+
+def test_trades_directory_structure(tmp_path):
+    store = DataStore(str(tmp_path), 'kraken', 'BTC/USD', None, 'trades')
+    expected = tmp_path / 'kraken' / 'trades' / 'BTC-USD'
+    assert store.directory == expected
+
+
+def test_orderbook_directory_structure(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'ETH/USDT', None, 'orderbook')
+    expected = tmp_path / 'binance' / 'orderbook' / 'ETH-USDT'
+    assert store.directory == expected
+
+
+def test_exchange_lowercased(tmp_path):
+    store = DataStore(str(tmp_path), 'Binance', 'BTC/USDT', 60, 'ohlc')
+    assert 'binance' in str(store.directory)
+
+
+def test_invalid_data_type_raises():
+    with pytest.raises(ValueError, match='data_type must be'):
+        DataStore('/tmp', 'binance', 'BTC/USDT', 3600, 'invalid')
+
+
+def test_ohlc_without_span_raises():
+    with pytest.raises(ValueError, match='span is required'):
+        DataStore('/tmp', 'binance', 'BTC/USDT', None, 'ohlc')
+
+
+# ---------------------------------------------------------------------------
+# DataStore.save — OHLC annual files
+# ---------------------------------------------------------------------------
+
+def test_save_ohlc_creates_annual_file(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    # TS in year 2023
+    df = _ohlc_df([1672531200, 1675209600])  # 2023-01-01, 2023-02-01
+    store.save(df)
+
+    files = list(store.directory.glob('*.parquet'))
+    assert len(files) == 1
+    assert files[0].stem == '2023'
+
+
+def test_save_ohlc_multiple_years(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    df = _ohlc_df([
+        1672531200,  # 2023-01-01
+        1704067200,  # 2024-01-01
+    ])
+    store.save(df)
+
+    files = sorted(store.directory.glob('*.parquet'))
+    assert len(files) == 2
+    assert {f.stem for f in files} == {'2023', '2024'}
+
+
+def test_save_merges_with_existing(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    df1 = _ohlc_df([1672531200, 1672534800])  # 2023-01-01 00:00, 01:00
+    df2 = _ohlc_df([1672534800, 1672538400])  # 2023-01-01 01:00 (dup), 02:00
+    store.save(df1)
+    store.save(df2)
+
+    result = pd.read_parquet(store.directory / '2023.parquet')
+    # Dedup on TS: 3 unique timestamps
+    assert len(result) == 3
+    assert sorted(result['TS'].tolist()) == [1672531200, 1672534800, 1672538400]
+
+
+def test_save_empty_df_is_noop(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(pd.DataFrame())
+    assert list(store.directory.glob('*.parquet')) == []
+
+
+# ---------------------------------------------------------------------------
+# DataStore.save — trades daily files
+# ---------------------------------------------------------------------------
+
+def test_save_trades_daily_file(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', None, 'trades')
+    df = _trades_df([1700000000, 1700003600])  # both 2023-11-14
+    store.save(df)
+
+    files = list(store.directory.glob('*.parquet'))
+    assert len(files) == 1
+    assert files[0].stem == '2023-11-14'
+
+
+def test_save_trades_multiple_days(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', None, 'trades')
+    df = _trades_df([
+        1700000000,  # 2023-11-14
+        1700100000,  # 2023-11-15
+    ])
+    store.save(df)
+
+    files = sorted(store.directory.glob('*.parquet'))
+    assert len(files) == 2
+
+
+# ---------------------------------------------------------------------------
+# DataStore.load
+# ---------------------------------------------------------------------------
+
+def test_load_returns_empty_when_no_data(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    result = store.load()
+    assert result.empty
+
+
+def test_load_range_across_years(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1672531200, 1704067200]))  # 2023 and 2024
+
+    result = store.load()
+    assert len(result) == 2
+
+    result_filtered = store.load(start=1672531200, end=1672531200)
+    assert len(result_filtered) == 1
+    assert result_filtered['TS'].iloc[0] == 1672531200
+
+
+def test_load_skips_corrupted_file(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1672531200]))  # writes 2023.parquet
+    (store.directory / '2022.parquet').write_bytes(b'bad data')
+
+    result = store.load()
+    assert len(result) == 1  # only 2023 loaded
+
+
+# ---------------------------------------------------------------------------
+# DataStore.existing_periods
+# ---------------------------------------------------------------------------
+
+def test_existing_periods_empty(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    assert store.existing_periods() == []
+
+
+def test_existing_periods_ohlc(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1672531200, 1704067200]))  # 2023 and 2024
+    assert store.existing_periods() == ['2023', '2024']
+
+
+# ---------------------------------------------------------------------------
+# DataStore.last_timestamp
+# ---------------------------------------------------------------------------
+
+def test_last_timestamp_empty(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    assert store.last_timestamp() is None
+
+
+def test_last_timestamp_with_data(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1672531200, 1704067200]))
+    assert store.last_timestamp() == 1704067200
+
+
+def test_last_timestamp_removes_corrupted_and_falls_back(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1672531200]))  # 2023.parquet
+    bad = store.directory / '2024.parquet'
+    bad.write_bytes(b'corrupted')
+
+    ts = store.last_timestamp()
+    assert ts == 1672531200  # falls back to 2023
+    assert not bad.exists()  # corrupted file was removed
+
+
+# ---------------------------------------------------------------------------
+# DataStore.missing_intervals (3.1 stub)
+# ---------------------------------------------------------------------------
+
+def test_missing_intervals_no_data(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    intervals = store.missing_intervals(1672531200, 1704067200)
+    assert intervals == [(1672531200, 1704067200)]
+
+
+def test_missing_intervals_with_existing_data(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1672531200]))  # last TS = 1672531200
+    intervals = store.missing_intervals(1672524000, 1704067200)
+    assert len(intervals) == 1
+    assert intervals[0][0] == 1672531200  # resume from last saved
+    assert intervals[0][1] == 1704067200
+
+
+def test_missing_intervals_already_up_to_date(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1704067200]))  # last = 2024-01-01
+    intervals = store.missing_intervals(1672531200, 1704067200)
+    assert intervals == []

--- a/dccd/tools/date_time.py
+++ b/dccd/tools/date_time.py
@@ -24,8 +24,14 @@ _logger = logging.getLogger(__name__)
 
 __all__ = [
     'TS_to_date', 'date_to_TS', 'str_to_span', 'span_to_str',
-    'binance_interval',
+    'span_label', 'binance_interval',
 ]
+
+_SPAN_LABEL: dict[int, str] = {
+    60: '1m', 180: '3m', 300: '5m', 900: '15m', 1800: '30m',
+    3600: '1h', 7200: '2h', 14400: '4h', 21600: '6h', 28800: '8h',
+    43200: '12h', 86400: '1d', 604800: '1w',
+}
 
 
 def TS_to_date(TS: int, form: str = '%Y-%m-%d %H:%M:%S', tz: str = 'local') -> str:
@@ -213,6 +219,33 @@ def span_to_str(span: int) -> str | None:
     if label is None:
         _logger.warning('Error, no string correspond to this time in seconds.')
     return label
+
+
+def span_label(span: int) -> str:
+    """ Return a short directory-safe label for *span* seconds.
+
+    Parameters
+    ----------
+    span : int
+        Candle interval in seconds.
+
+    Returns
+    -------
+    str
+        Short label (e.g. ``'1m'``, ``'1h'``, ``'1d'``).
+        Falls back to ``'{span}s'`` for unknown spans.
+
+    Examples
+    --------
+    >>> span_label(3600)
+    '1h'
+    >>> span_label(86400)
+    '1d'
+    >>> span_label(7777)
+    '7777s'
+
+    """
+    return _SPAN_LABEL.get(span, f'{span}s')
 
 
 def binance_interval(interval: int) -> str | None:

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -41,15 +41,14 @@ Quick start (CLI)
          - exchange: binance
            pairs: [BTC/USDT, ETH/USDT]
            span: 3600          # candle interval in seconds
-           format: parquet
-           by_period: Y        # one file per year
+           format: parquet     # stored as annual Parquet: binance/ohlc/BTC-USDT/1h/YYYY.parquet
 
        # Optional real-time streams
        stream_jobs:
          - exchange: binance
            pairs: [BTC/USDT]
            channels: [trades, book]
-           time_step: 60
+           time_step: 60       # stored daily: binance/trades/BTC-USDT/YYYY-MM-DD.parquet
 
        # Optional webhook alerts on consecutive failures
        alerts:
@@ -83,7 +82,7 @@ Quick start (CLI)
        # Run all jobs in parallel threads
        dccd backfill --config config.yml --parallel
 
-       # One-shot: download all histo jobs once and exit
+       # One-shot: run all histo jobs once and exit
        dccd run --config config.yml
        # Done. successes=2 failures=0
 
@@ -192,6 +191,12 @@ Storage
    :toctree: generated/
 
    storage.RemoteStorage -- push local data directories to remote destinations via rclone
+
+Data Store
+----------
+
+The :class:`~dccd.storage.DataStore` class provides the unified storage
+layer.  See :doc:`storage` for the full API reference.
 
 CLI
 ---

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -123,5 +123,6 @@ Contents
    histo_dl.bybit
    histo_dl.okx
    daemon
+   storage
    process_data
    tools

--- a/doc/source/storage.rst
+++ b/doc/source/storage.rst
@@ -1,0 +1,42 @@
+------------------------------------------
+ Storage (:mod:`dccd.storage`)
+------------------------------------------
+
+.. automodule:: dccd.storage
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:
+
+:class:`DataStore` is the unified read/write interface for all dccd data
+types (OHLC, trades, order book).  It replaces the scattered save/load
+logic previously spread across ``exchange.py``, ``backfill.py``, and
+``stream_manager.py``.
+
+Directory layout
+----------------
+
+::
+
+    {data_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet
+    {data_path}/{exchange}/trades/{pair}/YYYY-MM-DD.parquet
+    {data_path}/{exchange}/orderbook/{pair}/YYYY-MM-DD.parquet
+
+- *exchange*: lowercase (``'binance'``, ``'kraken'``…)
+- *pair*: ``BTC-USDT`` (slash replaced by hyphen)
+- *span*: short label — ``'1m'``, ``'1h'``, ``'1d'``… (OHLC only)
+- OHLC files are **annual**; trades and orderbook files are **daily**
+
+Example paths::
+
+    ~/data/crypto/binance/ohlc/BTC-USDT/1h/2026.parquet
+    ~/data/crypto/kraken/ohlc/BTC-USD/1d/2025.parquet
+    ~/data/crypto/binance/trades/BTC-USDT/2026-05-22.parquet
+    ~/data/crypto/binance/orderbook/BTC-USDT/2026-05-22.parquet
+
+API
+---
+
+.. autosummary::
+   :toctree: generated/
+
+   DataStore

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -37,9 +37,9 @@ storage:
 # ---------------------------------------------------------------------------
 # Historical (REST API) jobs
 # ---------------------------------------------------------------------------
-# Each job polls one exchange at a fixed interval and saves OHLCV candles.
-# One file per period (by_period) is created under:
-#   {local_path}/{Exchange}/Data/Clean_Data/{span_label}/{pair}/
+# Each job polls one exchange at a fixed interval and saves OHLCV candles
+# as annual Parquet files under:
+#   {local_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet
 histo_jobs:
 
   - exchange: binance          # one of: binance, kraken, bybit, okx, coinbase
@@ -48,7 +48,6 @@ histo_jobs:
       - ETH/USDT
     span: 3600                 # candle interval in seconds (>= 60)
     format: parquet            # one of: parquet, csv, xlsx
-    by_period: Y               # file grouping: Y (year), M (month), D (day)
 
   - exchange: kraken
     pairs:
@@ -56,14 +55,12 @@ histo_jobs:
       - ETH/USD
     span: 86400                # daily candles
     format: parquet
-    by_period: Y
 
   - exchange: bybit
     pairs:
       - BTC/USDT
     span: 900                  # 15-minute candles
-    format: csv
-    by_period: M               # one file per month
+    format: parquet
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +68,8 @@ histo_jobs:
 # ---------------------------------------------------------------------------
 # Each job opens one WebSocket connection per pair (or per pair+channel for
 # Bitfinex/Bitmex) and saves snapshots every time_step seconds under:
-#   {local_path}/{Exchange}/Data/WS_Data/{time_step}s/{pair}/
+#   {local_path}/{exchange}/trades/{pair}/YYYY-MM-DD.parquet
+#   {local_path}/{exchange}/orderbook/{pair}/YYYY-MM-DD.parquet
 #
 # stream_jobs:
 #   - exchange: binance        # one of: binance, kraken, bybit, okx, bitfinex, bitmex


### PR DESCRIPTION
## Summary

- New `dccd/storage.py::DataStore` — single read/write interface for OHLC, trades, and orderbook data
- New directory layout: `{exchange}/ohlc/{pair}/{span}/YYYY.parquet` / `…/trades/{pair}/YYYY-MM-DD.parquet` / `…/orderbook/{pair}/YYYY-MM-DD.parquet`
- Removed `by_period` config field — file granularity is now automatic (annual OHLC, daily trades/orderbook)

## Changes

- `dccd/storage.py` (new): `DataStore` with `save(df)`, `load(start, end)`, `existing_periods()`, `last_timestamp()`, `missing_intervals()` (stub for 3.2)
- `dccd/tools/date_time.py`: added `span_label(span)` and `_SPAN_LABEL` mapping
- `dccd/histo_dl/exchange.py`: `save()`, `_get_last_date()`, `save_trades()`, `save_orderbook()` delegate to `DataStore`; removed `last_df`, `_set_by_period`, `_name_file`, `_excel_format`
- `dccd/histo_dl/{binance,bybit,coinbase,okx}.py`: removed `full_path` overrides
- `dccd/daemon/{backfill,scheduler,stream_manager,config}.py`: removed `by_period` throughout
- `dccd/tests/test_storage.py` (new): 23 unit tests for `DataStore`
- `doc/source/storage.rst` (new): Sphinx page with directory layout examples
- `examples/config.example.yml`, `README.rst`, `doc/source/daemon.rst`: updated path docs

## Changelog

Added under `[Unreleased]`:
- `dccd/storage.py` — new `DataStore` class
- `dccd/tools/date_time.py` — `span_label()`
- New arborescence, removed `by_period`, all save/load delegated to `DataStore`

## Test plan

- [x] `pytest` — 300 tests pass
- [x] `ruff check dccd/` — clean
- [ ] CI green