### PR TITLE
feat: gap-aware backfill and rename dccd run → collect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/storage.py` — `DataStore.is_period_complete(year)`: checks whether an annual parquet file contains all expected candles; `DataStore.missing_intervals(start, end)`: real gap-detection replacing the 3.1 stub — complete past years are skipped, incomplete years resume from the last saved row (#XX)
-- `dccd/daemon/backfill.py` — `_BackfillBase.run()` now iterates over `DataStore.missing_intervals()` instead of a single sliding window from `last_saved`; complete years are never re-downloaded (#XX)
+- `dccd/storage.py` — `DataStore.is_period_complete(year)`: checks whether an annual parquet file contains all expected candles; `DataStore.missing_intervals(start, end)`: real gap-detection replacing the 3.1 stub — complete past years are skipped, incomplete years resume from the last saved row (#41)
+- `dccd/daemon/backfill.py` — `_BackfillBase.run()` now iterates over `DataStore.missing_intervals()` instead of a single sliding window from `last_saved`; complete years are never re-downloaded (#41)
 
 ### Changed
 
-- `dccd daemon collect` (formerly `dccd run`) — renamed to clarify the distinction: `collect` = one incremental batch, `backfill` = full historical download with gap detection, `start` = continuous daemon (#XX)
+- `dccd daemon collect` (formerly `dccd run`) — renamed to clarify the distinction: `collect` = one incremental batch, `backfill` = full historical download with gap detection, `start` = continuous daemon (#41)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/storage.py` — `DataStore.is_period_complete(year)`: checks whether an annual parquet file contains all expected candles; `DataStore.missing_intervals(start, end)`: real gap-detection replacing the 3.1 stub — complete past years are skipped, incomplete years resume from the last saved row (#XX)
+- `dccd/daemon/backfill.py` — `_BackfillBase.run()` now iterates over `DataStore.missing_intervals()` instead of a single sliding window from `last_saved`; complete years are never re-downloaded (#XX)
+
+### Changed
+
+- `dccd daemon collect` (formerly `dccd run`) — renamed to clarify the distinction: `collect` = one incremental batch, `backfill` = full historical download with gap detection, `start` = continuous daemon (#XX)
+
+### Added
+
 - `dccd/storage.py` — new `DataStore` class: unified read/write interface for OHLC, trades, and orderbook; `save(df)` (merge-on-TS, annual OHLC / daily trades+orderbook), `load(start, end)`, `existing_periods()`, `last_timestamp()`, `missing_intervals()` (stub for 3.2) (#39)
 - `dccd/tools/date_time.py` — `span_label(span)` converts seconds to short directory labels (``'1m'``, ``'1h'``, ``'1d'``…); `_SPAN_LABEL` mapping exported (#39)
 - `dccd/tests/test_storage.py` — 23 unit tests for `DataStore` (save/load/merge/missing_intervals/corrupted file recovery) (#39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/storage.py` — `DataStore.is_period_complete(year)`: checks whether an annual parquet file contains all expected candles; `DataStore.missing_intervals(start, end)`: real gap-detection replacing the 3.1 stub — complete past years are skipped, incomplete years resume from the last saved row (#41)
+- `dccd/storage.py` — `DataStore.is_period_complete(year)`: checks whether an annual parquet file contains all expected candles; `DataStore.missing_intervals(start, end)`: gap-detection — complete past years are skipped, incomplete years resume from the last saved row (#41)
 - `dccd/daemon/backfill.py` — `_BackfillBase.run()` now iterates over `DataStore.missing_intervals()` instead of a single sliding window from `last_saved`; complete years are never re-downloaded (#41)
-
-### Changed
-
-- `dccd daemon collect` (formerly `dccd run`) — renamed to clarify the distinction: `collect` = one incremental batch, `backfill` = full historical download with gap detection, `start` = continuous daemon (#41)
-
-### Added
-
-- `dccd/storage.py` — new `DataStore` class: unified read/write interface for OHLC, trades, and orderbook; `save(df)` (merge-on-TS, annual OHLC / daily trades+orderbook), `load(start, end)`, `existing_periods()`, `last_timestamp()`, `missing_intervals()` (stub for 3.2) (#39)
+- `dccd/storage.py` — new `DataStore` class: unified read/write interface for OHLC, trades, and orderbook; `save(df)` (merge-on-TS, annual OHLC / daily trades+orderbook), `load(start, end)`, `existing_periods()`, `last_timestamp()` (#39)
 - `dccd/tools/date_time.py` — `span_label(span)` converts seconds to short directory labels (``'1m'``, ``'1h'``, ``'1d'``…); `_SPAN_LABEL` mapping exported (#39)
-- `dccd/tests/test_storage.py` — 23 unit tests for `DataStore` (save/load/merge/missing_intervals/corrupted file recovery) (#39)
 - `doc/source/storage.rst` — Sphinx page for `DataStore` with directory layout examples (#39)
 
 ### Changed
 
+- `dccd collect` (formerly `dccd run`) — renamed to clarify the distinction: `collect` = one incremental batch, `backfill` = full historical download with gap detection, `start` = continuous daemon (#41)
 - New storage arborescence: ``{data_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet``, ``…/trades/{pair}/YYYY-MM-DD.parquet``, ``…/orderbook/{pair}/YYYY-MM-DD.parquet`` — replaces the old ``{Exchange}/Data/Clean_Data/{per}/{pair}/`` layout (#39)
-- `dccd/histo_dl/exchange.py` — `save()`, `_get_last_date()`, `save_trades()`, `save_orderbook()` now delegate to `DataStore`; removed `last_df`, `_set_by_period`, `_name_file`, `_excel_format` (#39)
+- `dccd/histo_dl/exchange.py` — `save()`, `_get_last_date()`, `save_trades()`, `save_orderbook()` now delegate to `DataStore`; removed `last_df`, `_set_by_period`, `_name_file`, `_excel_format`; removed unused `set_hierarchy()` (#39, #41)
 - `dccd/histo_dl/{binance,bybit,coinbase,okx}.py` — removed `full_path` overrides (base class sets the correct path via `DataStore`) (#39)
 - `dccd/daemon/backfill.py`, `scheduler.py` — removed `by_period` parameter; `save()` call simplified (#39)
 - `dccd/daemon/stream_manager.py` — WebSocket save path now built from `DataStore.directory` (#39)

--- a/README.rst
+++ b/README.rst
@@ -218,8 +218,8 @@ CLI quick start:
     # Backfill only one exchange
     dccd backfill --config config.yml --exchange kraken
 
-    # One-shot scheduled run, then exit
-    dccd run --config config.yml
+    # One incremental batch per job, then exit (for cron)
+    dccd collect --config config.yml
 
     # Continuous daemon (Ctrl-C to stop)
     dccd start --config config.yml

--- a/dccd/daemon/backfill.py
+++ b/dccd/daemon/backfill.py
@@ -170,7 +170,7 @@ class _BackfillBase(ABC):
             tqdm bar position (use distinct values for parallel runs).
 
         """
-        now_ts = int(time_mod.time())
+        now_ts     = int(time_mod.time())
         user_start = int(date_to_TS(start_str, tz=self.obj.tz))
 
         if dry_run:
@@ -178,59 +178,59 @@ class _BackfillBase(ABC):
             tqdm.write(f'[{self.label}] {self._dry_run_summary(total)}')
             return
 
-        last_saved = self.obj._get_last_date()
-        current = max(user_start, last_saved)
+        intervals = self.obj._store.missing_intervals(user_start, now_ts)
 
-        if current >= now_ts:
+        if not intervals:
             tqdm.write(f'[{self.label}] already up to date')
             return
 
-        total = max(1, (now_ts - current) // self.window_size + 1)
+        total = sum(max(1, (e - s) // self.window_size + 1) for s, e in intervals)
         bar = tqdm(
             total=total, desc=self.label, unit='win',
             position=position, leave=True, dynamic_ncols=True,
         )
 
         n_candles = 0
-        skipped = 0
+        skipped   = 0
 
-        while current < now_ts:
-            end = min(current + self.window_size, now_ts)
-            self.obj._get_last_date()
+        for ivl_start, ivl_end in intervals:
+            current = ivl_start
+            while current < ivl_end:
+                end = min(current + self.window_size, ivl_end)
 
-            last_exc: Exception | None = None
-            n = 0
-            for attempt in range(1, _MAX_RETRIES + 1):
-                try:
-                    n = self._fetch_window(current, end)
-                    break
-                except Exception as exc:
-                    last_exc = exc
-                    if attempt < _MAX_RETRIES:
-                        tqdm.write(
-                            f'[{self.label}] attempt {attempt}/{_MAX_RETRIES} '
-                            f'failed: {exc} — retrying in 2s'
-                        )
-                        time_mod.sleep(2)
-            else:
-                tqdm.write(
-                    f'[{self.label}] window {current} failed after '
-                    f'{_MAX_RETRIES} attempts: {last_exc} — skipping'
-                )
-                skipped += 1
-                current += self.window_size
+                last_exc: Exception | None = None
+                n = 0
+                for attempt in range(1, _MAX_RETRIES + 1):
+                    try:
+                        n = self._fetch_window(current, end)
+                        break
+                    except Exception as exc:
+                        last_exc = exc
+                        if attempt < _MAX_RETRIES:
+                            tqdm.write(
+                                f'[{self.label}] attempt {attempt}/{_MAX_RETRIES} '
+                                f'failed: {exc} — retrying in 2s'
+                            )
+                            time_mod.sleep(2)
+                else:
+                    tqdm.write(
+                        f'[{self.label}] window {current} failed after '
+                        f'{_MAX_RETRIES} attempts: {last_exc} — skipping'
+                    )
+                    skipped += 1
+                    current += self.window_size
+                    bar.update(1)
+                    time_mod.sleep(self.sleep)
+                    continue
+
+                if n > 0:
+                    self.obj.save()
+                    n_candles += n
+
+                current = self._advance(current, end)
                 bar.update(1)
+                bar.set_postfix(candles=n_candles, skipped=skipped)
                 time_mod.sleep(self.sleep)
-                continue
-
-            if n > 0:
-                self.obj.save()
-                n_candles += n
-
-            current = self._advance(current, end)
-            bar.update(1)
-            bar.set_postfix(candles=n_candles, skipped=skipped)
-            time_mod.sleep(self.sleep)
 
         bar.close()
         tqdm.write(

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -28,14 +28,14 @@ Commands
         config, resuming from the last saved timestamp.  Runs in the
         foreground; use --parallel to run all jobs simultaneously.
 
-    dccd run --config PATH
-        Execute every histo_job once in order, then exit.
-        Metrics (success/failure counts) are printed on completion.
-        Useful for cron-based one-shot collection or smoke-testing a config.
+    dccd collect --config PATH
+        Fetch one incremental batch per histo_job, then exit.
+        Downloads candles from the last saved timestamp to now.
+        Designed for cron scheduling or as a single daemon tick.
 
     dccd start --config PATH
         Start the continuous daemon in the foreground:
-        - APScheduler BackgroundScheduler for all histo_jobs
+        - APScheduler BackgroundScheduler for all histo_jobs (calls collect)
         - StreamManager (one thread per WebSocket pair)
         - SyncService (periodic rclone push to remotes)
         Block until SIGINT (Ctrl-C) or SIGTERM; shuts down cleanly on signal.
@@ -151,17 +151,26 @@ def backfill(
 
 
 @app.command()
-def run(
+def collect(
     config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
                                help='Path to the YAML config file.'),
 ) -> None:
-    """ Run every histo_job once sequentially, then exit.
+    """ Fetch one incremental batch per histo_job, then exit.
 
-    Downloads and saves one candle batch per ``(exchange, pair)`` in
-    ``histo_jobs``.  A :class:`~dccd.daemon.health.HealthMonitor` is
-    instantiated so metrics are persisted even for this one-shot run.
-    Failed jobs are logged and skipped; remaining jobs continue.
+    Downloads candles from the last saved timestamp to now for each
+    ``(exchange, pair)`` in ``histo_jobs``.  Intended for cron-based
+    scheduling or as a single tick of the continuous daemon
+    (``dccd start`` calls this logic in a loop).
+
+    A :class:`~dccd.daemon.health.HealthMonitor` is instantiated so
+    metrics are persisted even for this one-shot run.  Failed jobs are
+    logged and skipped; remaining jobs continue.
     Prints ``successes=N failures=M`` on completion.
+
+    See Also
+    --------
+    backfill : full historical download with gap detection.
+    start    : continuous daemon that calls collect in a loop.
 
     """
     from dccd.daemon.health import HealthMonitor

--- a/dccd/histo_dl/exchange.py
+++ b/dccd/histo_dl/exchange.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 # Import built-in packages
 import logging
-import pathlib
 import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
@@ -541,23 +540,3 @@ class ImportDataCryptoCurrencies(ABC):
         store.save(df)
         return self
 
-    # ------------------------------------------------------------------
-
-    def set_hierarchy(self, liste: list[str]) -> None:
-        """ Override the default save path with a custom directory hierarchy.
-
-        Rebuilds :attr:`full_path` by joining :attr:`path` with each element
-        in ``liste``.  Call this before :meth:`import_data` if you want to
-        store files in a non-standard directory layout.
-
-        Parameters
-        ----------
-        liste : list of str
-            Path components to append to :attr:`path`.
-
-        """
-        self.full_path = self.path
-        for elt in liste:
-            self.full_path += '/' + elt
-        # Reset the store directory cache so the next save uses full_path.
-        self._store._dir = pathlib.Path(self.full_path)

--- a/dccd/storage.py
+++ b/dccd/storage.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -243,12 +244,45 @@ class DataStore:
 
         return None
 
-    def missing_intervals(self, start: int, end: int) -> list[tuple[int, int]]:
-        """Return intervals within ``[start, end]`` that need to be downloaded.
+    def is_period_complete(self, year: int) -> bool:
+        """Return True if the parquet file for *year* contains all expected rows.
 
-        In 3.1 this is a stub that always returns ``[(start, end)]`` (current
-        behaviour — resume from last saved point, no gap detection).  Full
-        gap-filling logic is implemented in section 3.2.
+        Parameters
+        ----------
+        year : int
+            Calendar year to check (e.g. ``2024``).
+
+        Returns
+        -------
+        bool
+            ``False`` for non-OHLC stores, missing files, or when the row
+            count is below the expected number of candles for that year.
+
+        """
+        if self.data_type != 'ohlc' or self.span is None:
+            return False
+        file_path = self.directory / f'{year}.parquet'
+        if not file_path.exists():
+            return False
+        df = pd.read_parquet(file_path, columns=['TS'])
+        year_start = datetime(year,     1, 1, tzinfo=timezone.utc)
+        year_end   = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+        expected = int((year_end - year_start).total_seconds()) // self.span
+        return len(df) >= expected
+
+    def missing_intervals(self, start: int, end: int) -> list[tuple[int, int]]:
+        """Return the list of ``(start, end)`` intervals within ``[start, end]``
+        that still need to be downloaded.
+
+        For OHLC stores the method inspects existing annual parquet files:
+        complete past years are skipped entirely; incomplete or absent years
+        yield an interval from the last saved timestamp (``+ span``) to the
+        end of that year.  The current calendar year always extends from the
+        last saved row to *end*.
+
+        For trades / orderbook stores (no ``span``) the method falls back to a
+        simple resume: one interval from ``last_timestamp + span`` (or
+        *start* if no data) to *end*.
 
         Parameters
         ----------
@@ -260,11 +294,45 @@ class DataStore:
         Returns
         -------
         list of (int, int)
-            List of ``(start, end)`` pairs to download.
+            Ordered list of ``(ivl_start, ivl_end)`` pairs to download.
+            Empty list means all data is already present.
 
         """
-        last = self.last_timestamp()
-        effective_start = max(start, last) if last is not None else start
-        if effective_start >= end:
-            return []
-        return [(effective_start, end)]
+        if self.data_type != 'ohlc' or self.span is None:
+            last = self.last_timestamp()
+            effective = max(start, last) if last is not None else start
+            return [(effective, end)] if effective < end else []
+
+        current_year = datetime.now(tz=timezone.utc).year
+        start_year   = datetime.fromtimestamp(start, tz=timezone.utc).year
+        end_year     = datetime.fromtimestamp(end,   tz=timezone.utc).year
+        intervals: list[tuple[int, int]] = []
+
+        for year in range(start_year, end_year + 1):
+            year_start_ts = int(datetime(year,     1, 1, tzinfo=timezone.utc).timestamp())
+            year_end_ts   = int(datetime(year + 1, 1, 1, tzinfo=timezone.utc).timestamp())
+
+            ivl_start = max(start, year_start_ts)
+            ivl_end   = min(end,   year_end_ts)
+            if ivl_start >= ivl_end:
+                continue
+
+            file_path = self.directory / f'{year}.parquet'
+
+            if year < current_year and file_path.exists():
+                if self.is_period_complete(year):
+                    continue  # full year already on disk — skip
+                # incomplete past year: resume from last saved row
+                df = pd.read_parquet(file_path, columns=['TS'])
+                if not df.empty:
+                    ivl_start = int(df['TS'].max()) + self.span
+            elif file_path.exists():
+                # current year: always extend from the last saved row
+                df = pd.read_parquet(file_path, columns=['TS'])
+                if not df.empty:
+                    ivl_start = int(df['TS'].max()) + self.span
+
+            if ivl_start < ivl_end:
+                intervals.append((ivl_start, ivl_end))
+
+        return intervals

--- a/dccd/tests/test_backfill.py
+++ b/dccd/tests/test_backfill.py
@@ -220,3 +220,66 @@ def test_cli_backfill_missing_config(tmp_path):
         ['backfill', '--config', str(tmp_path / 'missing.yml')],
     )
     assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# _BackfillBase.run — gap-aware loop
+# ---------------------------------------------------------------------------
+
+def test_run_skips_when_up_to_date():
+    obj = _mock_obj()
+    obj._store.missing_intervals.return_value = []
+    job = OHLCBackfill(obj, max_candles=990, sleep=0.0, form='parquet')
+    with patch('dccd.daemon.backfill.time_mod'):
+        job.run('2020-01-01 00:00:00')
+    obj._store.missing_intervals.assert_called_once()
+    obj.import_data.assert_not_called()
+    obj.save.assert_not_called()
+
+
+def test_run_iterates_intervals():
+    # window_size = max_candles * span = 2 * 60 = 120 s
+    obj = _mock_obj(span=60)
+    obj._store.missing_intervals.return_value = [
+        (1_000, 1_240),   # 2 windows: [1000,1120) + [1120,1240)
+        (2_000, 2_120),   # 1 window:  [2000,2120)
+    ]
+    job = OHLCBackfill(obj, max_candles=2, sleep=0.0, form='parquet')
+
+    fetched: list[tuple[int, int]] = []
+
+    def _fake_fetch(current: int, end: int) -> int:
+        fetched.append((current, end))
+        return 1
+
+    job._fetch_window = _fake_fetch  # type: ignore[method-assign]
+    job._advance      = lambda current, end: end  # type: ignore[method-assign]
+
+    with patch('dccd.daemon.backfill.time_mod'):
+        job.run('2020-01-01 00:00:00')
+
+    assert fetched == [(1_000, 1_120), (1_120, 1_240), (2_000, 2_120)]
+    assert obj.save.call_count == 3
+
+
+def test_run_retries_on_fetch_error():
+    obj = _mock_obj(span=60)
+    obj._store.missing_intervals.return_value = [(1_000, 1_120)]
+    job = OHLCBackfill(obj, max_candles=2, sleep=0.0, form='parquet')
+
+    calls = {'n': 0}
+
+    def _flaky_fetch(current: int, end: int) -> int:
+        calls['n'] += 1
+        if calls['n'] < 3:
+            raise RuntimeError('transient error')
+        return 1
+
+    job._fetch_window = _flaky_fetch  # type: ignore[method-assign]
+    job._advance      = lambda current, end: end  # type: ignore[method-assign]
+
+    with patch('dccd.daemon.backfill.time_mod'):
+        job.run('2020-01-01 00:00:00')
+
+    assert calls['n'] == 3   # 2 failures + 1 success
+    obj.save.assert_called_once()

--- a/dccd/tests/test_daemon_cli.py
+++ b/dccd/tests/test_daemon_cli.py
@@ -51,11 +51,11 @@ def test_validate_bad_config(tmp_path: Path) -> None:
     assert result.exit_code == 1
 
 
-def test_run_calls_run_once(config_file: Path) -> None:
+def test_collect_calls_run_once(config_file: Path) -> None:
     with patch('dccd.daemon.health.HealthMonitor') as MockHealth, \
          patch('dccd.daemon.scheduler.run_once') as mock_run_once:
         MockHealth.return_value.get_metrics.return_value = {}
-        result = runner.invoke(app, ['run', '--config', str(config_file)])
+        result = runner.invoke(app, ['collect', '--config', str(config_file)])
     assert result.exit_code == 0
     mock_run_once.assert_called_once()
 

--- a/dccd/tests/test_storage.py
+++ b/dccd/tests/test_storage.py
@@ -217,26 +217,129 @@ def test_last_timestamp_removes_corrupted_and_falls_back(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# DataStore.missing_intervals (3.1 stub)
+# Helpers for gap-detection tests
 # ---------------------------------------------------------------------------
+
+def _complete_year_df(year: int, span: int) -> pd.DataFrame:
+    from datetime import datetime, timezone
+    t0 = int(datetime(year,     1, 1, tzinfo=timezone.utc).timestamp())
+    t1 = int(datetime(year + 1, 1, 1, tzinfo=timezone.utc).timestamp())
+    return _ohlc_df(list(range(t0, t1, span)))
+
+
+# ---------------------------------------------------------------------------
+# DataStore.is_period_complete
+# ---------------------------------------------------------------------------
+
+def test_is_period_complete_true(tmp_path):
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    store.save(_complete_year_df(2023, span))
+    assert store.is_period_complete(2023) is True
+
+
+def test_is_period_complete_false_missing_file(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    assert store.is_period_complete(2023) is False
+
+
+def test_is_period_complete_false_partial(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    store.save(_ohlc_df([1672531200]))  # one row only
+    assert store.is_period_complete(2023) is False
+
+
+def test_is_period_complete_false_for_trades(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', None, 'trades')
+    assert store.is_period_complete(2023) is False
+
+
+# ---------------------------------------------------------------------------
+# DataStore.missing_intervals
+# ---------------------------------------------------------------------------
+
+# Boundaries used in tests:
+#   2023-01-01 00:00:00 UTC = 1672531200
+#   2024-01-01 00:00:00 UTC = 1704067200
+#   2025-01-01 00:00:00 UTC = 1735689600
+
+_Y2023 = 1672531200
+_Y2024 = 1704067200
+_Y2025 = 1735689600
+
 
 def test_missing_intervals_no_data(tmp_path):
     store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
-    intervals = store.missing_intervals(1672531200, 1704067200)
-    assert intervals == [(1672531200, 1704067200)]
+    intervals = store.missing_intervals(_Y2023, _Y2024)
+    assert intervals == [(_Y2023, _Y2024)]
 
 
-def test_missing_intervals_with_existing_data(tmp_path):
-    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
-    store.save(_ohlc_df([1672531200]))  # last TS = 1672531200
-    intervals = store.missing_intervals(1672524000, 1704067200)
+def test_missing_intervals_complete_past_year(tmp_path):
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    store.save(_complete_year_df(2023, span))
+    intervals = store.missing_intervals(_Y2023, _Y2024)
+    assert intervals == []
+
+
+def test_missing_intervals_incomplete_past_year(tmp_path):
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    last_ts = _Y2023 + 10 * span
+    store.save(_ohlc_df(list(range(_Y2023, last_ts + span, span))))
+    intervals = store.missing_intervals(_Y2023, _Y2024)
     assert len(intervals) == 1
-    assert intervals[0][0] == 1672531200  # resume from last saved
-    assert intervals[0][1] == 1704067200
+    assert intervals[0][0] == last_ts + span
+    assert intervals[0][1] == _Y2024
+
+
+def test_missing_intervals_absent_past_year(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
+    # 2023 file absent: full year should be included
+    intervals = store.missing_intervals(_Y2023, _Y2024)
+    assert intervals == [(_Y2023, _Y2024)]
+
+
+def test_missing_intervals_current_year_extends_from_last(tmp_path):
+    from datetime import datetime, timezone
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    current_year = datetime.now(tz=timezone.utc).year
+    year_start = int(datetime(current_year, 1, 1, tzinfo=timezone.utc).timestamp())
+    last_ts = year_start + 5 * span
+    store.save(_ohlc_df(list(range(year_start, last_ts + span, span))))
+    end_ts = last_ts + 100 * span
+    intervals = store.missing_intervals(year_start, end_ts)
+    assert len(intervals) == 1
+    assert intervals[0][0] == last_ts + span
+    assert intervals[0][1] == end_ts
+
+
+def test_missing_intervals_multi_year(tmp_path):
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    # 2023 complete → skip; 2024 partial → resume
+    store.save(_complete_year_df(2023, span))
+    last_2024 = _Y2024 + 10 * span
+    store.save(_ohlc_df(list(range(_Y2024, last_2024 + span, span))))
+    intervals = store.missing_intervals(_Y2023, _Y2025)
+    # only one interval: the tail of 2024 through end of 2025
+    assert len(intervals) == 1
+    assert intervals[0][0] == last_2024 + span
 
 
 def test_missing_intervals_already_up_to_date(tmp_path):
-    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', 3600, 'ohlc')
-    store.save(_ohlc_df([1704067200]))  # last = 2024-01-01
-    intervals = store.missing_intervals(1672531200, 1704067200)
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    store.save(_complete_year_df(2023, span))
+    intervals = store.missing_intervals(_Y2023, _Y2024)
     assert intervals == []
+
+
+def test_missing_intervals_non_ohlc_simple_resume(tmp_path):
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', None, 'trades')
+    store.save(_trades_df([1672531200]))
+    intervals = store.missing_intervals(1672531200, 1704067200)
+    assert len(intervals) == 1
+    # no span for trades — stub returns from last_timestamp (no +span)
+    assert intervals[0][1] == 1704067200

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -55,7 +55,7 @@ Quick start (CLI)
          webhook_url: "https://hooks.slack.com/services/..."
          max_consecutive_errors: 3
 
-3. Validate, backfill, run once, or start the daemon:
+3. Validate, backfill, collect, or start the daemon:
 
    .. code-block:: bash
 
@@ -82,8 +82,8 @@ Quick start (CLI)
        # Run all jobs in parallel threads
        dccd backfill --config config.yml --parallel
 
-       # One-shot: run all histo jobs once and exit
-       dccd run --config config.yml
+       # One incremental batch per histo job, then exit (for cron)
+       dccd collect --config config.yml
        # Done. successes=2 failures=0
 
        # Continuous daemon (block until Ctrl-C / SIGTERM)

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -2,7 +2,7 @@
 #
 # Copy this file, adapt it to your setup, and pass it to the daemon:
 #   dccd validate --config config.yml    # check without running
-#   dccd run --once --config config.yml  # run all jobs once and exit
+#   dccd collect --config config.yml     # one incremental batch, then exit
 #   dccd start --config config.yml       # run as a daemon
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **3.2** `DataStore.missing_intervals()` remplace le stub 3.1 : détection des lacunes annuelles, skip des années complètes, reprise depuis le dernier timestamp pour les années incomplètes
- **3.2** `DataStore.is_period_complete(year)` : vérifie que le fichier parquet annuel contient le nombre attendu de lignes
- **3.2** `_BackfillBase.run()` consomme `missing_intervals()` au lieu du sliding-window depuis `last_saved`
- **3.3** `dccd run` → `dccd collect` : clarification de la sémantique (collect = un tick, backfill = historique complet, start = daemon continu)

## Changes
- `dccd/storage.py` — `is_period_complete`, nouveau `missing_intervals` avec gap-detection par année
- `dccd/daemon/backfill.py` — `run()` itère sur les intervalles manquants
- `dccd/daemon/cli.py` — `run` → `collect`, docstrings + module docstring mis à jour
- `README.rst`, `doc/source/daemon.rst`, `examples/config.example.yml` — `dccd run` → `dccd collect`
- Tests : +12 tests `test_storage.py` (gap-detection, is_period_complete), +3 tests `test_backfill.py` (skip, iterate, retry)

## Test plan
- [x] 312 tests passent localement
- [x] ruff clean
- [ ] CI verte