### PR TITLE
feat: polish web UI branding, grouping and quick actions

### DIFF
--- a/dccd/daemon/api.py
+++ b/dccd/daemon/api.py
@@ -26,6 +26,8 @@ import json
 import threading
 import time
 from datetime import date
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -44,6 +46,11 @@ _TEMPLATES_DIR = _UI_DIR / 'templates'
 _STATIC_DIR = _UI_DIR / 'static'
 
 _DATA_TYPES = ('ohlc', 'trades', 'orderbook')
+
+try:
+    _DCCD_VERSION = _pkg_version('dccd')
+except PackageNotFoundError:  # editable install without metadata
+    _DCCD_VERSION = 'dev'
 
 # Keep at most this many finished backfill records on disk so the tracker
 # file does not grow without bound; running jobs are always kept.
@@ -212,6 +219,11 @@ class _BackfillBody(BaseModel):
     exchange: str | None = None
     pairs: list[str] | None = None
     start: str = '2020-01-01 00:00:00'
+
+
+class _CollectBody(BaseModel):
+    exchange: str | None = None
+    pair: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -487,14 +499,32 @@ def _register_api(app: FastAPI) -> None:
     # --- Collect --------------------------------------------------------
 
     @app.post('/api/collect', status_code=202, dependencies=[auth])
-    def start_collect(request: Request) -> dict:
+    def start_collect(request: Request, body: _CollectBody | None = None) -> dict:
         from dccd.daemon.health import HealthMonitor
-        from dccd.daemon.scheduler import run_once
+        from dccd.daemon.scheduler import run_histo_job, run_once
         cfg = _cfg(request)
         health = HealthMonitor(cfg.storage.local_path, cfg.alerts)
+        exchange = body.exchange if body else None
+        pair = body.pair if body else None
 
-        def _job() -> None:
-            run_once(cfg, health=health)
+        if exchange is None and pair is None:
+            def _job() -> None:
+                run_once(cfg, health=health)
+        else:
+            targets = [
+                (job, p)
+                for job in cfg.histo_jobs
+                if exchange is None or job.exchange == exchange
+                for p in job.pairs
+                if pair is None or p == pair
+            ]
+            if not targets:
+                raise HTTPException(status_code=404, detail='No matching histo job')
+
+            def _job() -> None:
+                for job, p in targets:
+                    run_histo_job(job, p, cfg.storage.local_path,
+                                  cfg.settings.timezone, health)
 
         threading.Thread(target=_job, daemon=True, name='ui-collect').start()
         return {'status': 'started'}
@@ -551,7 +581,9 @@ def _register_pages(app: FastAPI) -> None:
 
     def _page(name: str, request: Request) -> HTMLResponse:
         resp = request.app.state.templates.TemplateResponse(
-            request, name, {'request': request},
+            request, name,
+            {'request': request, 'version': _DCCD_VERSION,
+             'active': request.url.path},
         )
         token = request.query_params.get('token')
         if token and token == request.app.state.auth_token:

--- a/dccd/daemon/ui/static/favicon.svg
+++ b/dccd/daemon/ui/static/favicon.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="322 288 380 380">
+<defs>
+  <linearGradient id="gArc" x1="0" y1="0" x2="0.5" y2="1">
+    <stop offset="0%" stop-color="#c3ccd6"/>
+    <stop offset="55%" stop-color="#7f8a97"/>
+    <stop offset="100%" stop-color="#5a636e"/>
+  </linearGradient>
+  <linearGradient id="gGreen" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#2ec45f"/>
+    <stop offset="100%" stop-color="#15923a"/>
+  </linearGradient>
+  <linearGradient id="gRed" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#ff463b"/>
+    <stop offset="100%" stop-color="#cf1410"/>
+  </linearGradient>
+</defs>
+<path fill="url(#gArc)" d="M 506 304 A 168 174 0 0 0 506 652 A 92 174 0 0 1 506 304 Z"/>
+<path fill="url(#gArc)" d="M 518 304 A 168 174 0 0 1 518 652 A 92 174 0 0 0 518 304 Z"/>
+<line stroke="#a4adb8" stroke-width="5" stroke-linecap="round" x1="460" y1="455" x2="460" y2="512"/>
+<line stroke="#a4adb8" stroke-width="5" stroke-linecap="round" x1="494" y1="492" x2="494" y2="535"/>
+<line stroke="#a4adb8" stroke-width="5" stroke-linecap="round" x1="528" y1="462" x2="528" y2="532"/>
+<line stroke="#a4adb8" stroke-width="5" stroke-linecap="round" x1="562" y1="388" x2="562" y2="482"/>
+<rect fill="url(#gRed)"   stroke="#a4adb8" stroke-width="3" x="449" y="470" width="22" height="30" rx="2"/>
+<rect fill="url(#gRed)"   stroke="#a4adb8" stroke-width="3" x="483" y="500" width="22" height="20" rx="2"/>
+<rect fill="url(#gGreen)" stroke="#a4adb8" stroke-width="3" x="517" y="470" width="22" height="50" rx="2"/>
+<rect fill="url(#gGreen)" stroke="#a4adb8" stroke-width="3" x="551" y="400" width="22" height="70" rx="2"/>
+</svg>

