### PR TITLE
fix: missing_intervals returns beginning gap when start predates file_min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `dccd/storage.py` — `DataStore.missing_intervals` now detects the gap **before** the first saved row when the requested `start` predates `file_min`; previously only the trailing gap (after `file_max`) was returned, causing `dccd backfill --start <early-date>` to silently skip all historical data before the first existing candle (#XX)
+
 - `dccd/histo_dl/coinbase.py` — raise `RuntimeError` when Coinbase returns HTTP 200 with a JSON dict (e.g. `{"message": "..."}` for near-future windows) instead of silently iterating dict keys and crashing with `ValueError` (#XX)
 - `dccd/histo_dl/coinbase.py` — additional guard: raise `RuntimeError` when Coinbase returns a JSON list whose first element is not itself a list/tuple (e.g. `["message"]`); previously caused `float("m")` `ValueError` (#XX)
 - `dccd/histo_dl/exchange.py` — `_sort_data` no longer raises `KeyError: 'TS'` when the API returns empty data; returns early with an empty `self.df` so the backfill skips the window cleanly (#XX)

--- a/dccd/storage.py
+++ b/dccd/storage.py
@@ -319,18 +319,23 @@ class DataStore:
 
             file_path = self.directory / f'{year}.parquet'
 
-            if year < current_year and file_path.exists():
-                if self.is_period_complete(year):
+            if file_path.exists():
+                if year < current_year and self.is_period_complete(year):
                     continue  # full year already on disk — skip
-                # incomplete past year: resume from last saved row
                 df = pd.read_parquet(file_path, columns=['TS'])
                 if not df.empty:
-                    ivl_start = int(df['TS'].max()) + self.span
-            elif file_path.exists():
-                # current year: always extend from the last saved row
-                df = pd.read_parquet(file_path, columns=['TS'])
-                if not df.empty:
-                    ivl_start = int(df['TS'].max()) + self.span
+                    file_min = int(df['TS'].min())
+                    file_max = int(df['TS'].max())
+                    # Gap before the first saved row (e.g. backfill requested
+                    # from an earlier date than the file's first candle)
+                    if ivl_start < file_min:
+                        intervals.append((ivl_start, file_min))
+                    # Trailing gap after the last saved row
+                    trailing = file_max + self.span
+                    if trailing < ivl_end:
+                        intervals.append((trailing, ivl_end))
+                    continue
+                # file exists but is empty: fall through to full-interval append
 
             if ivl_start < ivl_end:
                 intervals.append((ivl_start, ivl_end))

--- a/dccd/tests/test_storage.py
+++ b/dccd/tests/test_storage.py
@@ -336,6 +336,52 @@ def test_missing_intervals_already_up_to_date(tmp_path):
     assert intervals == []
 
 
+def test_missing_intervals_start_before_file_min_current_year(tmp_path):
+    """File starts mid-year; requested start is before file_min → beginning gap + trailing gap."""
+    from datetime import datetime, timezone
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    current_year = datetime.now(tz=timezone.utc).year
+    year_start = int(datetime(current_year, 1, 1, tzinfo=timezone.utc).timestamp())
+    # File covers mid-May onwards (simulates the user's real situation)
+    file_start = year_start + 100 * span
+    file_end   = year_start + 110 * span
+    store.save(_ohlc_df(list(range(file_start, file_end + span, span))))
+    end_ts = file_end + 50 * span
+
+    intervals = store.missing_intervals(year_start, end_ts)
+
+    # Expect two intervals: [year_start, file_start) and [file_end+span, end_ts)
+    assert len(intervals) == 2
+    assert intervals[0] == (year_start, file_start)
+    assert intervals[1] == (file_end + span, end_ts)
+
+
+def test_missing_intervals_start_before_file_min_past_year(tmp_path):
+    """Past incomplete year where file starts after requested start → beginning gap returned."""
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    file_start = _Y2023 + 100 * span
+    file_end   = _Y2023 + 200 * span
+    store.save(_ohlc_df(list(range(file_start, file_end + span, span))))
+
+    intervals = store.missing_intervals(_Y2023, _Y2024)
+
+    assert len(intervals) == 2
+    assert intervals[0] == (_Y2023, file_start)
+    assert intervals[1] == (file_end + span, _Y2024)
+
+
+def test_missing_intervals_file_already_covers_full_request(tmp_path):
+    """File already covers [start, end] exactly → no intervals."""
+    span = 3600
+    store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', span, 'ohlc')
+    store.save(_ohlc_df(list(range(_Y2023, _Y2023 + 10 * span + span, span))))
+    end_ts = _Y2023 + 5 * span
+    intervals = store.missing_intervals(_Y2023, end_ts)
+    assert intervals == []
+
+
 def test_missing_intervals_non_ohlc_simple_resume(tmp_path):
     store = DataStore(str(tmp_path), 'binance', 'BTC/USDT', None, 'trades')
     store.save(_trades_df([1672531200]))


### PR DESCRIPTION
## Summary
- `DataStore.missing_intervals` was only looking at `df['TS'].max()` when a parquet file existed, resuming from the end of the file
- When `--start` was set to a date before the first saved row (e.g. `--start "2026-01-01"` with data only from May 15), the entire beginning gap was silently ignored
- Fix: compare `ivl_start` against both `file_min` and `file_max`; emit `(ivl_start, file_min)` if a beginning gap exists, then `(file_max+span, ivl_end)` for the trailing gap

## Changes
- `dccd/storage.py` — refactored the file-exists branch in `missing_intervals` to detect beginning + trailing gaps independently
- `dccd/tests/test_storage.py` — 3 new tests: `test_missing_intervals_start_before_file_min_current_year`, `test_missing_intervals_start_before_file_min_past_year`, `test_missing_intervals_file_already_covers_full_request`

## Test plan
- [x] `pytest dccd/tests/test_storage.py` — 35 passed
- [x] `pytest` — 315 passed
- [ ] CI green