### PR TITLE
fix: correct OKX max_candles (990→300) and Kraken OHLC alignment

### DIFF
--- a/dccd/daemon/backfill.py
+++ b/dccd/daemon/backfill.py
@@ -58,8 +58,8 @@ __all__ = ['OHLCBackfill', 'KrakenBackfill', 'make_job', 'run_backfill']
 _EXCHANGE_DEFAULTS: dict[str, dict] = {
     'binance':  {'max_candles': 990, 'sleep': 0.12},
     'bybit':    {'max_candles': 990, 'sleep': 0.15},
-    'kraken':   {'sleep': 1.00},
-    'okx':      {'max_candles': 990, 'sleep': 0.20},
+    'kraken':   {'sleep': 1.0},
+    'okx':      {'max_candles': 300, 'sleep': 0.20},
     'coinbase': {'max_candles': 300, 'sleep': 0.25},
 }
 
@@ -471,7 +471,7 @@ class KrakenBackfill(_BackfillBase):
             .sort('ts')
         )
         result = (
-            df.group_by_dynamic('ts', every=f'{span}s', closed='left', start_by='datapoint')
+            df.group_by_dynamic('ts', every=f'{span}s', closed='left', start_by='window')
             .agg(
                 pl.col('price').first().alias('open'),
                 pl.col('price').max().alias('high'),
@@ -484,10 +484,11 @@ class KrakenBackfill(_BackfillBase):
                 (pl.col('ts').dt.epoch(time_unit='s') >= start_ts)
                 & (pl.col('ts').dt.epoch(time_unit='s') < end_ts)
             )
+            .with_columns(pl.col('ts').dt.epoch(time_unit='s').alias('ts_sec'))
         )
 
         return [{
-            'date':            int(row['ts'].timestamp()),
+            'date':            row['ts_sec'],
             'open':            float(row['open']),
             'high':            float(row['high']),
             'low':             float(row['low']),

--- a/dccd/tests/test_backfill.py
+++ b/dccd/tests/test_backfill.py
@@ -37,7 +37,7 @@ def _make_kraken_job(tmp_path) -> KrakenBackfill:
 
 def test_trades_to_ohlc_basic():
     job = _make_kraken_job('/tmp')
-    start = 1700000000
+    start = 1700000040  # must be a multiple of 60 so start_by='window' bins align exactly
     end   = start + 300  # 5 minutes
 
     trades = [
@@ -59,12 +59,12 @@ def test_trades_to_ohlc_basic():
 
 def test_trades_to_ohlc_empty():
     job = _make_kraken_job('/tmp')
-    assert job._trades_to_ohlc([], 1700000000, 1700000300) == []
+    assert job._trades_to_ohlc([], 1700000040, 1700000340) == []
 
 
 def test_trades_to_ohlc_weighted_average():
     job = _make_kraken_job('/tmp')
-    start = 1700000000
+    start = 1700000040  # must be a multiple of 60
     trades = [
         {'timestamp': start + 5,  'price': 100.0, 'amount': 1.0},
         {'timestamp': start + 10, 'price': 200.0, 'amount': 1.0},


### PR DESCRIPTION
## Summary

- **OKX `max_candles` 990→300**: the API returns at most 300 candles per request; the wrong value padded every 990-minute window with 690 forward-filled null rows, making ~69 % of OKX data silent nulls
- **Kraken bin alignment** (`start_by='datapoint'→'window'`): bins were anchored at the first trade's timestamp (e.g. `11:00:01`) instead of the clean minute boundary (`11:00:00`), producing ~206k candles with `TS % 60 != 0` that collided with the `_sort_data` uniform grid and inflated row counts by ~20 %
- **Kraken timezone fix** (`row['ts'].timestamp()` → `dt.epoch(time_unit='s')`): `pl.from_epoch` produces a timezone-naive datetime; calling `.timestamp()` on it interpreted the value as local time (CET = UTC+1), shifting all Kraken candle dates by 3 600 s

## Test plan

- [ ] `pytest dccd/tests/test_backfill.py` passes (16/16)
- [ ] Test timestamps use a minute-aligned `start` (multiple of 60) — the only value that occurs in production backfill runs
- [ ] Re-run `dccd backfill --exchange kraken --start "2024-01-01"` after deleting corrupted files; verify no non-aligned TS and correct date range
- [ ] Re-run `dccd backfill --exchange okx --start "2024-01-01"`; verify null rate drops from 69 % to ~0.3 %