### PR TITLE
feat: add dccd inventory and dccd remove CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#49)
+- `dccd/daemon/cli.py` — `dccd inventory`: scans `data_path` and prints a table of all stored OHLC, trades, and orderbook data with date range, row count, and gap count per series; uses Polars for fast columnar reads (#XX)
+- `dccd/daemon/cli.py` — `dccd remove --exchange X --pair Y --span N`: removes a pair from a histo_job (or the whole job if it was the last pair) and re-validates the config before writing (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#49)
-- `dccd/daemon/cli.py` — `dccd inventory`: scans `data_path` and prints a table of all stored OHLC, trades, and orderbook data with date range, row count, and gap count per series; uses Polars for fast columnar reads (#XX)
-- `dccd/daemon/cli.py` — `dccd remove --exchange X --pair Y --span N`: removes a pair from a histo_job (or the whole job if it was the last pair) and re-validates the config before writing (#XX)
+- `dccd/daemon/cli.py` — `dccd inventory`: scans `data_path` and prints a table of all stored OHLC, trades, and orderbook data with date range, row count, and gap count per series; uses Polars for fast columnar reads (#50)
+- `dccd/daemon/cli.py` — `dccd remove --exchange X --pair Y --span N`: removes a pair from a histo_job (or the whole job if it was the last pair) and re-validates the config before writing (#50)
 
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,16 @@ CLI quick start:
     # Continuous daemon (Ctrl-C to stop)
     dccd start --config config.yml
 
+    # Add / remove a histo job in-place
+    dccd add --exchange kraken --pair ETH/USD --span 86400 --config config.yml
+    dccd remove --exchange kraken --pair ETH/USD --span 86400 --config config.yml
+
+    # Inspect all data on disk (OHLC, trades, orderbook)
+    dccd inventory --config config.yml
+
+Note: ``--config`` is optional — dccd searches ``./config.yml`` then
+``~/.config/dccd/config.yml`` when omitted.
+
 Python API:
 
 .. code-block:: python

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -52,6 +52,14 @@ Commands
         Append a new histo_job to the YAML config file in-place and
         re-validate the modified config before writing.
 
+    dccd remove --exchange X --pair Y --span N [--config PATH]
+        Remove a pair from a histo_job (or the whole job if it was the last
+        pair) and re-validate before writing.
+
+    dccd inventory [--config PATH]
+        Scan data_path and print a table of all stored data (OHLC, trades,
+        orderbook) with date range, row count, and gap count per series.
+
 """
 
 from __future__ import annotations
@@ -338,3 +346,150 @@ def add(
     config_path.write_text(yaml.dump(raw, default_flow_style=False))
     typer.echo(f'Added histo job: exchange={exchange} pair={pair} span={span}s')
     typer.echo(f'Config written to {config_path}.')
+
+
+@app.command()
+def remove(
+    exchange: str = typer.Option(..., '--exchange', '-e', help='Exchange name.'),
+    pair: str = typer.Option(..., '--pair', '-p', help='Trading pair (e.g. BTC/USDT).'),
+    span: int = typer.Option(..., '--span', '-s', help='Candle interval in seconds.'),
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
+    ),
+) -> None:
+    """ Remove a pair from a histo_job in the YAML config file in-place.
+
+    Finds the ``histo_job`` matching ``(exchange, span)`` that contains
+    *pair*, removes *pair* from its ``pairs`` list, and removes the whole
+    job if the list becomes empty.  Re-validates the config with Pydantic
+    before writing; exits with code 1 and leaves the file unchanged if
+    validation fails (e.g. removing the last job).
+
+    """
+    import yaml
+    from pydantic import ValidationError
+
+    from dccd.daemon.config import CollectorConfig, resolve_config_path
+
+    try:
+        config_path = resolve_config_path(config)
+    except FileNotFoundError as exc:
+        typer.echo(f'Error: {exc}', err=True)
+        raise typer.Exit(1)
+
+    if not config_path.exists():
+        typer.echo(f'Error: config file not found: {config_path}', err=True)
+        raise typer.Exit(1)
+
+    raw: dict = yaml.safe_load(config_path.read_text())
+    jobs: list = raw.get('histo_jobs', [])
+
+    target = next(
+        (j for j in jobs if j.get('exchange') == exchange
+         and j.get('span') == span and pair in j.get('pairs', [])),
+        None,
+    )
+    if target is None:
+        typer.echo(
+            f'No matching job found: exchange={exchange} pair={pair} span={span}s',
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    target['pairs'].remove(pair)
+    if not target['pairs']:
+        jobs.remove(target)
+
+    try:
+        CollectorConfig.model_validate(raw)
+    except ValidationError as exc:
+        typer.echo(f'Validation error after remove: {exc}', err=True)
+        raise typer.Exit(1)
+
+    config_path.write_text(yaml.dump(raw, default_flow_style=False))
+    typer.echo(f'Removed {pair} from {exchange}/{span}s.')
+    typer.echo(f'Config written to {config_path}.')
+
+
+@app.command()
+def inventory(
+    config: Optional[str] = typer.Option(
+        None, '--config', '-c',
+        help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
+    ),
+) -> None:
+    """ Print a table of all data stored under data_path.
+
+    Scans ``{data_path}/{exchange}/{ohlc|trades|orderbook}/…`` for Parquet
+    files and reports, for each series: exchange, pair, data type, span
+    (OHLC only), date range, row count, and gap count (missing years for
+    OHLC, missing days for trades/orderbook).
+
+    Requires ``polars`` (included in the ``daemon`` and ``io`` extras).
+
+    """
+    import collections
+    from datetime import date
+    from pathlib import Path as _Path
+
+    import polars as pl
+
+    from dccd.tools.date_time import TS_to_date
+
+    cfg = _load(config)
+    data_path = _Path(cfg.storage.local_path)  # type: ignore[attr-defined]
+
+    _DATA_TYPES = ('ohlc', 'trades', 'orderbook')
+    groups: dict[tuple[str, str, str, str], list[_Path]] = collections.defaultdict(list)
+
+    for dt in _DATA_TYPES:
+        for f in data_path.glob(f'*/{dt}/**/*.parquet'):
+            parts = f.relative_to(data_path).parts
+            # ohlc:  (exchange, 'ohlc', pair_slug, span_label, 'YYYY.parquet')     len=5
+            # other: (exchange, 'trades'|'orderbook', pair_slug, 'YYYY-MM-DD.parquet') len=4
+            exchange_name = parts[0]
+            pair_slug = parts[2]
+            span_lbl = parts[3] if dt == 'ohlc' and len(parts) == 5 else '-'
+            groups[(exchange_name, dt, pair_slug, span_lbl)].append(f)
+
+    if not groups:
+        typer.echo(f'No data found under {data_path}.')
+        return
+
+    rows = []
+    for (exchange_name, dt, pair_slug, span_lbl), files in sorted(groups.items()):
+        files = sorted(files)
+        ts_col = pl.concat([
+            pl.read_parquet(f, columns=['TS']) for f in files
+        ])['TS']
+        total_rows = len(ts_col)
+        ts_min = ts_col.min()
+        ts_max = ts_col.max()
+        from_date = TS_to_date(int(ts_min), form='%Y-%m-%d') if ts_min is not None else '-'
+        to_date = TS_to_date(int(ts_max), form='%Y-%m-%d') if ts_max is not None else '-'
+
+        if dt == 'ohlc':
+            existing_years = {int(f.stem) for f in files}
+            gaps = len(set(range(min(existing_years), max(existing_years) + 1)) - existing_years)
+        else:
+            existing_days = {f.stem for f in files}
+            d0 = date.fromisoformat(min(existing_days))
+            d1 = date.fromisoformat(max(existing_days))
+            gaps = (d1 - d0).days + 1 - len(existing_days)
+
+        pair = pair_slug.replace('-', '/', 1)
+        rows.append((exchange_name, pair, dt, span_lbl, from_date, to_date, total_rows, gaps))
+
+    ew, pw, tw, sw, fw, tow, rw, gw = 10, 12, 11, 6, 12, 12, 8, 6
+    header = (
+        f"{'exchange':<{ew}} {'pair':<{pw}} {'type':<{tw}} {'span':<{sw}} "
+        f"{'from':<{fw}} {'to':<{tow}} {'rows':>{rw}} {'gaps':>{gw}}"
+    )
+    typer.echo(header)
+    typer.echo('-' * len(header))
+    for exchange_name, pair, dt, span_lbl, from_date, to_date, total_rows, gaps in rows:
+        typer.echo(
+            f"{exchange_name:<{ew}} {pair:<{pw}} {dt:<{tw}} {span_lbl:<{sw}} "
+            f"{from_date:<{fw}} {to_date:<{tow}} {total_rows:>{rw},} {gaps:>{gw}}"
+        )

--- a/dccd/tests/test_daemon_cli.py
+++ b/dccd/tests/test_daemon_cli.py
@@ -108,6 +108,144 @@ def test_add_histo_job(config_file: Path) -> None:
     assert 'ETH/USD' in pairs_all
 
 
+# ---------------------------------------------------------------------------
+# dccd remove
+# ---------------------------------------------------------------------------
+
+def test_remove_pair(config_file: Path) -> None:
+    # Add a second pair first so removing BTC/USDT leaves the job alive
+    result = runner.invoke(app, [
+        'add', '--exchange', 'binance', '--pair', 'ETH/USDT', '--span', '3600',
+        '--config', str(config_file),
+    ])
+    assert result.exit_code == 0
+
+    result = runner.invoke(app, [
+        'remove', '--exchange', 'binance', '--pair', 'BTC/USDT', '--span', '3600',
+        '--config', str(config_file),
+    ])
+    assert result.exit_code == 0
+    loaded = yaml.safe_load(config_file.read_text())
+    pairs_all = [p for job in loaded['histo_jobs'] for p in job['pairs']]
+    assert 'BTC/USDT' not in pairs_all
+    assert 'ETH/USDT' in pairs_all
+
+
+def test_remove_last_pair_removes_job(tmp_path: Path) -> None:
+    # Config with two jobs so removing one still leaves a valid config
+    cfg = {
+        'storage': {'local_path': '/tmp'},
+        'histo_jobs': [
+            {'exchange': 'binance', 'pairs': ['BTC/USDT'], 'span': 3600},
+            {'exchange': 'kraken', 'pairs': ['ETH/USD'], 'span': 3600},
+        ],
+    }
+    p = tmp_path / 'config.yml'
+    p.write_text(yaml.dump(cfg))
+
+    result = runner.invoke(app, [
+        'remove', '--exchange', 'binance', '--pair', 'BTC/USDT', '--span', '3600',
+        '--config', str(p),
+    ])
+    assert result.exit_code == 0
+    loaded = yaml.safe_load(p.read_text())
+    assert all(j['exchange'] != 'binance' for j in loaded['histo_jobs'])
+
+
+def test_remove_not_found(config_file: Path) -> None:
+    result = runner.invoke(app, [
+        'remove', '--exchange', 'binance', '--pair', 'XRP/USDT', '--span', '3600',
+        '--config', str(config_file),
+    ])
+    assert result.exit_code == 1
+    assert 'No matching job' in result.output
+
+
+def test_remove_last_job_fails(config_file: Path) -> None:
+    original = config_file.read_text()
+    result = runner.invoke(app, [
+        'remove', '--exchange', 'binance', '--pair', 'BTC/USDT', '--span', '3600',
+        '--config', str(config_file),
+    ])
+    assert result.exit_code == 1
+    assert config_file.read_text() == original  # file unchanged
+
+
+# ---------------------------------------------------------------------------
+# dccd inventory
+# ---------------------------------------------------------------------------
+
+def _write_ohlc_parquet(data_path: Path, exchange: str, pair: str, span: str, year: int,
+                         timestamps: list) -> None:
+    import pandas as pd
+    p = data_path / exchange / 'ohlc' / pair.replace('/', '-') / span / f'{year}.parquet'
+    p.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame({'TS': timestamps}).to_parquet(p)
+
+
+def _write_trades_parquet(data_path: Path, exchange: str, pair: str, day: str,
+                           timestamps: list) -> None:
+    import pandas as pd
+    p = data_path / exchange / 'trades' / pair.replace('/', '-') / f'{day}.parquet'
+    p.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame({'TS': timestamps}).to_parquet(p)
+
+
+@pytest.fixture()
+def inventory_config(tmp_path: Path) -> tuple[Path, Path]:
+    data_path = tmp_path / 'data'
+    cfg = {
+        'storage': {'local_path': str(data_path)},
+        'histo_jobs': [{'exchange': 'binance', 'pairs': ['BTC/USDT'], 'span': 3600}],
+    }
+    cfg_file = tmp_path / 'config.yml'
+    cfg_file.write_text(yaml.dump(cfg))
+    return cfg_file, data_path
+
+
+def test_inventory_shows_ohlc(inventory_config: tuple) -> None:
+    cfg_file, data_path = inventory_config
+    _write_ohlc_parquet(data_path, 'binance', 'BTC/USDT', '1h', 2024,
+                         [1704067200, 1704070800])
+    result = runner.invoke(app, ['inventory', '--config', str(cfg_file)])
+    assert result.exit_code == 0
+    assert 'binance' in result.output
+    assert 'BTC/USDT' in result.output
+    assert 'ohlc' in result.output
+    assert '1h' in result.output
+
+
+def test_inventory_shows_trades(inventory_config: tuple) -> None:
+    cfg_file, data_path = inventory_config
+    _write_trades_parquet(data_path, 'binance', 'BTC/USDT', '2024-01-01',
+                           [1704067200, 1704067260])
+    result = runner.invoke(app, ['inventory', '--config', str(cfg_file)])
+    assert result.exit_code == 0
+    assert 'trades' in result.output
+
+
+def test_inventory_no_data(inventory_config: tuple) -> None:
+    cfg_file, data_path = inventory_config
+    data_path.mkdir(parents=True, exist_ok=True)
+    result = runner.invoke(app, ['inventory', '--config', str(cfg_file)])
+    assert result.exit_code == 0
+    assert 'No data found' in result.output
+
+
+def test_inventory_counts_gaps(inventory_config: tuple) -> None:
+    cfg_file, data_path = inventory_config
+    # Two annual files with a missing year in between → 1 gap
+    _write_ohlc_parquet(data_path, 'binance', 'BTC/USDT', '1h', 2022, [1641024000])
+    _write_ohlc_parquet(data_path, 'binance', 'BTC/USDT', '1h', 2024, [1704067200])
+    result = runner.invoke(app, ['inventory', '--config', str(cfg_file)])
+    assert result.exit_code == 0
+    assert '1' in result.output  # gaps column should show 1
+
+
+# ---------------------------------------------------------------------------
+# XDG fallback tests
+# ---------------------------------------------------------------------------
+
 def test_validate_no_config_uses_xdg(config_file: Path) -> None:
     with patch('dccd.daemon.config.resolve_config_path', return_value=config_file):
         result = runner.invoke(app, ['validate'])

--- a/doc/source/daemon.rst
+++ b/doc/source/daemon.rst
@@ -99,6 +99,22 @@ Quick start (CLI)
        # Add a new histo job to an existing config in-place
        dccd add --exchange kraken --pair ETH/USD --span 86400 --config config.yml
 
+       # Remove a pair (or whole job) from the config
+       dccd remove --exchange kraken --pair ETH/USD --span 86400 --config config.yml
+
+       # Inspect all data stored on disk (OHLC, trades, orderbook)
+       dccd inventory --config config.yml
+       # exchange   pair         type        span   from         to           rows  gaps
+       # -------------------------------------------------------------------------------
+       # binance    BTC/USDT     ohlc        1h     2020-01-01   2026-05-24  1 234     0
+       # binance    BTC/USDT     trades      -      2021-01-01   2026-05-24     50     0
+
+.. note::
+
+   The ``--config`` option is optional for all commands.  When omitted, dccd
+   searches for ``./config.yml`` in the current directory first, then falls back
+   to ``$XDG_CONFIG_HOME/dccd/config.yml`` (default ``~/.config/dccd/config.yml``).
+
 Python API
 ----------
 
@@ -137,6 +153,8 @@ Configuration
    :toctree: generated/
 
    config.load_config -- load and validate a YAML configuration file
+   config.resolve_config_path -- resolve config path with XDG fallback
+   config.DEFAULT_CONFIG_PATH -- XDG default config path constant
    config.CollectorConfig -- root configuration model
    config.SettingsConfig -- global local settings (data path, timezone)
    config.StorageConfig -- remote sync settings and destinations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
 
 [project.optional-dependencies]
 io = ["pyarrow>=13", "polars>=0.20"]
-daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12", "tqdm>=4.64"]
-dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12", "tqdm>=4.64"]
+daemon = ["pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12", "tqdm>=4.64", "polars>=0.20", "pyarrow>=13"]
+dev = ["pytest>=7.4", "pytest-asyncio>=0.23", "pytest-cov>=4.1", "ruff>=0.4", "interrogate>=1.5", "mypy>=1.0", "pandas-stubs>=2.0", "pyyaml>=6.0", "apscheduler>=3.10,<4", "typer>=0.12", "tqdm>=4.64", "polars>=0.20", "pyarrow>=13"]
 doc = ["sphinx>=7.0", "furo", "numpydoc", "sphinx-design", "sphinx-copybutton", "pyyaml>=6.0", "apscheduler>=3.10,<4"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- `dccd inventory`: scans `data_path` and prints a table of all stored OHLC, trades, and orderbook series with exchange, pair, type, span, date range, row count, and gap count. Uses Polars for fast columnar parquet reads.
- `dccd remove --exchange X --pair Y --span N`: removes a pair from a histo_job (or the whole job if it was the last pair), re-validates the config before writing.
- `polars` and `pyarrow` added to the `daemon` and `dev` extras in `pyproject.toml`.

## Changes

- `dccd/daemon/cli.py` — `inventory()` and `remove()` commands
- `dccd/tests/test_daemon_cli.py` — 8 new tests (4 per command)
- `pyproject.toml` — `polars>=0.20` + `pyarrow>=13` added to `daemon` and `dev` extras

## Changelog

Added under [Unreleased]:
- `dccd inventory`: scans `data_path`, prints OHLC/trades/orderbook table with date range, rows, gaps (Polars reads)
- `dccd remove --exchange X --pair Y --span N`: removes a pair/job from the YAML config with re-validation

## Test plan

- [x] `pytest` passes (331 tests)
- [x] `ruff check dccd/` passes
- [ ] CI green