### PR TITLE
fix: responsive header and homepage cards

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -68,22 +68,30 @@
 .sidebar-sticky { top: var(--navbar-height) !important; }
 .toc-sticky     { top: var(--navbar-height) !important; }
 
-/* === Responsive: tablet ================================================== */
-@media (max-width: 768px) {
-    .page-logo-header { padding: 0 1rem; gap: 0.5rem; }
-    /* Hide text-only links (User Guide, Fynance) */
-    .page-logo-header__nav-link--text { display: none; }
-    /* Hide the divider when text links are gone */
-    .page-logo-header__divider { display: none; }
-}
-
-/* === Responsive: mobile ================================================== */
-@media (max-width: 480px) {
-    .page-logo-header { padding: 0 0.75rem; }
-    .page-logo-header__name { display: none; }
-    /* Icon-only links: hide text labels */
-    .page-logo-header__label { display: none; }
-    .page-logo-header__nav-link { padding: 0.375rem 0.5rem; }
+/* === Responsive: compact header on small screens ========================= */
+@media (max-width: 700px) {
+    :root { --navbar-height: 5.5rem; }
+    .page-logo-header {
+        flex-wrap: wrap;
+        align-content: center;
+        height: auto;
+        min-height: var(--navbar-height);
+        padding: 0.35rem 1rem;
+        row-gap: 0.1rem;
+    }
+    /* Brand takes full width → nav wraps to second row */
+    .page-logo-header__brand { flex: 0 0 100%; }
+    .page-logo-header__nav {
+        margin-left: 0;
+        width: 100%;
+        justify-content: flex-start;
+    }
+    .page-logo-header__nav-link {
+        padding: 0.2rem 0.5rem;
+        font-size: 0.8rem;
+    }
+    .page-logo-header img { height: 1.5rem; }
+    .page-logo-header__name { font-size: 1rem; }
 }
 
 /* Divider between nav groups */

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -68,6 +68,24 @@
 .sidebar-sticky { top: var(--navbar-height) !important; }
 .toc-sticky     { top: var(--navbar-height) !important; }
 
+/* === Responsive: tablet ================================================== */
+@media (max-width: 768px) {
+    .page-logo-header { padding: 0 1rem; gap: 0.5rem; }
+    /* Hide text-only links (User Guide, Fynance) */
+    .page-logo-header__nav-link--text { display: none; }
+    /* Hide the divider when text links are gone */
+    .page-logo-header__divider { display: none; }
+}
+
+/* === Responsive: mobile ================================================== */
+@media (max-width: 480px) {
+    .page-logo-header { padding: 0 0.75rem; }
+    .page-logo-header__name { display: none; }
+    /* Icon-only links: hide text labels */
+    .page-logo-header__label { display: none; }
+    .page-logo-header__nav-link { padding: 0.375rem 0.5rem; }
+}
+
 /* Divider between nav groups */
 .page-logo-header__divider {
     display: inline-block;

--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -12,10 +12,10 @@
       <span class="page-logo-header__name">dccd</span>
     </a>
     <nav class="page-logo-header__nav">
-      <a class="page-logo-header__nav-link" href="{{ pathto('quickstart') }}">
+      <a class="page-logo-header__nav-link page-logo-header__nav-link--text" href="{{ pathto('quickstart') }}">
         User Guide
       </a>
-      <a class="page-logo-header__nav-link page-logo-header__nav-link--fynance" href="https://fynance.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer">
+      <a class="page-logo-header__nav-link page-logo-header__nav-link--text" href="https://fynance.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer">
         Fynance
       </a>
       <span class="page-logo-header__divider" aria-hidden="true"></span>
@@ -23,13 +23,13 @@
         <svg class="page-logo-header__icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M12.001 2C6.477 2 2 6.477 2 12s4.477 10 10.001 10C17.523 22 22 17.523 22 12S17.523 2 12.001 2zm.002 2c4.41 0 7.998 3.587 8 7.997 0 2.17-.868 4.14-2.278 5.584L7.42 6.277A7.96 7.96 0 0 1 12.003 4zM4 12.003c0-2.17.868-4.14 2.278-5.584l10.303 10.304A7.96 7.96 0 0 1 12 20c-4.41 0-8-3.588-8-7.997z"/>
         </svg>
-        PyPI
+        <span class="page-logo-header__label">PyPI</span>
       </a>
       <a class="page-logo-header__nav-link" href="{{ theme_source_repository }}" target="_blank" rel="noopener noreferrer" aria-label="Source on GitHub">
         <svg class="page-logo-header__icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
         </svg>
-        GitHub
+        <span class="page-logo-header__label">GitHub</span>
       </a>
     </nav>
   </header>

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,7 +33,7 @@ multiple exchanges via REST and WebSocket APIs.
 
    pip install dccd
 
-.. grid:: 3
+.. grid:: 1 1 2 3
    :gutter: 3
 
    .. grid-item-card:: Python API


### PR DESCRIPTION
## Summary
- Cards homepage: `.. grid:: 3` → `.. grid:: 1 1 2 3` (stack on mobile, 2 cols on tablet, 3 on desktop)
- Header navbar:
  - ≤ 768px: masque les liens texte (User Guide, Fynance) et le séparateur
  - ≤ 480px: masque aussi le nom "dccd" et les labels PyPI/GitHub (icônes seules)

## Test plan
- [ ] Vérifier la page d'accueil à 375px, 768px, 1200px
- [ ] Vérifier que le header ne déborde plus sur mobile