### PR TITLE
feat: XDG default config path fallback for all CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#XX)
+
 ### Changed
 
 - `dccd/daemon/backfill.py` — backfill progress bar now shows the current window date (`YYYY-MM-DD → YYYY-MM-DD`) instead of a raw window count (`n win`); makes it easy to see which period is being downloaded at a glance (#48)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#XX)
+- `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#49)
 
 ### Changed
 

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -69,17 +69,15 @@ __all__ = ['app']
 
 app = typer.Typer(help='dccd — autonomous crypto data collection daemon')
 
-_DEFAULT_CONFIG = 'config.yml'
-
-
-def _load(config_path: str) -> object:
+def _load(config_path: Optional[str]) -> object:
     """Load config, exit with code 1 on any error."""
-    from dccd.daemon.config import load_config
+    from dccd.daemon.config import load_config, resolve_config_path
 
     try:
-        return load_config(config_path)
-    except FileNotFoundError:
-        typer.echo(f'Error: config file not found: {config_path}', err=True)
+        resolved = resolve_config_path(config_path)
+        return load_config(resolved)
+    except FileNotFoundError as exc:
+        typer.echo(f'Error: {exc}', err=True)
         raise typer.Exit(1)
     except Exception as exc:
         typer.echo(f'Error: {exc}', err=True)
@@ -88,8 +86,10 @@ def _load(config_path: str) -> object:
 
 @app.command()
 def validate(
-    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
-                               help='Path to the YAML config file.'),
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
+    ),
 ) -> None:
     """ Validate a YAML config file and print a one-line summary.
 
@@ -98,8 +98,15 @@ def validate(
     Exits with code 1 on any error (missing file, bad YAML, invalid config).
 
     """
-    cfg = _load(config)
-    typer.echo(f'Config: {config}')
+    from dccd.daemon.config import resolve_config_path
+
+    try:
+        resolved = resolve_config_path(config)
+    except FileNotFoundError as exc:
+        typer.echo(f'Error: {exc}', err=True)
+        raise typer.Exit(1)
+    cfg = _load(str(resolved))
+    typer.echo(f'Config: {resolved}')
     typer.echo(f'  data_path          : {cfg.settings.data_path}')  # type: ignore[attr-defined]
     typer.echo(f'  timezone           : {cfg.settings.timezone}')  # type: ignore[attr-defined]
     typer.echo(f'  remotes            : {len(cfg.storage.remotes)}')  # type: ignore[attr-defined]
@@ -110,8 +117,9 @@ def validate(
 
 @app.command()
 def backfill(
-    config: str = typer.Option(
-        _DEFAULT_CONFIG, '--config', '-c', help='Path to the YAML config file.',
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
     ),
     exchange: Optional[str] = typer.Option(
         None, '--exchange', '-e',
@@ -152,8 +160,10 @@ def backfill(
 
 @app.command()
 def collect(
-    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
-                               help='Path to the YAML config file.'),
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
+    ),
 ) -> None:
     """ Fetch one incremental batch per histo_job, then exit.
 
@@ -187,8 +197,10 @@ def collect(
 
 @app.command()
 def start(
-    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
-                               help='Path to the YAML config file.'),
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
+    ),
 ) -> None:
     """ Start the continuous daemon and block until SIGINT or SIGTERM.
 
@@ -234,8 +246,10 @@ def start(
 
 @app.command()
 def status(
-    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
-                               help='Path to the YAML config file.'),
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
+    ),
 ) -> None:
     """ Print a health table from the saved metrics JSON.
 
@@ -280,8 +294,10 @@ def add(
     exchange: str = typer.Option(..., '--exchange', '-e', help='Exchange name.'),
     pair: str = typer.Option(..., '--pair', '-p', help='Trading pair (e.g. BTC/USDT).'),
     span: int = typer.Option(..., '--span', '-s', help='Candle interval in seconds.'),
-    config: str = typer.Option(_DEFAULT_CONFIG, '--config', '-c',
-                               help='Path to the YAML config file.'),
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
+    ),
 ) -> None:
     """ Append a new histo job to the YAML config file in-place.
 
@@ -293,11 +309,16 @@ def add(
     import yaml
     from pydantic import ValidationError
 
-    from dccd.daemon.config import CollectorConfig
+    from dccd.daemon.config import CollectorConfig, resolve_config_path
 
-    config_path = Path(config)
+    try:
+        config_path = resolve_config_path(config)
+    except FileNotFoundError as exc:
+        typer.echo(f'Error: {exc}', err=True)
+        raise typer.Exit(1)
+
     if not config_path.exists():
-        typer.echo(f'Error: config file not found: {config}', err=True)
+        typer.echo(f'Error: config file not found: {config_path}', err=True)
         raise typer.Exit(1)
 
     raw: dict = yaml.safe_load(config_path.read_text())
@@ -316,4 +337,4 @@ def add(
 
     config_path.write_text(yaml.dump(raw, default_flow_style=False))
     typer.echo(f'Added histo job: exchange={exchange} pair={pair} span={span}s')
-    typer.echo(f'Config written to {config}.')
+    typer.echo(f'Config written to {config_path}.')

--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -9,6 +9,7 @@ Loads a YAML file and validates it with Pydantic v2 models.
 
 from __future__ import annotations
 
+import os
 import pathlib
 from typing import Any
 
@@ -18,13 +19,21 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 __all__ = [
     'AlertConfig',
     'CollectorConfig',
+    'DEFAULT_CONFIG_PATH',
     'HistoJob',
     'RemoteConfig',
     'SettingsConfig',
     'StorageConfig',
     'StreamJob',
     'load_config',
+    'resolve_config_path',
 ]
+
+_XDG_CONFIG_HOME: pathlib.Path = pathlib.Path(
+    os.environ.get('XDG_CONFIG_HOME', '~/.config')
+).expanduser()
+
+DEFAULT_CONFIG_PATH: pathlib.Path = _XDG_CONFIG_HOME / 'dccd' / 'config.yml'
 
 SUPPORTED_HISTO_EXCHANGES: frozenset[str] = frozenset(
     {'binance', 'kraken', 'bybit', 'okx', 'coinbase'}
@@ -265,6 +274,42 @@ class CollectorConfig(BaseModel):
                 "(histo_jobs or stream_jobs)"
             )
         return self
+
+
+def resolve_config_path(path: str | pathlib.Path | None = None) -> pathlib.Path:
+    """ Return the config file path to use, applying XDG fallback when *path* is None.
+
+    Parameters
+    ----------
+    path : str, pathlib.Path, or None
+        Explicit config path.  When ``None``, the function searches in order:
+        ``./config.yml`` (current working directory), then
+        :data:`DEFAULT_CONFIG_PATH` (``$XDG_CONFIG_HOME/dccd/config.yml``).
+
+    Returns
+    -------
+    pathlib.Path
+        Resolved path.  When *path* is not ``None`` the value is returned
+        as-is (after ``expanduser``); existence is **not** checked.
+
+    Raises
+    ------
+    FileNotFoundError
+        When *path* is ``None`` and none of the candidate paths exist.
+
+    """
+    if path is not None:
+        return pathlib.Path(path).expanduser()
+    xdg_cfg = (
+        pathlib.Path(os.environ.get('XDG_CONFIG_HOME', '~/.config')).expanduser()
+        / 'dccd' / 'config.yml'
+    )
+    candidates = [pathlib.Path('config.yml'), xdg_cfg]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    tried = ', '.join(str(c) for c in candidates)
+    raise FileNotFoundError(f'No config file found. Tried: {tried}')
 
 
 def load_config(path: str | pathlib.Path) -> CollectorConfig:

--- a/dccd/tests/test_daemon_cli.py
+++ b/dccd/tests/test_daemon_cli.py
@@ -106,3 +106,20 @@ def test_add_histo_job(config_file: Path) -> None:
         p for job in loaded['histo_jobs'] for p in job['pairs']
     ]
     assert 'ETH/USD' in pairs_all
+
+
+def test_validate_no_config_uses_xdg(config_file: Path) -> None:
+    with patch('dccd.daemon.config.resolve_config_path', return_value=config_file):
+        result = runner.invoke(app, ['validate'])
+    assert result.exit_code == 0
+    assert 'valid' in result.output.lower()
+
+
+def test_validate_missing_all_configs(tmp_path: Path) -> None:
+    with patch(
+        'dccd.daemon.config.resolve_config_path',
+        side_effect=FileNotFoundError('No config file found. Tried: config.yml, ~/.config/dccd/config.yml'),
+    ):
+        result = runner.invoke(app, ['validate'])
+    assert result.exit_code == 1
+    assert 'No config file found' in result.output

--- a/dccd/tests/test_daemon_config.py
+++ b/dccd/tests/test_daemon_config.py
@@ -8,8 +8,10 @@ import yaml
 from pydantic import ValidationError
 
 from dccd.daemon.config import (
+    DEFAULT_CONFIG_PATH,
     CollectorConfig,
     load_config,
+    resolve_config_path,
 )
 
 # ---------------------------------------------------------------------------
@@ -166,3 +168,49 @@ def test_load_config_validation_error(tmp_path):
     p = _make_config_file(tmp_path, bad)
     with pytest.raises(ValidationError):
         load_config(p)
+
+
+# ---------------------------------------------------------------------------
+# resolve_config_path
+# ---------------------------------------------------------------------------
+
+def test_resolve_explicit_path(tmp_path):
+    p = tmp_path / 'my.yml'
+    result = resolve_config_path(str(p))
+    assert result == p
+
+
+def test_resolve_explicit_path_expanduser(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    result = resolve_config_path('~/my.yml')
+    assert result == tmp_path / 'my.yml'
+
+
+def test_resolve_cwd_fallback(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cwd_cfg = tmp_path / 'config.yml'
+    cwd_cfg.write_text(yaml.dump(_VALID_CONFIG))
+    result = resolve_config_path(None)
+    assert result == pathlib.Path('config.yml')
+
+
+def test_resolve_xdg_fallback(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    xdg_dir = tmp_path / 'xdg'
+    xdg_cfg = xdg_dir / 'dccd' / 'config.yml'
+    xdg_cfg.parent.mkdir(parents=True)
+    xdg_cfg.write_text(yaml.dump(_VALID_CONFIG))
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(xdg_dir))
+    result = resolve_config_path(None)
+    assert result == xdg_cfg
+
+
+def test_resolve_no_config_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'empty_xdg'))
+    with pytest.raises(FileNotFoundError, match='No config file found'):
+        resolve_config_path(None)
+
+
+def test_default_config_path_constant():
+    assert DEFAULT_CONFIG_PATH.parts[-2:] == ('dccd', 'config.yml')


### PR DESCRIPTION
## Summary

- All `dccd` commands (`validate`, `backfill`, `collect`, `start`, `status`, `add`) now resolve the config file via a priority chain when `--config` is not provided: `./config.yml` → `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`)
- Exposes `resolve_config_path()` and `DEFAULT_CONFIG_PATH` in `dccd.daemon.config`
- No new dependencies — stdlib `os` + `pathlib` only

## Changes

- `dccd/daemon/config.py` — added `resolve_config_path(path)` and `DEFAULT_CONFIG_PATH` constant; XDG path is read from `os.environ` at call time so `XDG_CONFIG_HOME` overrides work without module reload
- `dccd/daemon/cli.py` — removed hardcoded `_DEFAULT_CONFIG = 'config.yml'`; all commands use `Optional[str] = typer.Option(None, ...)` and delegate resolution to `_load()` / `resolve_config_path()`
- `dccd/tests/test_daemon_config.py` — 6 new tests for `resolve_config_path` (explicit path, expanduser, CWD fallback, XDG fallback, no config raises, constant shape)
- `dccd/tests/test_daemon_cli.py` — 2 new tests for CLI XDG fallback and missing-all-configs error path

## Changelog

Added under [Unreleased]:
- `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#XX)

## Test plan

- [x] `pytest` passes (323 tests)
- [x] `ruff check dccd/` passes
- [ ] CI green