### PR TITLE
fix: add daemon extra to RTD install to fix missing tqdm

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ python:
       path: .
       extra_requirements:
         - doc
+        - daemon
 
 submodules:
   include: []


### PR DESCRIPTION
RTD builds `.[doc]` only; `dccd.daemon.backfill` imports `tqdm` at module level so Sphinx fails to import it. Adding `daemon` to extra_requirements installs `tqdm` (and `typer`) in the RTD environment.