### PR TITLE
feat: show date range instead of window count in backfill progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `dccd/daemon/backfill.py` — backfill progress bar now shows the current window date (`YYYY-MM-DD → YYYY-MM-DD`) instead of a raw window count (`n win`); makes it easy to see which period is being downloaded at a glance (#XX)
+- `dccd/daemon/backfill.py` — backfill progress bar now shows the current window date (`YYYY-MM-DD → YYYY-MM-DD`) instead of a raw window count (`n win`); makes it easy to see which period is being downloaded at a glance (#48)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `dccd/daemon/backfill.py` — backfill progress bar now shows the current window date (`YYYY-MM-DD → YYYY-MM-DD`) instead of a raw window count (`n win`); makes it easy to see which period is being downloaded at a glance (#XX)
+
 ### Fixed
 
 - `dccd/storage.py` — `DataStore.missing_intervals` now detects the gap **before** the first saved row when the requested `start` predates `file_min`; previously only the trailing gap (after `file_max`) was returned, causing `dccd backfill --start <early-date>` to silently skip all historical data before the first existing candle (#XX)

--- a/dccd/daemon/backfill.py
+++ b/dccd/daemon/backfill.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import time as time_mod
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -184,9 +185,15 @@ class _BackfillBase(ABC):
             tqdm.write(f'[{self.label}] already up to date')
             return
 
-        total = sum(max(1, (e - s) // self.window_size + 1) for s, e in intervals)
+        def _iso(ts: int) -> str:
+            return datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d')
+
+        total        = sum(max(1, (e - s) // self.window_size + 1) for s, e in intervals)
+        end_date_str = _iso(intervals[-1][1])
         bar = tqdm(
-            total=total, desc=self.label, unit='win',
+            total=total,
+            desc=f'{self.label}  {_iso(intervals[0][0])} → {end_date_str}',
+            unit='',
             position=position, leave=True, dynamic_ncols=True,
         )
 
@@ -227,8 +234,10 @@ class _BackfillBase(ABC):
                     self.obj.save()
                     n_candles += n
 
+                current_date = _iso(current)
                 current = self._advance(current, end)
                 bar.update(1)
+                bar.set_description(f'{self.label}  {current_date} → {end_date_str}')
                 bar.set_postfix(candles=n_candles, skipped=skipped)
                 time_mod.sleep(self.sleep)
 


### PR DESCRIPTION
## Summary

- Replace `unit='win'` with a dynamic `desc` showing `YYYY-MM-DD → YYYY-MM-DD` so you can see at a glance which time period is being downloaded, not just how many API windows have been processed.

## Changes

- `dccd/daemon/backfill.py` — add `_iso()` helper, initialise bar with start/end dates, call `set_description()` on each window with the current window date.

## Changelog

Added under `[Unreleased] ### Changed`:
- `dccd/daemon/backfill.py` — backfill progress bar now shows the current window date (`YYYY-MM-DD → YYYY-MM-DD`) instead of a raw window count (`n win`).

## Test plan

- [x] `pytest` passes (315 tests)
- [x] `ruff check dccd/` passes
- [ ] CI green