--- a/dccd/daemon/ui/static/logo.svg
+++ b/dccd/daemon/ui/static/logo.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="237 200 570 570" width="256" height="256">
+<defs>
+<style>
+.struct{fill:#a4adb8;} .green{fill:url(#gGreen);} .red{fill:url(#gRed);}
+.edge{stroke:url(#gEdge);stroke-width:3;stroke-linecap:round;fill:none;}
+.node{fill:url(#gNode);} .wick{stroke:#a4adb8;stroke-width:6;stroke-linecap:round;}
+.cwick{stroke:#a4adb8;stroke-width:5;stroke-linecap:round;} .body{stroke:#a4adb8;stroke-width:3;}
+</style>
+<radialGradient id="gNode" cx="40%" cy="35%" r="75%">
+  <stop offset="0%" stop-color="#6ea8ff"/><stop offset="100%" stop-color="#2f6df0"/>
+</radialGradient>
+<linearGradient id="gEdge" x1="0" y1="0" x2="1" y2="0">
+  <stop offset="0%" stop-color="#566b82" stop-opacity="0.55"/>
+  <stop offset="50%" stop-color="#566b82" stop-opacity="0.95"/>
+  <stop offset="100%" stop-color="#566b82" stop-opacity="0.55"/>
+</linearGradient>
+<linearGradient id="gGreen" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#2ec45f"/><stop offset="100%" stop-color="#15923a"/>
+</linearGradient>
+<linearGradient id="gRed" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ff463b"/><stop offset="100%" stop-color="#cf1410"/>
+</linearGradient>
+<filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+  <feGaussianBlur stdDeviation="6" result="b"/>
+  <feFlood flood-color="#5b93ff" flood-opacity="0.75"/>
+  <feComposite in2="b" operator="in" result="g"/>
+  <feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge>
+</filter>
+<filter id="softshadow" x="-30%" y="-30%" width="160%" height="160%">
+  <feDropShadow dx="0" dy="3" stdDeviation="4" flood-color="#000000" flood-opacity="0.18"/>
+</filter>
+<linearGradient id="gArc" x1="0" y1="0" x2="0.5" y2="1">
+  <stop offset="0%" stop-color="#c3ccd6"/>
+  <stop offset="55%" stop-color="#7f8a97"/>
+  <stop offset="100%" stop-color="#5a636e"/>
+</linearGradient>
+<filter id="bevel" x="-20%" y="-20%" width="140%" height="140%">
+  <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+  <feSpecularLighting in="blur" surfaceScale="4" specularConstant="0.8" specularExponent="18" lighting-color="#ffffff" result="spec">
+    <fePointLight x="350" y="180" z="260"/>
+  </feSpecularLighting>
+  <feComposite in="spec" in2="SourceAlpha" operator="in" result="spec2"/>
+  <feComposite in="SourceGraphic" in2="spec2" operator="arithmetic" k1="0" k2="1" k3="0.55" k4="0"/>
+</filter>
+</defs>
+
+<g filter="url(#glow)"><line class="edge" x1="302" y1="367" x2="432" y2="392"/><line class="edge" x1="302" y1="367" x2="432" y2="466"/><line class="edge" x1="302" y1="367" x2="432" y2="541"/><line class="edge" x1="302" y1="442" x2="432" y2="392"/><line class="edge" x1="302" y1="442" x2="432" y2="466"/><line class="edge" x1="302" y1="442" x2="432" y2="541"/><line class="edge" x1="302" y1="516" x2="432" y2="392"/><line class="edge" x1="302" y1="516" x2="432" y2="466"/><line class="edge" x1="302" y1="516" x2="432" y2="541"/><line class="edge" x1="302" y1="590" x2="432" y2="392"/><line class="edge" x1="302" y1="590" x2="432" y2="466"/><line class="edge" x1="302" y1="590" x2="432" y2="541"/><line class="edge" x1="432" y1="392" x2="593" y2="392"/><line class="edge" x1="432" y1="392" x2="593" y2="466"/><line class="edge" x1="432" y1="392" x2="593" y2="541"/><line class="edge" x1="432" y1="466" x2="593" y2="392"/><line class="edge" x1="432" y1="466" x2="593" y2="466"/><line class="edge" x1="432" y1="466" x2="593" y2="541"/><line class="edge" x1="432" y1="541" x2="593" y2="392"/><line class="edge" x1="432" y1="541" x2="593" y2="466"/><line class="edge" x1="432" y1="541" x2="593" y2="541"/><line class="edge" x1="593" y1="392" x2="742" y2="442"/><line class="edge" x1="593" y1="392" x2="742" y2="516"/><line class="edge" x1="593" y1="466" x2="742" y2="442"/><line class="edge" x1="593" y1="466" x2="742" y2="516"/><line class="edge" x1="593" y1="541" x2="742" y2="442"/><line class="edge" x1="593" y1="541" x2="742" y2="516"/><circle class="node" cx="302" cy="367" r="11"/><circle class="node" cx="302" cy="442" r="11"/><circle class="node" cx="302" cy="516" r="11"/><circle class="node" cx="302" cy="590" r="11"/><circle class="node" cx="432" cy="392" r="10"/><circle class="node" cx="432" cy="466" r="10"/><circle class="node" cx="432" cy="541" r="10"/><circle class="node" cx="593" cy="392" r="10"/><circle class="node" cx="593" cy="466" r="10"/><circle class="node" cx="593" cy="541" r="10"/><circle class="node" cx="742" cy="442" r="12"/><circle class="node" cx="742" cy="516" r="12"/></g>
+<g filter="url(#softshadow)">
+<g filter="url(#bevel)">
+<path fill="url(#gArc)" d="M 506 304 A 168 174 0 0 0 506 652 A 92 174 0 0 1 506 304 Z"/>
+<path fill="url(#gArc)" d="M 518 304 A 168 174 0 0 1 518 652 A 92 174 0 0 0 518 304 Z"/>
+</g>
+</g>
+<line class="wick" x1="512" y1="250" x2="512" y2="720"/>
+<line class="cwick" x1="460" y1="455" x2="460" y2="512"/><line class="cwick" x1="494" y1="492" x2="494" y2="535"/>
+<line class="cwick" x1="528" y1="462" x2="528" y2="532"/><line class="cwick" x1="562" y1="388" x2="562" y2="482"/>
+<rect class="red body" x="449" y="470" width="22" height="30" rx="2"/><rect class="red body" x="483" y="500" width="22" height="20" rx="2"/>
+<rect class="green body" x="517" y="470" width="22" height="50" rx="2"/><rect class="green body" x="551" y="400" width="22" height="70" rx="2"/>
+</svg>

--- a/dccd/daemon/ui/templates/base.html
+++ b/dccd/daemon/ui/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}dccd{% endblock %} — dccd UI</title>
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <script src="/static/htmx.min.js"></script>
   <style>
     :root { --bg:#0f1419; --fg:#e6e6e6; --muted:#8b98a5; --accent:#4a9eff;
@@ -11,13 +12,23 @@
     * { box-sizing: border-box; }
     body { margin:0; font:14px/1.5 system-ui, sans-serif; background:var(--bg);
            color:var(--fg); }
-    nav { display:flex; gap:.25rem; flex-wrap:wrap; padding:.5rem 1rem;
-          background:var(--card); border-bottom:1px solid var(--border); }
+    header.topbar { display:flex; align-items:center; gap:.6rem; padding:.6rem 1rem;
+            background:var(--card); border-bottom:1px solid var(--border); }
+    header.topbar img { height:30px; width:auto; display:block; }
+    header.topbar .brand { font-size:1.15rem; font-weight:700; letter-spacing:.02em; }
+    header.topbar .ver { color:var(--muted); font-size:.8rem; font-family:ui-monospace,monospace; }
+    nav { display:flex; gap:.25rem; flex-wrap:wrap; padding:.4rem 1rem;
+          background:var(--card); border-bottom:1px solid var(--border);
+          position:sticky; top:0; z-index:5; }
     nav a { color:var(--muted); text-decoration:none; padding:.4rem .8rem;
             border-radius:6px; }
     nav a:hover { background:var(--border); color:var(--fg); }
-    nav a.active { color:var(--accent); }
+    nav a.active { color:var(--accent); background:rgba(74,158,255,.12);
+            font-weight:600; }
     main { padding:1rem; max-width:1100px; margin:0 auto; }
+    footer { color:var(--muted); font-size:.8rem; text-align:center;
+            padding:1.5rem 1rem; }
+    footer a { color:var(--muted); }
     h1 { font-size:1.3rem; margin:0 0 1rem; }
     h2 { font-size:1.05rem; margin:1.5rem 0 .5rem; }
     table { width:100%; border-collapse:collapse; margin:.5rem 0; }
@@ -47,21 +58,34 @@
                 display:none; align-items:center; justify-content:center; }
     .modal-bg.show { display:flex; }
     .modal { background:var(--card); border:1px solid var(--border);
-             border-radius:8px; padding:1.5rem; min-width:320px; }
+             border-radius:8px; padding:1.5rem; min-width:320px; position:relative; }
+    .modal-close { position:absolute; top:.5rem; right:.5rem; background:transparent;
+             color:var(--muted); border:0; font-size:1.4rem; line-height:1;
+             padding:.2rem .5rem; cursor:pointer; }
+    .modal-close:hover { color:var(--fg); }
   </style>
 </head>
 <body>
+  <header class="topbar">
+    <img src="/static/logo.svg" alt="dccd logo">
+    <span class="brand">dccd</span>
+    <span class="ver">v{{ version }}</span>
+  </header>
   <nav>
-    <a href="/">Dashboard</a>
-    <a href="/inventory">Inventory</a>
-    <a href="/jobs">Jobs</a>
-    <a href="/logs">Logs</a>
-    <a href="/config">Config</a>
-    <a href="/storage">Storage</a>
+    {% set links = [('/', 'Dashboard'), ('/inventory', 'Inventory'),
+                    ('/jobs', 'Jobs'), ('/logs', 'Logs'),
+                    ('/config', 'Config'), ('/storage', 'Storage')] %}
+    {% for href, label in links %}
+    <a href="{{ href }}"{% if active == href %} class="active"{% endif %}>{{ label }}</a>
+    {% endfor %}
   </nav>
   <main>
     {% block content %}{% endblock %}
   </main>
+  <footer>
+    dccd v{{ version }} —
+    <a href="https://github.com/ArthurBernard/Download_Crypto_Currencies_Data">GitHub</a>
+  </footer>
   <script>
     // Minimal vanilla helpers shared across pages — no JS framework.
     function fmtTs(ts) {

--- a/dccd/daemon/ui/templates/inventory.html
+++ b/dccd/daemon/ui/templates/inventory.html
@@ -1,22 +1,18 @@
 {% extends "base.html" %}
 {% block title %}Inventory{% endblock %}
 {% block content %}
-<h1>Inventory</h1>
-<p class="muted">Stored data series. Launch a backfill from any OHLC row.</p>
-<div class="card">
-  <table>
-    <thead>
-      <tr><th>Exchange</th><th>Pair</th><th>Type</th><th>Span</th>
-          <th>From</th><th>To</th><th>Rows</th><th>Gaps</th><th></th></tr>
-    </thead>
-    <tbody id="inv-body">
-      <tr><td colspan="9" class="muted">Loading…</td></tr>
-    </tbody>
-  </table>
+<div class="row" style="justify-content:space-between; align-items:flex-end;">
+  <div>
+    <h1>Inventory</h1>
+    <p class="muted">Stored data series, grouped by exchange. Launch a backfill from any OHLC row.</p>
+  </div>
+  <button id="bf-all-btn" onclick="openBackfill(null, null)" style="display:none;">Backfill all</button>
 </div>
+<div id="inv-root"><p class="muted">Loading…</p></div>
 
 <div class="modal-bg" id="bf-modal">
   <div class="modal">
+    <button class="modal-close" onclick="closeModal('bf-modal')" title="Close" aria-label="Close">&times;</button>
     <h2>Backfill</h2>
     <p id="bf-target" class="muted"></p>
     <div class="row">
@@ -25,61 +21,148 @@
       </label>
     </div>
     <div class="row" style="margin-top:1rem;">
-      <button onclick="launchBackfill()">Launch</button>
-      <button class="ghost" onclick="closeModal('bf-modal')">Cancel</button>
+      <button id="bf-launch" onclick="launchBackfill()">Launch</button>
+      <button id="bf-stop" class="danger" onclick="stopBackfill()" style="display:none;">Stop</button>
+      <button class="ghost" onclick="closeBackfill()">Cancel</button>
     </div>
+    <div id="bf-progress" style="margin-top:1rem;"></div>
     <p id="bf-msg" class="muted"></p>
+    <p id="bf-link" style="display:none;">
+      <a href="/jobs">View in Jobs › Backfill →</a>
+    </p>
   </div>
 </div>
 {% endblock %}
 {% block scripts %}
 <script>
-  let bfExchange = null, bfPair = null;
+  let bfExchange = null, bfPair = null, bfJobId = null, bfPoll = null;
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  function rowHtml(s) {
+    const btn = s.type === 'ohlc'
+      ? '<button class="ghost" onclick="openBackfill(' +
+        JSON.stringify(s.exchange) + ',' + JSON.stringify(s.pair) + ')">Backfill</button>'
+      : '';
+    const gapCls = s.gaps > 0 ? 'err' : 'ok';
+    return '<tr><td>' + escapeHtml(s.pair) + '</td><td>' + escapeHtml(s.type) +
+      '</td><td>' + s.span + '</td><td>' + (s.first || '-') + '</td><td>' +
+      (s.last || '-') + '</td><td>' + s.rows.toLocaleString() +
+      '</td><td class="' + gapCls + '">' + s.gaps + '</td><td>' + btn + '</td></tr>';
+  }
 
   async function loadInventory() {
-    const body = document.getElementById('inv-body');
+    const root = document.getElementById('inv-root');
     try {
       const rows = await api('GET', '/api/inventory');
       if (!rows.length) {
-        body.innerHTML = '<tr><td colspan="9" class="muted">No data found.</td></tr>';
+        root.innerHTML = '<div class="card"><p class="muted">No data found.</p></div>';
         return;
       }
-      body.innerHTML = rows.map(function (s) {
-        const btn = s.type === 'ohlc'
-          ? '<button class="ghost" onclick="openBackfill(\'' + s.exchange +
-            '\',\'' + s.pair + '\')">Backfill</button>'
-          : '';
-        const gapCls = s.gaps > 0 ? 'err' : 'ok';
-        return '<tr><td>' + s.exchange + '</td><td>' + s.pair + '</td><td>' +
-          s.type + '</td><td>' + s.span + '</td><td>' + (s.first || '-') +
-          '</td><td>' + (s.last || '-') + '</td><td>' + s.rows.toLocaleString() +
-          '</td><td class="' + gapCls + '">' + s.gaps + '</td><td>' + btn +
-          '</td></tr>';
+      document.getElementById('bf-all-btn').style.display = '';
+      const groups = {};
+      rows.forEach(function (s) { (groups[s.exchange] = groups[s.exchange] || []).push(s); });
+      root.innerHTML = Object.keys(groups).sort().map(function (ex) {
+        const body = groups[ex].map(rowHtml).join('');
+        return '<div class="row" style="justify-content:space-between; align-items:center; margin-top:1.2rem;">' +
+          '<h2 style="margin:0;">' + escapeHtml(ex) + '</h2>' +
+          '<button class="ghost" onclick="openBackfill(' + JSON.stringify(ex) +
+          ', null)">Backfill ' + escapeHtml(ex) + '</button></div>' +
+          '<div class="card"><table><thead><tr><th>Pair</th><th>Type</th>' +
+          '<th>Span</th><th>From</th><th>To</th><th>Rows</th><th>Gaps</th><th></th>' +
+          '</tr></thead><tbody>' + body + '</tbody></table></div>';
       }).join('');
     } catch (e) {
-      body.innerHTML = '<tr><td colspan="9" class="err">' + e.message + '</td></tr>';
+      root.innerHTML = '<div class="card"><p class="err">' + escapeHtml(e.message) + '</p></div>';
     }
   }
 
   function openBackfill(exchange, pair) {
-    bfExchange = exchange; bfPair = pair;
-    document.getElementById('bf-target').textContent = exchange + ' ' + pair;
+    bfExchange = exchange; bfPair = pair; bfJobId = null;
+    let target;
+    if (pair) target = exchange + ' ' + pair;
+    else if (exchange) target = 'All pairs of ' + exchange;
+    else target = 'All exchanges and pairs';
+    document.getElementById('bf-target').textContent = target;
     document.getElementById('bf-msg').textContent = '';
+    document.getElementById('bf-msg').className = 'muted';
+    document.getElementById('bf-progress').innerHTML = '';
+    document.getElementById('bf-link').style.display = 'none';
+    document.getElementById('bf-launch').style.display = '';
+    document.getElementById('bf-launch').disabled = false;
+    document.getElementById('bf-stop').style.display = 'none';
     openModal('bf-modal');
+  }
+
+  function closeBackfill() {
+    if (bfPoll) { clearInterval(bfPoll); bfPoll = null; }
+    closeModal('bf-modal');
+  }
+
+  function renderProgress(job) {
+    const prog = job.progress || {};
+    const keys = Object.keys(prog);
+    if (!keys.length) {
+      return job.status === 'running'
+        ? '<p class="muted">Starting…</p>' : '';
+    }
+    return keys.map(function (p) {
+      const pr = prog[p];
+      const pct = pr.total > 0 ? Math.round(100 * pr.done / pr.total) : 0;
+      return '<div class="muted">' + escapeHtml(p) + ' — ' + pr.done + '/' + pr.total +
+        ' (' + pct + '%)</div><div class="bar"><span style="width:' + pct + '%"></span></div>';
+    }).join('');
+  }
+
+  async function pollBackfill() {
+    if (!bfJobId) return;
+    try {
+      const job = await api('GET', '/api/backfill/' + bfJobId);
+      document.getElementById('bf-progress').innerHTML = renderProgress(job);
+      const msg = document.getElementById('bf-msg');
+      const statusCls = job.status === 'error' ? 'err'
+        : (job.status === 'done' ? 'ok' : 'muted');
+      msg.className = statusCls;
+      msg.textContent = 'Status: ' + job.status + (job.error ? ' — ' + job.error : '');
+      if (job.status !== 'running' && job.status !== 'cancelling') {
+        if (bfPoll) { clearInterval(bfPoll); bfPoll = null; }
+        document.getElementById('bf-stop').style.display = 'none';
+      }
+    } catch (e) {
+      if (bfPoll) { clearInterval(bfPoll); bfPoll = null; }
+    }
   }
 
   async function launchBackfill() {
     const start = document.getElementById('bf-start').value;
     const msg = document.getElementById('bf-msg');
+    const launch = document.getElementById('bf-launch');
     try {
-      const r = await api('POST', '/api/backfill',
-        { exchange: bfExchange, pairs: [bfPair], start: start });
+      const payload = { start: start };
+      if (bfExchange) payload.exchange = bfExchange;
+      if (bfPair) payload.pairs = [bfPair];
+      const r = await api('POST', '/api/backfill', payload);
+      bfJobId = r.id;
+      launch.style.display = 'none';
+      document.getElementById('bf-stop').style.display = '';
+      document.getElementById('bf-link').style.display = '';
       msg.className = 'ok';
-      msg.textContent = 'Started: ' + r.id + ' — see Jobs page.';
+      msg.textContent = 'Started: ' + r.id;
+      pollBackfill();
+      bfPoll = setInterval(pollBackfill, 2000);
     } catch (e) {
       msg.className = 'err';
       msg.textContent = e.message;
     }
+  }
+
+  async function stopBackfill() {
+    if (!bfJobId) return;
+    try { await api('DELETE', '/api/backfill/' + bfJobId); } catch (e) { alert(e.message); }
   }
 
   loadInventory();

--- a/dccd/daemon/ui/templates/jobs.html
+++ b/dccd/daemon/ui/templates/jobs.html
@@ -3,13 +3,11 @@
 {% block content %}
 <h1>Jobs</h1>
 
-<h2>Histo jobs</h2>
-<div class="card">
-  <table>
-    <thead><tr><th>Exchange</th><th>Pairs</th><th>Span</th><th>Format</th><th></th></tr></thead>
-    <tbody id="histo-body"><tr><td colspan="5" class="muted">Loading…</td></tr></tbody>
-  </table>
+<div class="row" style="justify-content:space-between; align-items:center;">
+  <h2 style="margin:0;">Histo jobs</h2>
+  <button id="collect-all" onclick="collectNow()" style="display:none;">Collect all now</button>
 </div>
+<div id="histo-root"><p class="muted">Loading…</p></div>
 
 <h2>Add histo job</h2>
 <div class="card">
@@ -39,16 +37,44 @@
 {% endblock %}
 {% block scripts %}
 <script>
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
   async function loadJobs() {
     const data = await api('GET', '/api/jobs');
-    const hb = document.getElementById('histo-body');
-    hb.innerHTML = data.histo_jobs.length ? data.histo_jobs.map(function (j) {
-      return j.pairs.map(function (p) {
-        return '<tr><td>' + j.exchange + '</td><td>' + p + '</td><td>' + j.span +
-          '</td><td>' + j.format + '</td><td><button class="danger" onclick="rmJob(\'' +
-          j.exchange + '\',\'' + p + '\',' + j.span + ')">Remove</button></td></tr>';
+    const root = document.getElementById('histo-root');
+    if (!data.histo_jobs.length) {
+      root.innerHTML = '<div class="card"><p class="muted">None.</p></div>';
+      document.getElementById('collect-all').style.display = 'none';
+    } else {
+      document.getElementById('collect-all').style.display = '';
+      const groups = {};
+      data.histo_jobs.forEach(function (j) {
+        (groups[j.exchange] = groups[j.exchange] || []).push(j);
+      });
+      root.innerHTML = Object.keys(groups).sort().map(function (ex) {
+        const rows = groups[ex].map(function (j) {
+          return j.pairs.map(function (p) {
+            return '<tr><td>' + escapeHtml(p) + '</td><td>' + j.span + '</td><td>' +
+              escapeHtml(j.format) + '</td><td class="row" style="gap:.4rem;">' +
+              '<button class="ghost" onclick="collectNow(' + JSON.stringify(ex) + ',' +
+              JSON.stringify(p) + ')">Collect</button>' +
+              '<button class="danger" onclick="rmJob(' + JSON.stringify(ex) + ',' +
+              JSON.stringify(p) + ',' + j.span + ')">Remove</button></td></tr>';
+          }).join('');
+        }).join('');
+        return '<div class="row" style="justify-content:space-between; align-items:center; margin-top:1rem;">' +
+          '<h3 style="margin:0;">' + escapeHtml(ex) + '</h3>' +
+          '<button class="ghost" onclick="collectNow(' + JSON.stringify(ex) +
+          ')">Collect ' + escapeHtml(ex) + '</button></div>' +
+          '<div class="card"><table><thead><tr><th>Pair</th><th>Span</th>' +
+          '<th>Format</th><th></th></tr></thead><tbody>' + rows +
+          '</tbody></table></div>';
       }).join('');
-    }).join('') : '<tr><td colspan="5" class="muted">None.</td></tr>';
+    }
 
     const sb = document.getElementById('stream-body');
     sb.innerHTML = data.stream_jobs.length ? data.stream_jobs.map(function (j) {
@@ -82,6 +108,21 @@
 
   async function cancelBf(id) {
     try { await api('DELETE', '/api/backfill/' + id); } catch (e) { alert(e.message); }
+  }
+
+  async function collectNow(exchange, pair) {
+    const body = {};
+    if (exchange) body.exchange = exchange;
+    if (pair) body.pair = pair;
+    const label = pair ? (exchange + ' ' + pair) : (exchange || 'all jobs');
+    try {
+      await api('POST', '/api/collect', body);
+      const m = document.getElementById('j-msg');
+      m.className = 'ok'; m.textContent = 'Collect started for ' + label + '.';
+    } catch (e) {
+      const m = document.getElementById('j-msg');
+      m.className = 'err'; m.textContent = e.message;
+    }
   }
 
   document.body.addEventListener('htmx:afterSwap', function (e) {

--- a/dccd/tests/test_daemon_api.py
+++ b/dccd/tests/test_daemon_api.py
@@ -199,6 +199,55 @@ def test_backfill_unknown_404(client):
 
 
 # ---------------------------------------------------------------------------
+# Collect
+# ---------------------------------------------------------------------------
+
+class _SyncThread:
+    """ Drop-in for threading.Thread that runs the target synchronously. """
+
+    def __init__(self, target=None, daemon=None, name=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+def test_collect_all_runs_run_once(tmp_path, monkeypatch):
+    import dccd.daemon.api as api_mod
+    import dccd.daemon.scheduler as sched
+
+    called = {}
+    monkeypatch.setattr(sched, 'run_once',
+                        lambda cfg, health=None: called.setdefault('once', True))
+    monkeypatch.setattr(api_mod.threading, 'Thread', _SyncThread)
+    client = TestClient(create_app(_write_config(tmp_path)))
+    r = client.post('/api/collect')
+    assert r.status_code == 202
+    assert called.get('once') is True
+
+
+def test_collect_filtered_runs_matching_jobs(tmp_path, monkeypatch):
+    import dccd.daemon.api as api_mod
+    import dccd.daemon.scheduler as sched
+
+    runs = []
+    monkeypatch.setattr(sched, 'run_histo_job',
+                        lambda job, pair, path, tz, health: runs.append((job.exchange, pair)))
+    monkeypatch.setattr(api_mod.threading, 'Thread', _SyncThread)
+    client = TestClient(create_app(_write_config(tmp_path)))
+    r = client.post('/api/collect', json={'exchange': 'binance', 'pair': 'BTC/USDT'})
+    assert r.status_code == 202
+    assert runs == [('binance', 'BTC/USDT')]
+
+
+def test_collect_unknown_returns_404(client):
+    assert client.post('/api/collect', json={'exchange': 'kraken'}).status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # Logs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Lot 1 of the web UI polish (follow-up to #65). Pure templates/CSS plus a
small API addition — no new dependencies.

- **Branding**: header with the dccd logo, package version and favicon;
  active nav link is highlighted; footer with version + GitHub link.
- **Grouping**: Inventory and Jobs (histo) are now grouped by exchange
  instead of one flat table.
- **Backfill actions**: "Backfill all" (page header) and per-exchange
  "Backfill {exchange}" buttons reuse the existing modal with preselection
  (`/api/backfill` already accepts `exchange=None` / per-exchange).
- **Backfill modal UX**: stays open after Launch and polls
  `/api/backfill/{id}` (~2s) for live progress + status, a distinct close
  (×) button, a Stop control while running, and a link to Jobs › Backfill.
- **Collect now**: global / per-exchange / per-job buttons. `POST /api/collect`
  now accepts an optional `{exchange?, pair?}` body and runs the matching
  histo jobs via `run_histo_job` (no body → `run_once`, unchanged).

## Test plan

- [x] `pytest` (365 passed) — incl. new collect-all / collect-filtered / collect-404 tests
- [x] `ruff check dccd/` clean, `mypy` clean on changed files
- [x] Manual: logo/version/active nav render; inventory & jobs grouped by
      exchange (5 groups); static assets served; `/api/collect` filter returns
      404 for unknown exchange; all pages return 200