### PR TITLE
fix: OKX before param off-by-one causes NaN every 5h at window boundary

### DIFF
--- a/dccd/histo_dl/okx.py
+++ b/dccd/histo_dl/okx.py
@@ -140,7 +140,7 @@ class FromOKX(ImportDataCryptoCurrencies):
         param = {
             'instId': self.pair,
             'bar': okx_interval(self.span),
-            'before': self.start * 1000,
+            'before': self.start * 1000 - 1,  # -1 ms: OKX `before` is exclusive
             'after': self.end * 1000,
             'limit': 300,
         }

--- a/dccd/tests/test_okx.py
+++ b/dccd/tests/test_okx.py
@@ -36,6 +36,31 @@ def test_import_data(loader, mock_okx):
         assert key in data[0]
 
 
+def test_before_param_is_inclusive(loader, monkeypatch):
+    """before=start*1000-1 so the window-start candle is not excluded by OKX."""
+    import requests
+    from unittest.mock import MagicMock, patch
+
+    captured = {}
+    start = 1_704_067_200  # 2024-01-01 00:00:00 UTC
+
+    def fake_get(url, params=None, **kwargs):
+        captured['params'] = params
+        m = MagicMock()
+        m.status_code = 200
+        m.raise_for_status = lambda: None
+        m.json.return_value = {
+            "data": [
+                [str(start * 1000), "42000", "42100", "41900", "42050", "1.5", "1.5", "63075", "1"],
+            ]
+        }
+        return m
+
+    monkeypatch.setattr("requests.get", fake_get)
+    loader._import_data(start=start)
+    assert captured['params']['before'] == start * 1000 - 1
+
+
 def test_pair_format(loader):
     assert loader.pair == 'BTC-USDT'
 

--- a/dccd/tests/test_okx.py
+++ b/dccd/tests/test_okx.py
@@ -38,8 +38,7 @@ def test_import_data(loader, mock_okx):
 
 def test_before_param_is_inclusive(loader, monkeypatch):
     """before=start*1000-1 so the window-start candle is not excluded by OKX."""
-    import requests
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock
 
     captured = {}
     start = 1_704_067_200  # 2024-01-01 00:00:00 UTC


### PR DESCRIPTION
## Summary

- The OKX `history-candles` API treats `before` as **exclusive** (`ts > before`). Using `self.start * 1000` excluded the candle at the exact window-start timestamp from every response.
- That slot was present in the `_sort_data` ts_grid but had no value to forward-fill from → **1 NaN row every 18 000 s** (= 300 candles × 60 s, i.e. every 5 hours) across all OKX pairs.
- Fix: `self.start * 1000 - 1` shifts the cursor back by 1 ms so the window-start candle is included.

## Test plan

- [x] New test `test_before_param_is_inclusive` asserts the `before` param equals `start * 1000 - 1`
- [x] All 11 OKX tests pass
- [x] Full suite: 342 passed
- [x] Verified on live data: 4 210 NaN rows across `BTC/ETH × USDT/USD` (2024–2026) patched to zero; no periodic NaN pattern after re-backfill