### PR TITLE
fix: _sort_data no longer crashes on empty API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dccd/histo_dl/coinbase.py` — raise `RuntimeError` when Coinbase returns HTTP 200 with a JSON dict (e.g. `{"message": "..."}` for near-future windows) instead of silently iterating dict keys and crashing with `ValueError` (#XX)
 - `dccd/histo_dl/coinbase.py` — additional guard: raise `RuntimeError` when Coinbase returns a JSON list whose first element is not itself a list/tuple (e.g. `["message"]`); previously caused `float("m")` `ValueError` (#XX)
-- `dccd/histo_dl/exchange.py` — `_sort_data` no longer raises `ColumnNotFoundError: "date"` when the exchange API returns an empty candle list; now returns early with an empty `self.df` so the backfill skips the window cleanly instead of retrying 3× and logging a cryptic error (#XX)
+- `dccd/histo_dl/exchange.py` — `_sort_data` no longer raises `ColumnNotFoundError: "date"` when the exchange API returns an empty candle list; now returns early with an empty `self.df` so the backfill skips the window cleanly instead of retrying 3× and logging a cryptic error (#54)
 - `dccd/histo_dl/exchange.py` — `_sort_data` strips any candle at or beyond `self.end` before merging; exchanges with inclusive endpoint semantics (Coinbase) no longer cause `_advance` to overshoot by one span per window, preventing drift that accumulated into near-future requests (#XX)
 - `dccd/histo_dl/okx.py` — raise `RuntimeError` when OKX response code is not `"0"`, letting the backfill retry/skip logic handle API-level errors (#XX)
 - `dccd/histo_dl/okx.py` — switch `_import_data` from `/market/candles` to `/market/history-candles`; the former only serves the last ~24 h of 1-minute bars and silently returns empty data for older windows (#XX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dccd/histo_dl/coinbase.py` — raise `RuntimeError` when Coinbase returns HTTP 200 with a JSON dict (e.g. `{"message": "..."}` for near-future windows) instead of silently iterating dict keys and crashing with `ValueError` (#XX)
 - `dccd/histo_dl/coinbase.py` — additional guard: raise `RuntimeError` when Coinbase returns a JSON list whose first element is not itself a list/tuple (e.g. `["message"]`); previously caused `float("m")` `ValueError` (#XX)
-- `dccd/histo_dl/exchange.py` — `_sort_data` no longer raises `KeyError: 'TS'` when the API returns empty data; returns early with an empty `self.df` so the backfill skips the window cleanly (#XX)
+- `dccd/histo_dl/exchange.py` — `_sort_data` no longer raises `ColumnNotFoundError: "date"` when the exchange API returns an empty candle list; now returns early with an empty `self.df` so the backfill skips the window cleanly instead of retrying 3× and logging a cryptic error (#XX)
 - `dccd/histo_dl/exchange.py` — `_sort_data` strips any candle at or beyond `self.end` before merging; exchanges with inclusive endpoint semantics (Coinbase) no longer cause `_advance` to overshoot by one span per window, preventing drift that accumulated into near-future requests (#XX)
 - `dccd/histo_dl/okx.py` — raise `RuntimeError` when OKX response code is not `"0"`, letting the backfill retry/skip logic handle API-level errors (#XX)
 - `dccd/histo_dl/okx.py` — switch `_import_data` from `/market/candles` to `/market/history-candles`; the former only serves the last ~24 h of 1-minute bars and silently returns empty data for older windows (#XX)

--- a/dccd/histo_dl/exchange.py
+++ b/dccd/histo_dl/exchange.py
@@ -223,10 +223,10 @@ class ImportDataCryptoCurrencies(ABC):
 
         """
         data = [OHLCBar(**d).model_dump(exclude_none=False) for d in data]
-        df = pl.DataFrame(data).rename({'date': 'TS'}).with_columns(pl.col('TS').cast(pl.Int64))
-        if len(df) == 0 or 'TS' not in df.columns:
-            self.df = df
+        if not data:
+            self.df = pl.DataFrame()
             return self
+        df = pl.DataFrame(data).rename({'date': 'TS'}).with_columns(pl.col('TS').cast(pl.Int64))
         # Discard any candle at or beyond self.end: those belong to the next
         # window.  Without this filter, exchanges that return the endpoint
         # candle (inclusive API boundary) would cause _advance to overshoot

--- a/dccd/tests/test_histo_dl.py
+++ b/dccd/tests/test_histo_dl.py
@@ -65,6 +65,14 @@ def test_save_parquet(tmp_path):
     assert len(df) >= 1
 
 
+def test_sort_data_empty_list_no_crash(tmp_path):
+    from dccd.histo_dl.binance import FromBinance
+
+    obj = FromBinance(str(tmp_path), 'BTC', 3600, fiat='USDT')
+    obj._sort_data([])
+    assert len(obj.df) == 0
+
+
 def test_save_creates_correct_path(tmp_path):
     from dccd.histo_dl.binance import FromBinance
 


### PR DESCRIPTION
## Summary

- `_sort_data` raised `ColumnNotFoundError: "date"` when the exchange returned an empty candle list because `pl.DataFrame([]).rename({'date': 'TS'})` fails on a zero-column DataFrame
- Added an early return for the empty-data case before the rename
- Added regression test `test_sort_data_empty_list_no_crash`

## Root cause

```python
# Before — crashes when data == []
data = [OHLCBar(**d).model_dump(...) for d in data]      # → []
df = pl.DataFrame(data).rename({'date': 'TS'})            # ColumnNotFoundError!
if len(df) == 0:  # never reached
    ...
```

```python
# After — early return
if not data:
    self.df = pl.DataFrame()
    return self
df = pl.DataFrame(data).rename({'date': 'TS'})
```

## Changelog

Fixed under [Unreleased]:
- `dccd/histo_dl/exchange.py` — `_sort_data` no longer raises `ColumnNotFoundError: "date"` when the API returns an empty candle list

## Test plan

- [x] `pytest` passes (341 tests)
- [x] `ruff check dccd/` clean
- [ ] CI green