### PR TITLE
feat: status --json, CLI edge-case tests, configurable retry/back-off per job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dccd/daemon/cli.py` — `dccd status --json`: emit raw metrics as a JSON object on stdout, suitable for piping into Grafana / jq (#XX)
-- `dccd/daemon/config.py` — `HistoJob.max_retries` (int, 1–10, default 3) and `HistoJob.retry_delay` (float ≥ 0, default 2.0): per-job retry configuration for transient network errors; delay is exponential (`retry_delay * 2^(attempt-1)`) (#XX)
+- `dccd/daemon/cli.py` — `dccd status --json`: emit raw metrics as a JSON object on stdout, suitable for piping into Grafana / jq (#53)
+- `dccd/daemon/config.py` — `HistoJob.max_retries` (int, 1–10, default 3) and `HistoJob.retry_delay` (float ≥ 0, default 2.0): per-job retry configuration for transient network errors; delay is exponential (`retry_delay * 2^(attempt-1)`) (#53)
 - `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#49)
 - `dccd/daemon/cli.py` — `dccd inventory`: scans `data_path` and prints a table of all stored OHLC, trades, and orderbook data with date range, row count, and gap count per series; uses Polars for fast columnar reads (#50)
 - `dccd/daemon/cli.py` — `dccd remove --exchange X --pair Y --span N`: removes a pair from a histo_job (or the whole job if it was the last pair) and re-validates the config before writing (#50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd/daemon/cli.py` — `dccd status --json`: emit raw metrics as a JSON object on stdout, suitable for piping into Grafana / jq (#XX)
+- `dccd/daemon/config.py` — `HistoJob.max_retries` (int, 1–10, default 3) and `HistoJob.retry_delay` (float ≥ 0, default 2.0): per-job retry configuration for transient network errors; delay is exponential (`retry_delay * 2^(attempt-1)`) (#XX)
 - `dccd/daemon/config.py` — `resolve_config_path()` and `DEFAULT_CONFIG_PATH`: CLI commands now fall back to `$XDG_CONFIG_HOME/dccd/config.yml` (default `~/.config/dccd/config.yml`) when no `--config` option is provided and `./config.yml` does not exist (#49)
 - `dccd/daemon/cli.py` — `dccd inventory`: scans `data_path` and prints a table of all stored OHLC, trades, and orderbook data with date range, row count, and gap count per series; uses Polars for fast columnar reads (#50)
 - `dccd/daemon/cli.py` — `dccd remove --exchange X --pair Y --span N`: removes a pair from a histo_job (or the whole job if it was the last pair) and re-validates the config before writing (#50)

--- a/dccd/daemon/backfill.py
+++ b/dccd/daemon/backfill.py
@@ -93,6 +93,12 @@ class _BackfillBase(ABC):
     form : str
         Output format (accepted for backward compatibility; storage is
         always Parquet via :class:`~dccd.storage.DataStore`).
+    max_retries : int, optional
+        Maximum fetch attempts per window before skipping it.  Default 3.
+    retry_delay : float, optional
+        Base delay in seconds between retries.  Actual delay is
+        ``retry_delay * 2 ** (attempt - 1)`` (exponential back-off).
+        Default 2.0.
 
     """
 
@@ -101,10 +107,14 @@ class _BackfillBase(ABC):
         obj: ImportDataCryptoCurrencies,
         sleep: float,
         form: str,
+        max_retries: int = 3,
+        retry_delay: float = 2.0,
     ) -> None:
         self.obj = obj
         self.sleep = sleep
         self.form = form
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
         cls_name = type(obj).__name__[4:]  # strip leading 'From'
         self.label = f'{cls_name:8s} {obj.crypto}/{obj.fiat}'
 
@@ -207,22 +217,23 @@ class _BackfillBase(ABC):
 
                 last_exc: Exception | None = None
                 n = 0
-                for attempt in range(1, _MAX_RETRIES + 1):
+                for attempt in range(1, self.max_retries + 1):
                     try:
                         n = self._fetch_window(current, end)
                         break
                     except Exception as exc:
                         last_exc = exc
-                        if attempt < _MAX_RETRIES:
+                        if attempt < self.max_retries:
+                            delay = self.retry_delay * (2 ** (attempt - 1))
                             tqdm.write(
-                                f'[{self.label}] attempt {attempt}/{_MAX_RETRIES} '
-                                f'failed: {exc} — retrying in 2s'
+                                f'[{self.label}] attempt {attempt}/{self.max_retries} '
+                                f'failed: {exc} — retrying in {delay:.1f}s'
                             )
-                            time_mod.sleep(2)
+                            time_mod.sleep(delay)
                 else:
                     tqdm.write(
                         f'[{self.label}] window {current} failed after '
-                        f'{_MAX_RETRIES} attempts: {last_exc} — skipping'
+                        f'{self.max_retries} attempts: {last_exc} — skipping'
                     )
                     skipped += 1
                     current += self.window_size
@@ -265,6 +276,10 @@ class OHLCBackfill(_BackfillBase):
         Seconds to wait between requests.
     form : str
         Output format (accepted for backward compatibility).
+    max_retries : int, optional
+        See :class:`_BackfillBase`.  Default 3.
+    retry_delay : float, optional
+        See :class:`_BackfillBase`.  Default 2.0.
 
     """
 
@@ -274,8 +289,10 @@ class OHLCBackfill(_BackfillBase):
         max_candles: int,
         sleep: float,
         form: str,
+        max_retries: int = 3,
+        retry_delay: float = 2.0,
     ) -> None:
-        super().__init__(obj, sleep, form)
+        super().__init__(obj, sleep, form, max_retries=max_retries, retry_delay=retry_delay)
         self.max_candles = max_candles
 
     @property
@@ -496,6 +513,8 @@ def make_job(
     path: str,
     tz: str,
     form: str,
+    max_retries: int = 3,
+    retry_delay: float = 2.0,
 ) -> _BackfillBase:
     """Build the appropriate backfill strategy for an (exchange, pair).
 
@@ -542,13 +561,16 @@ def make_job(
     obj = cls(path, crypto, span, fiat, form=form, tz=tz)
 
     if exchange == _KRAKEN_EXCHANGE:
-        return KrakenBackfill(obj, sleep=sleep, form=form)
+        return KrakenBackfill(obj, sleep=sleep, form=form,
+                              max_retries=max_retries, retry_delay=retry_delay)
 
     return OHLCBackfill(
         obj,
         max_candles=defaults['max_candles'],
         sleep=sleep,
         form=form,
+        max_retries=max_retries,
+        retry_delay=retry_delay,
     )
 
 
@@ -597,6 +619,8 @@ def run_backfill(
             job = make_job(
                 histo_job.exchange, crypto, fiat, histo_job.span,
                 path, tz, histo_job.format,
+                max_retries=histo_job.max_retries,
+                retry_delay=histo_job.retry_delay,
             )
             if job.obj.full_path in seen_paths:
                 tqdm.write(

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -258,6 +258,7 @@ def status(
         None, '--config', '-c',
         help='Path to the YAML config file (default: ./config.yml or ~/.config/dccd/config.yml).',
     ),
+    json_out: bool = typer.Option(False, '--json', help='Output raw metrics as JSON on stdout.'),
 ) -> None:
     """ Print a health table from the saved metrics JSON.
 
@@ -266,15 +267,22 @@ def status(
     ``last_success``, ``rows`` (cumulative), ``errors`` (consecutive).
     Prints ``No metrics yet.`` if the file does not exist.
 
+    Pass ``--json`` to emit the raw metrics dict as JSON on stdout instead,
+    suitable for piping into Grafana, jq, or other tooling.
+
     """
     cfg = _load(config)
     metrics_file = Path(cfg.storage.local_path) / '.dccd' / 'metrics.json'  # type: ignore[attr-defined]
 
     if not metrics_file.exists():
-        typer.echo('No metrics yet.')
+        typer.echo('{}' if json_out else 'No metrics yet.')
         return
 
     data: dict = json.loads(metrics_file.read_text())
+
+    if json_out:
+        typer.echo(json.dumps(data, indent=2))
+        return
 
     def _fmt_ts(ts: float | None) -> str:
         if ts is None:

--- a/dccd/daemon/config.py
+++ b/dccd/daemon/config.py
@@ -140,6 +140,8 @@ class HistoJob(BaseModel):
     pairs: list[str]
     span: int
     format: str = 'parquet'
+    max_retries: int = Field(default=3, ge=1, le=10)
+    retry_delay: float = Field(default=2.0, ge=0.0)
 
     @field_validator('exchange')
     @classmethod

--- a/dccd/tests/test_backfill.py
+++ b/dccd/tests/test_backfill.py
@@ -283,3 +283,51 @@ def test_run_retries_on_fetch_error():
 
     assert calls['n'] == 3   # 2 failures + 1 success
     obj.save.assert_called_once()
+
+
+def test_custom_max_retries():
+    """job.max_retries is honoured — loop stops after N attempts."""
+    obj = _mock_obj(span=60)
+    obj._store.missing_intervals.return_value = [(1_000, 1_060)]
+    job = OHLCBackfill(obj, max_candles=1, sleep=0.0, form='parquet', max_retries=2)
+
+    calls = {'n': 0}
+
+    def _always_fail(current: int, end: int) -> int:
+        calls['n'] += 1
+        raise RuntimeError('always fails')
+
+    job._fetch_window = _always_fail  # type: ignore[method-assign]
+
+    with patch('dccd.daemon.backfill.time_mod'):
+        job.run('2020-01-01 00:00:00')
+
+    assert calls['n'] == 2   # exactly max_retries attempts, then skipped
+    obj.save.assert_not_called()
+
+
+def test_custom_retry_delay():
+    """Exponential backoff uses retry_delay as base."""
+    obj = _mock_obj(span=60)
+    obj._store.missing_intervals.return_value = [(1_000, 1_060)]
+    job = OHLCBackfill(obj, max_candles=1, sleep=0.0, form='parquet',
+                       max_retries=3, retry_delay=5.0)
+
+    attempt = {'n': 0}
+
+    def _fail_twice(current: int, end: int) -> int:
+        attempt['n'] += 1
+        if attempt['n'] < 3:
+            raise RuntimeError('transient')
+        return 1
+
+    job._fetch_window = _fail_twice  # type: ignore[method-assign]
+    job._advance      = lambda current, end: end  # type: ignore[method-assign]
+
+    with patch('dccd.daemon.backfill.time_mod') as mock_time:
+        job.run('2020-01-01 00:00:00')
+
+    sleep_calls = [c.args[0] for c in mock_time.sleep.call_args_list]
+    # First retry: 5.0 * 2^0 = 5.0 ; second retry: 5.0 * 2^1 = 10.0
+    assert 5.0 in sleep_calls
+    assert 10.0 in sleep_calls

--- a/dccd/tests/test_daemon_cli.py
+++ b/dccd/tests/test_daemon_cli.py
@@ -261,3 +261,98 @@ def test_validate_missing_all_configs(tmp_path: Path) -> None:
         result = runner.invoke(app, ['validate'])
     assert result.exit_code == 1
     assert 'No config file found' in result.output
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — config validation
+# ---------------------------------------------------------------------------
+
+def test_validate_unknown_exchange(tmp_path: Path) -> None:
+    cfg = {
+        'storage': {'local_path': str(tmp_path)},
+        'histo_jobs': [{'exchange': 'fakeex', 'pairs': ['BTC/USDT'], 'span': 3600}],
+    }
+    cfg_file = tmp_path / 'config.yml'
+    cfg_file.write_text(yaml.dump(cfg))
+    result = runner.invoke(app, ['validate', '--config', str(cfg_file)])
+    assert result.exit_code != 0
+    assert 'fakeex' in result.output.lower() or result.exit_code != 0
+
+
+def test_validate_bad_pair_format(tmp_path: Path) -> None:
+    cfg = {
+        'storage': {'local_path': str(tmp_path)},
+        'histo_jobs': [{'exchange': 'binance', 'pairs': ['BTCUSDT'], 'span': 3600}],
+    }
+    cfg_file = tmp_path / 'config.yml'
+    cfg_file.write_text(yaml.dump(cfg))
+    result = runner.invoke(app, ['validate', '--config', str(cfg_file)])
+    assert result.exit_code != 0
+
+
+def test_validate_missing_config_file() -> None:
+    result = runner.invoke(app, ['validate', '--config', '/nonexistent/config.yml'])
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — status --json
+# ---------------------------------------------------------------------------
+
+def test_status_json_no_metrics(config_file: Path) -> None:
+    result = runner.invoke(app, ['status', '--json', '--config', str(config_file)])
+    assert result.exit_code == 0
+    data = json.loads(result.output.strip())
+    assert data == {}
+
+
+def test_status_json_output(tmp_path: Path) -> None:
+    dccd_dir = tmp_path / 'data' / '.dccd'
+    dccd_dir.mkdir(parents=True)
+    metrics = {
+        'binance/BTC/USDT': {
+            'last_run_at': 1747440000.0,
+            'last_success_at': 1747440000.0,
+            'rows_collected': 42,
+            'errors_count': 0,
+        }
+    }
+    (dccd_dir / 'metrics.json').write_text(json.dumps(metrics))
+    cfg = {
+        'storage': {'local_path': str(dccd_dir.parent)},
+        'histo_jobs': [{'exchange': 'binance', 'pairs': ['BTC/USDT'], 'span': 3600}],
+    }
+    cfg_file = tmp_path / 'config.yml'
+    cfg_file.write_text(yaml.dump(cfg))
+
+    result = runner.invoke(app, ['status', '--json', '--config', str(cfg_file)])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert 'binance/BTC/USDT' in data
+    assert data['binance/BTC/USDT']['rows_collected'] == 42
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — backfill filters
+# ---------------------------------------------------------------------------
+
+def test_backfill_dry_run_parallel(config_file: Path) -> None:
+    with patch('dccd.daemon.backfill.make_job') as mock_make:
+        mock_job = mock_make.return_value
+        mock_job.obj.full_path = '/tmp/fake'
+        result = runner.invoke(app, [
+            'backfill', '--dry-run', '--parallel', '--config', str(config_file),
+        ])
+    assert result.exit_code == 0
+    # dry-run must never call the real fetch
+    mock_job.run.assert_called_once()
+    call_kwargs = mock_job.run.call_args
+    assert call_kwargs.kwargs.get('dry_run') or call_kwargs.args[1]
+
+
+def test_backfill_exchange_filter_no_match(config_file: Path) -> None:
+    result = runner.invoke(app, [
+        'backfill', '--exchange', 'unknownex', '--config', str(config_file),
+    ])
+    assert result.exit_code == 0
+    assert 'no matching' in result.output.lower()

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -48,6 +48,8 @@ histo_jobs:
       - ETH/USDT
     span: 3600                 # candle interval in seconds (>= 60)
     format: parquet            # one of: parquet, csv, xlsx
+    # max_retries: 3           # attempts per window on transient errors (1–10, default 3)
+    # retry_delay: 2.0         # base delay in seconds; actual delay = retry_delay * 2^(attempt-1)
 
   - exchange: kraken
     pairs:


### PR DESCRIPTION
## Summary
- `dccd status --json`: nouvel flag pour émettre les métriques en JSON brut sur stdout (Grafana, jq, scripts)
- Tests CLI edge cases : exchange inconnu, pair mal formée, config manquante, status --json, backfill --dry-run --parallel, filtre exchange sans correspondance
- Retry/back-off configurable par job : `max_retries` (1–10, défaut 3) et `retry_delay` (float, défaut 2.0 s) dans `HistoJob`; backoff exponentiel (`retry_delay * 2^(attempt-1)`)

## Changes
- `dccd/daemon/cli.py` — `status`: ajout `--json` flag
- `dccd/daemon/config.py` — `HistoJob`: champs `max_retries` et `retry_delay`
- `dccd/daemon/backfill.py` — `_BackfillBase`, `OHLCBackfill`, `make_job`, `run_backfill`: propagation des paramètres retry
- `dccd/tests/test_daemon_cli.py` — 7 nouveaux tests edge cases
- `dccd/tests/test_backfill.py` — 2 nouveaux tests (`test_custom_max_retries`, `test_custom_retry_delay`)
- `examples/config.example.yml` — documentation des deux nouveaux champs

## Changelog
Added under [Unreleased]:
- `dccd status --json` — emit raw metrics as JSON on stdout (#XX)
- `HistoJob.max_retries` / `HistoJob.retry_delay` — per-job exponential retry config (#XX)

## Test plan
- [x] pytest 340 passed locally
- [x] ruff check passes
- [ ] CI green