### PR TITLE
feat: web UI config form, backfill logs and stream control (Lot 2)

### DIFF
--- a/dccd/daemon/api.py
+++ b/dccd/daemon/api.py
@@ -37,7 +37,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
-from dccd.daemon.backfill import run_backfill
+from dccd.daemon.backfill import has_matching_jobs, run_backfill
 from dccd.daemon.config import CollectorConfig, load_config
 
 if TYPE_CHECKING:
@@ -507,6 +507,12 @@ def _register_api(app: FastAPI) -> None:
     @app.post('/api/backfill', status_code=202, dependencies=[auth])
     def start_backfill(request: Request, body: _BackfillBody) -> dict:
         cfg = _cfg(request)
+        if not has_matching_jobs(cfg, body.exchange, body.pairs):
+            raise HTTPException(
+                status_code=400,
+                detail='No configured histo job matches this exchange/pair. '
+                       'Add one on the Config page first.',
+            )
         job_id = request.app.state.tracker.start(
             cfg, body.exchange, body.pairs, body.start,
         )

--- a/dccd/daemon/api.py
+++ b/dccd/daemon/api.py
@@ -573,8 +573,10 @@ def _register_api(app: FastAPI) -> None:
     @app.post('/api/streams/start', status_code=202, dependencies=[auth])
     def start_stream(request: Request, body: _StreamBody) -> dict:
         sm = request.app.state.stream_manager
+        # Read from the on-disk config so stream jobs added after startup
+        # (via the Config page) can be started without restarting the server.
         job = next(
-            (j for j in sm.config.stream_jobs
+            (j for j in _cfg(request).stream_jobs
              if j.exchange == body.exchange and body.pair in j.pairs),
             None,
         )

--- a/dccd/daemon/api.py
+++ b/dccd/daemon/api.py
@@ -29,6 +29,7 @@ from datetime import date
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
@@ -38,6 +39,9 @@ from pydantic import BaseModel
 
 from dccd.daemon.backfill import run_backfill
 from dccd.daemon.config import CollectorConfig, load_config
+
+if TYPE_CHECKING:
+    from dccd.daemon.stream_manager import StreamManager
 
 __all__ = ['BackfillTracker', 'create_app']
 
@@ -56,6 +60,9 @@ except PackageNotFoundError:  # editable install without metadata
 # file does not grow without bound; running jobs are always kept.
 _MAX_FINISHED_JOBS = 50
 _FINISHED_STATES = frozenset({'done', 'cancelled', 'error'})
+
+# Keep at most this many log lines per backfill job (oldest dropped).
+_MAX_LOG_LINES = 100
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +146,7 @@ class BackfillTracker:
             'start': start,
             'status': 'running',
             'progress': {},
+            'log': [],
             'started_at': time.time(),
             'error': None,
         }
@@ -174,10 +182,19 @@ class BackfillTracker:
                     rec['progress'][pair] = {'done': done, 'total': total}
                     self._save()
 
+        def _msg(exch: str, pair: str, line: str) -> None:
+            with self._lock:
+                rec = self._jobs.get(job_id)
+                if rec is not None:
+                    log = rec['log']
+                    log.append(line)
+                    del log[:-_MAX_LOG_LINES]
+                    self._save()
+
         try:
             run_backfill(
                 cfg, exchange=exchange, pairs=pairs, start=start,
-                progress_callback=_cb, stop_event=event,
+                progress_callback=_cb, stop_event=event, message_callback=_msg,
             )
             status = 'cancelled' if event.is_set() else 'done'
             with self._lock:
@@ -224,6 +241,12 @@ class _BackfillBody(BaseModel):
 class _CollectBody(BaseModel):
     exchange: str | None = None
     pair: str | None = None
+
+
+class _StreamBody(BaseModel):
+    exchange: str
+    pair: str
+    channels: list[str]
 
 
 # ---------------------------------------------------------------------------
@@ -308,13 +331,20 @@ def _scan_inventory(data_path: Path) -> list[dict]:
 # App factory
 # ---------------------------------------------------------------------------
 
-def create_app(cfg_path: str | Path) -> FastAPI:
+def create_app(cfg_path: str | Path,
+               stream_manager: StreamManager | None = None) -> FastAPI:
     """ Build the FastAPI application for *cfg_path*.
 
     Parameters
     ----------
     cfg_path : str or pathlib.Path
         Path to the YAML daemon configuration file.
+    stream_manager : StreamManager, optional
+        The live :class:`~dccd.daemon.stream_manager.StreamManager` of an
+        embedding ``dccd start`` process, so the UI reflects and controls the
+        streams actually running.  When ``None`` (standalone ``dccd ui``), a
+        fresh, *non-started* manager is created — its configured stream jobs
+        appear stopped until the user starts them from the UI.
 
     Returns
     -------
@@ -326,6 +356,10 @@ def create_app(cfg_path: str | Path) -> FastAPI:
     cfg_path = Path(cfg_path).expanduser().resolve()
     cfg = load_config(cfg_path)
     local_path = cfg.storage.local_path
+
+    if stream_manager is None:
+        from dccd.daemon.stream_manager import StreamManager
+        stream_manager = StreamManager(cfg)
 
     # When a token is configured, do not expose the unauthenticated OpenAPI
     # schema/docs — they would leak the API surface past the auth boundary.
@@ -339,6 +373,7 @@ def create_app(cfg_path: str | Path) -> FastAPI:
     app.state.auth_token = cfg.settings.ui_auth_token
     app.state.config_lock = threading.Lock()
     app.state.tracker = BackfillTracker(local_path)
+    app.state.stream_manager = stream_manager
     app.state.templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 
     app.mount('/static', StaticFiles(directory=str(_STATIC_DIR)), name='static')
@@ -528,6 +563,32 @@ def _register_api(app: FastAPI) -> None:
 
         threading.Thread(target=_job, daemon=True, name='ui-collect').start()
         return {'status': 'started'}
+
+    # --- Streams --------------------------------------------------------
+
+    @app.get('/api/streams', dependencies=[auth])
+    def list_streams(request: Request) -> list[dict]:
+        return request.app.state.stream_manager.status()
+
+    @app.post('/api/streams/start', status_code=202, dependencies=[auth])
+    def start_stream(request: Request, body: _StreamBody) -> dict:
+        sm = request.app.state.stream_manager
+        job = next(
+            (j for j in sm.config.stream_jobs
+             if j.exchange == body.exchange and body.pair in j.pairs),
+            None,
+        )
+        if job is None:
+            raise HTTPException(status_code=404, detail='No matching stream job')
+        key = sm.start_one(job, body.pair, body.channels)
+        return {'status': 'started', 'key': key}
+
+    @app.post('/api/streams/stop', dependencies=[auth])
+    def stop_stream(request: Request, body: _StreamBody) -> dict:
+        sm = request.app.state.stream_manager
+        key = sm._key(body.exchange, body.pair, body.channels)
+        live = sm.stop_one(key)
+        return {'status': 'stopping' if live else 'not_running', 'key': key}
 
     # --- Logs -----------------------------------------------------------
 

--- a/dccd/daemon/backfill.py
+++ b/dccd/daemon/backfill.py
@@ -52,6 +52,8 @@ if TYPE_CHECKING:
 
 # Progress callback: called as (windows_done, windows_total) after each window.
 ProgressCallback = Callable[[int, int], None]
+# Message callback: called with each human-readable log line of a single job.
+MessageCallback = Callable[[str], None]
 
 __all__ = ['OHLCBackfill', 'KrakenBackfill', 'make_job', 'run_backfill']
 
@@ -119,8 +121,19 @@ class _BackfillBase(ABC):
         self.form = form
         self.max_retries = max_retries
         self.retry_delay = retry_delay
+        self._msg_cb: MessageCallback | None = None
         cls_name = type(obj).__name__[4:]  # strip leading 'From'
         self.label = f'{cls_name:8s} {obj.crypto}/{obj.fiat}'
+
+    def _log(self, msg: str) -> None:
+        """Write *msg* to the tqdm stream and the optional message callback.
+
+        ``tqdm.write`` keeps CLI output intact; the callback (set by
+        :meth:`run`) lets the web UI capture the same lines for display.
+        """
+        tqdm.write(msg)
+        if self._msg_cb is not None:
+            self._msg_cb(msg)
 
     # ------------------------------------------------------------------
     # Abstract interface
@@ -173,6 +186,7 @@ class _BackfillBase(ABC):
         position: int = 0,
         progress_callback: ProgressCallback | None = None,
         stop_event: threading.Event | None = None,
+        message_callback: MessageCallback | None = None,
     ) -> None:
         """Run the full backfill for this (exchange, pair).
 
@@ -193,20 +207,25 @@ class _BackfillBase(ABC):
             When set, the backfill stops cleanly at the next window
             boundary.  Used by the web UI to cancel a running backfill;
             ``None`` (default) means the run cannot be interrupted.
+        message_callback : callable, optional
+            Called with each human-readable log line as it is written.
+            Used by the web UI to surface backfill logs; ``None`` (default)
+            keeps CLI behaviour unchanged.
 
         """
+        self._msg_cb = message_callback
         now_ts     = int(time_mod.time())
         user_start = int(date_to_TS(start_str, tz=self.obj.tz))
 
         if dry_run:
             total = max(1, (now_ts - user_start) // self.window_size + 1)
-            tqdm.write(f'[{self.label}] {self._dry_run_summary(total)}')
+            self._log(f'[{self.label}] {self._dry_run_summary(total)}')
             return
 
         intervals = self.obj._store.missing_intervals(user_start, now_ts)
 
         if not intervals:
-            tqdm.write(f'[{self.label}] already up to date')
+            self._log(f'[{self.label}] already up to date')
             if progress_callback is not None:
                 progress_callback(0, 0)
             return
@@ -233,7 +252,7 @@ class _BackfillBase(ABC):
             current = ivl_start
             while current < ivl_end:
                 if stop_event is not None and stop_event.is_set():
-                    tqdm.write(f'[{self.label}] cancelled at window {current}')
+                    self._log(f'[{self.label}] cancelled at window {current}')
                     bar.close()
                     return
 
@@ -249,13 +268,13 @@ class _BackfillBase(ABC):
                         last_exc = exc
                         if attempt < self.max_retries:
                             delay = self.retry_delay * (2 ** (attempt - 1))
-                            tqdm.write(
+                            self._log(
                                 f'[{self.label}] attempt {attempt}/{self.max_retries} '
                                 f'failed: {exc} — retrying in {delay:.1f}s'
                             )
                             time_mod.sleep(delay)
                 else:
-                    tqdm.write(
+                    self._log(
                         f'[{self.label}] window {current} failed after '
                         f'{self.max_retries} attempts: {last_exc} — skipping'
                     )
@@ -283,7 +302,7 @@ class _BackfillBase(ABC):
                 time_mod.sleep(self.sleep)
 
         bar.close()
-        tqdm.write(
+        self._log(
             f'[{self.label}] done — {n_candles:,} candles'
             + (f', {skipped} windows skipped' if skipped else '')
         )
@@ -344,12 +363,12 @@ class OHLCBackfill(_BackfillBase):
         ts_min = df['TS'].min()
         tolerance = self.obj.span * 5
         if ts_min > current + tolerance:
-            tqdm.write(
+            self._log(
                 f'[{self.label}] WARNING: data starts at {ts_min} but window '
                 f'began at {current} (gap={ts_min - current}s > {tolerance}s)'
             )
         if df['TS'].max() > now_ts + 60:
-            tqdm.write(f'[{self.label}] WARNING: future timestamps detected')
+            self._log(f'[{self.label}] WARNING: future timestamps detected')
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +475,7 @@ class KrakenBackfill(_BackfillBase):
             body = r.json()
             errors = body.get('error', [])
             if errors and any('Too many requests' in e for e in errors):
-                tqdm.write(
+                self._log(
                     f'[{self.label}] rate limited — backing off {backoff:.0f}s'
                 )
                 time_mod.sleep(backoff)
@@ -614,6 +633,7 @@ def run_backfill(
     dry_run: bool = False,
     progress_callback: Callable[[str, str, int, int], None] | None = None,
     stop_event: threading.Event | None = None,
+    message_callback: Callable[[str, str, str], None] | None = None,
 ) -> None:
     """Run historical backfill for all matching jobs in *cfg*.
 
@@ -639,6 +659,10 @@ def run_backfill(
     stop_event : threading.Event, optional
         When set, every job stops cleanly at its next window boundary.
         Used by the web UI to cancel a running backfill.
+    message_callback : callable, optional
+        Called as ``message_callback(exchange, pair, line)`` for each log
+        line of each job.  Used by the web UI to surface backfill logs;
+        ``None`` (default) keeps CLI behaviour unchanged.
 
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -681,12 +705,17 @@ def run_backfill(
             return None
         return lambda done, total: progress_callback(exch, pair, done, total)
 
+    def _msg_for(exch: str, pair: str) -> MessageCallback | None:
+        if message_callback is None:
+            return None
+        return lambda line: message_callback(exch, pair, line)
+
     if parallel:
         with ThreadPoolExecutor(max_workers=len(jobs)) as executor:
             futures = {
                 executor.submit(
                     job.run, start, dry_run, pos,
-                    _cb_for(exch, pair), stop_event,
+                    _cb_for(exch, pair), stop_event, _msg_for(exch, pair),
                 ): job
                 for job, pos, exch, pair in jobs
             }
@@ -702,4 +731,5 @@ def run_backfill(
                 start, dry_run=dry_run, position=0,
                 progress_callback=_cb_for(exch, pair),
                 stop_event=stop_event,
+                message_callback=_msg_for(exch, pair),
             )

--- a/dccd/daemon/backfill.py
+++ b/dccd/daemon/backfill.py
@@ -55,7 +55,10 @@ ProgressCallback = Callable[[int, int], None]
 # Message callback: called with each human-readable log line of a single job.
 MessageCallback = Callable[[str], None]
 
-__all__ = ['OHLCBackfill', 'KrakenBackfill', 'make_job', 'run_backfill']
+__all__ = [
+    'OHLCBackfill', 'KrakenBackfill', 'has_matching_jobs', 'make_job',
+    'run_backfill',
+]
 
 # ---------------------------------------------------------------------------
 # Per-exchange API constraints (not user-configurable — API-level limits)
@@ -622,6 +625,42 @@ def make_job(
         max_retries=max_retries,
         retry_delay=retry_delay,
     )
+
+
+def has_matching_jobs(
+    cfg: CollectorConfig,
+    exchange: str | None = None,
+    pairs: list[str] | None = None,
+) -> bool:
+    """Return ``True`` if any configured histo job matches the filters.
+
+    Mirrors the ``exchange``/``pairs`` filtering of :func:`run_backfill` so
+    callers (e.g. the web UI) can tell, before launching, whether a backfill
+    would actually do anything — a request for an exchange/pair without a
+    configured ``histo_job`` otherwise no-ops silently.
+
+    Parameters
+    ----------
+    cfg : CollectorConfig
+        Loaded daemon configuration.
+    exchange : str or None, optional
+        Filter to a single exchange.  ``None`` matches all.
+    pairs : list of str or None, optional
+        Filter to specific pairs in ``'CRYPTO/FIAT'`` format.  ``None``
+        matches all pairs defined in the config.
+
+    Returns
+    -------
+    bool
+
+    """
+    for histo_job in cfg.histo_jobs:
+        if exchange and histo_job.exchange != exchange:
+            continue
+        wanted_pairs = pairs or histo_job.pairs
+        if any(pair in wanted_pairs for pair in histo_job.pairs):
+            return True
+    return False
 
 
 def run_backfill(

--- a/dccd/daemon/cli.py
+++ b/dccd/daemon/cli.py
@@ -274,7 +274,7 @@ def start(
     scheduler = build_histo_scheduler(cfg, health=health)  # type: ignore[arg-type]
     stream_mgr = StreamManager(cfg, health=health)  # type: ignore[arg-type]
 
-    ui_server = _start_ui_thread(config_path, cfg)
+    ui_server = _start_ui_thread(config_path, cfg, stream_mgr)
 
     stop_event = threading.Event()
 
@@ -296,12 +296,17 @@ def start(
     typer.echo('Daemon stopped.')
 
 
-def _start_ui_thread(config_path: Path, cfg: object) -> Any | None:
+def _start_ui_thread(config_path: Path, cfg: object,
+                     stream_manager: object = None) -> Any | None:
     """ Start the web UI in a background thread, or ``None`` if unavailable.
 
     Returns the ``uvicorn.Server`` instance (so the caller can signal it to
     exit on shutdown), or ``None`` when the ``[ui]`` extra is not installed.
     Signal handlers are disabled because the server runs off the main thread.
+
+    *stream_manager* is the daemon's live
+    :class:`~dccd.daemon.stream_manager.StreamManager`, passed so the UI
+    reflects and controls the streams actually running in this process.
     """
     try:
         import uvicorn
@@ -315,7 +320,8 @@ def _start_ui_thread(config_path: Path, cfg: object) -> Any | None:
     port = cfg.settings.ui_port  # type: ignore[attr-defined]
     _warn_open_bind(host, cfg.settings.ui_auth_token)  # type: ignore[attr-defined]
     server = uvicorn.Server(uvicorn.Config(
-        create_app(config_path), host=host, port=port, log_level='warning',
+        create_app(config_path, stream_manager),  # type: ignore[arg-type]
+        host=host, port=port, log_level='warning',
     ))
     server.install_signal_handlers = False
     threading.Thread(target=server.run, daemon=True, name='dccd-ui').start()

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -291,42 +291,142 @@ class StreamManager:
                  health: HealthMonitor | None = None) -> None:
         self.config = config
         self._health = health
+        self._lock = threading.RLock()
         self._threads:     dict[str, threading.Thread]     = {}
         self._downloaders: dict[str, ContinuousDownloader] = {}
+        self._stops:       dict[str, threading.Event]      = {}
         self._stop_event = threading.Event()
         self._sync = SyncService(config.storage)
+
+    @staticmethod
+    def _key(exchange: str, pair: str, channels: list[str]) -> str:
+        """ Build the thread key for an ``(exchange, pair, channels)`` task. """
+        ch_tag = '_'.join(channels)
+        return f'{exchange}_{pair.replace("/", "_")}_{ch_tag}'
 
     def start(self) -> None:
         """ Start the sync service and all stream threads. """
         self._sync.start()
         for job in self.config.stream_jobs:
             for pair, channels in _iter_tasks(job):
-                ch_tag = '_'.join(channels)
-                key = f'{job.exchange}_{pair.replace("/", "_")}_{ch_tag}'
-                t = threading.Thread(
-                    target=self._run_forever,
-                    args=(job, pair, channels),
-                    name=key,
-                    daemon=True,
-                )
-                self._threads[key] = t
-                t.start()
-                logger.info('stream started: %s %s channels=%s', job.exchange, pair, channels)
+                self._start_thread(job, pair, channels)
+
+    def start_one(self, job: StreamJob, pair: str, channels: list[str]) -> str:
+        """ Start a single stream thread for *(pair, channels)* if not running.
+
+        Parameters
+        ----------
+        job : StreamJob
+            Stream job configuration (only ``exchange``/``time_step`` are used).
+        pair : str
+            Trading pair in ``'CRYPTO/FIAT'`` format.
+        channels : list of str
+            Channels for this thread.
+
+        Returns
+        -------
+        str
+            The thread key (running or freshly started).
+
+        """
+        return self._start_thread(job, pair, channels)
+
+    def _start_thread(self, job: StreamJob, pair: str, channels: list[str]) -> str:
+        key = self._key(job.exchange, pair, channels)
+        with self._lock:
+            existing = self._threads.get(key)
+            if existing is not None and existing.is_alive():
+                return key
+            stop = threading.Event()
+            self._stops[key] = stop
+            t = threading.Thread(
+                target=self._run_forever,
+                args=(job, pair, channels, stop),
+                name=key,
+                daemon=True,
+            )
+            self._threads[key] = t
+            t.start()
+        logger.info('stream started: %s %s channels=%s', job.exchange, pair, channels)
+        return key
 
     def stop(self) -> None:
         """ Signal all streams and the sync service to stop. """
         self._stop_event.set()
         self._sync.stop()
-        for dl in self._downloaders.values():
+        with self._lock:
+            for ev in self._stops.values():
+                ev.set()
+            downloaders = list(self._downloaders.values())
+        for dl in downloaders:
             dl.until = time.time()
             dl.is_connect = False
+
+    def stop_one(self, key: str) -> bool:
+        """ Signal a single stream thread (by key) to stop.
+
+        Parameters
+        ----------
+        key : str
+            Thread key as returned by :meth:`start_one` / :meth:`status`.
+
+        Returns
+        -------
+        bool
+            ``True`` if a matching running thread was found and signalled.
+
+        """
+        with self._lock:
+            ev = self._stops.get(key)
+            dl = self._downloaders.get(key)
+            thread = self._threads.get(key)
+        if ev is None and thread is None:
+            return False
+        if ev is not None:
+            ev.set()
+        if dl is not None:
+            dl.until = time.time()
+            dl.is_connect = False
+        return True
+
+    def running_keys(self) -> list[str]:
+        """ Return the keys of all currently alive stream threads. """
+        with self._lock:
+            return [k for k, t in self._threads.items() if t.is_alive()]
+
+    def status(self) -> list[dict[str, Any]]:
+        """ Return the configured stream tasks with their running state.
+
+        Returns
+        -------
+        list of dict
+            One entry per ``(pair, channels)`` task across all configured
+            ``stream_jobs``, with ``key``, ``exchange``, ``pair``,
+            ``channels``, ``time_step`` and ``running`` fields.
+
+        """
+        running = set(self.running_keys())
+        out: list[dict[str, Any]] = []
+        for job in self.config.stream_jobs:
+            for pair, channels in _iter_tasks(job):
+                key = self._key(job.exchange, pair, channels)
+                out.append({
+                    'key': key,
+                    'exchange': job.exchange,
+                    'pair': pair,
+                    'channels': list(channels),
+                    'time_step': job.time_step,
+                    'running': key in running,
+                })
+        return out
 
     # ------------------------------------------------------------------
     # Thread body
     # ------------------------------------------------------------------
 
-    def _run_forever(self, job: StreamJob, pair: str, channels: list[str]) -> None:
-        while not self._stop_event.is_set():
+    def _run_forever(self, job: StreamJob, pair: str, channels: list[str],
+                     stop: threading.Event) -> None:
+        while not self._stop_event.is_set() and not stop.is_set():
             try:
                 self._run_once(job, pair, channels)
                 if self._health:
@@ -335,8 +435,8 @@ class StreamManager:
                 logger.exception('stream crashed: %s %s', job.exchange, pair)
                 if self._health:
                     self._health.record_failure(job.exchange, pair)
-            if not self._stop_event.is_set():
-                self._stop_event.wait(timeout=_RESTART_DELAY)
+            if not self._stop_event.is_set() and not stop.is_set():
+                stop.wait(timeout=_RESTART_DELAY)
 
     def _run_once(self, job: StreamJob, pair: str, channels: list[str]) -> None:
         cls = _STREAM_CLASSES[job.exchange]

--- a/dccd/daemon/stream_manager.py
+++ b/dccd/daemon/stream_manager.py
@@ -365,6 +365,12 @@ class StreamManager:
     def stop_one(self, key: str) -> bool:
         """ Signal a single stream thread (by key) to stop.
 
+        The thread and stop-event slots are freed immediately so a subsequent
+        :meth:`start_one` for the same key always spawns a fresh thread instead
+        of reusing one that is still winding down.  The downloader entry is left
+        in place; the dying thread removes its own (identity-guarded) in
+        :meth:`_run_once`.
+
         Parameters
         ----------
         key : str
@@ -377,9 +383,9 @@ class StreamManager:
 
         """
         with self._lock:
-            ev = self._stops.get(key)
+            ev = self._stops.pop(key, None)
             dl = self._downloaders.get(key)
-            thread = self._threads.get(key)
+            thread = self._threads.pop(key, None)
         if ev is None and thread is None:
             return False
         if ev is not None:
@@ -458,9 +464,9 @@ class StreamManager:
                 until=0,
             )
 
-        ch_tag = '_'.join(channels)
-        key = f'{job.exchange}_{pair.replace("/", "_")}_{ch_tag}'
-        self._downloaders[key] = downloader
+        key = self._key(job.exchange, pair, channels)
+        with self._lock:
+            self._downloaders[key] = downloader
 
         has_trades = 'trades' in channels
         has_book   = 'book'   in channels
@@ -491,5 +497,9 @@ class StreamManager:
             ))
         finally:
             loop.close()
-            self._downloaders.pop(key, None)
+            with self._lock:
+                # Only remove our own downloader: a stop+restart may have
+                # already registered a fresh one under the same key.
+                if self._downloaders.get(key) is downloader:
+                    del self._downloaders[key]
             logger.info('stream ended: %s %s', job.exchange, pair)

--- a/dccd/daemon/ui/templates/base.html
+++ b/dccd/daemon/ui/templates/base.html
@@ -92,6 +92,11 @@
       if (ts == null) return '-';
       return new Date(ts * 1000).toISOString().slice(0, 16).replace('T', ' ');
     }
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+      });
+    }
     function openModal(id) { document.getElementById(id).classList.add('show'); }
     function closeModal(id) { document.getElementById(id).classList.remove('show'); }
     async function api(method, url, body) {

--- a/dccd/daemon/ui/templates/config.html
+++ b/dccd/daemon/ui/templates/config.html
@@ -92,9 +92,9 @@
       return;
     }
     tb.innerHTML = _remotes.map(function (r, i) {
-      return '<tr><td>' + (r.provider || 'rclone') + '</td><td>' + r.remote +
-        '</td><td><button class="danger" onclick="rmRemote(' + i +
-        ')">Remove</button></td></tr>';
+      return '<tr><td>' + escapeHtml(r.provider || 'rclone') + '</td><td>' +
+        escapeHtml(r.remote) + '</td><td><button class="danger" onclick="rmRemote(' +
+        i + ')">Remove</button></td></tr>';
     }).join('');
   }
 
@@ -143,6 +143,12 @@
     out.settings.ui_auth_token = tok || null;
 
     out.storage = out.storage || {};
+    // local_path is not a form field; when it merely tracks data_path (empty or
+    // equal to the previously loaded value) keep it in sync with the new data_path.
+    const prevDataPath = (_cfg.settings || {}).data_path || '';
+    if (!out.storage.local_path || out.storage.local_path === prevDataPath) {
+      out.storage.local_path = out.settings.data_path;
+    }
     out.storage.sync_interval =
       parseInt(document.getElementById('st-sync_interval').value, 10);
     out.storage.remotes = _remotes.map(function (r) {

--- a/dccd/daemon/ui/templates/config.html
+++ b/dccd/daemon/ui/templates/config.html
@@ -2,38 +2,182 @@
 {% block title %}Config{% endblock %}
 {% block content %}
 <h1>Config</h1>
-<p class="muted">Edit the raw configuration (JSON). Validate before saving.</p>
+<p class="muted">Edit settings, storage and alerts below. Jobs are edited on the
+  <a href="/jobs">Jobs</a> page; advanced fields live under Advanced (raw JSON).</p>
+
+<h2>Settings</h2>
 <div class="card">
-  <textarea id="cfg-text" spellcheck="false">Loading…</textarea>
-  <div class="row" style="margin-top:.5rem;">
-    <button class="ghost" onclick="validateCfg()">Validate</button>
-    <button onclick="saveCfg()">Save</button>
-    <button class="ghost" onclick="loadCfg()">Reload</button>
+  <div class="row">
+    <label>data_path <input id="s-data_path" size="28"></label>
+    <label>timezone
+      <select id="s-timezone">
+        <option value="local">local</option>
+        <option value="UTC">UTC</option>
+        <option value="Europe/Paris">Europe/Paris</option>
+      </select>
+    </label>
   </div>
-  <p id="cfg-msg" class="muted"></p>
+  <div class="row" style="margin-top:.5rem;">
+    <label>ui_host <input id="s-ui_host" size="14"></label>
+    <label>ui_port <input id="s-ui_port" type="number" size="6"></label>
+    <label>ui_auth_token <input id="s-ui_auth_token" size="20" placeholder="(none)"></label>
+  </div>
 </div>
+
+<h2>Storage</h2>
+<div class="card">
+  <div class="row">
+    <label>sync_interval (s) <input id="st-sync_interval" type="number" size="8"></label>
+  </div>
+  <table>
+    <thead><tr><th>Provider</th><th>Remote</th><th></th></tr></thead>
+    <tbody id="remotes-body"></tbody>
+  </table>
+  <div class="row">
+    <input id="r-provider" placeholder="rclone" size="10" value="rclone">
+    <input id="r-remote" placeholder="mynas:crypto/" size="20">
+    <button class="ghost" onclick="addRemote()">Add remote</button>
+  </div>
+</div>
+
+<h2>Alerts</h2>
+<div class="card">
+  <div class="row">
+    <label>webhook_url <input id="a-webhook_url" size="32" placeholder="(none)"></label>
+    <label>max_consecutive_errors
+      <input id="a-max_consecutive_errors" type="number" size="4"></label>
+  </div>
+</div>
+
+<h2>Advanced (raw JSON)</h2>
+<div class="card">
+  <details>
+    <summary class="muted">Edit the full configuration as JSON
+      (histo_jobs, stream_jobs, and every other field).</summary>
+    <p class="muted" style="margin-top:.5rem;">Editing this overrides the form
+      fields above on save.</p>
+    <textarea id="cfg-text" spellcheck="false">Loading…</textarea>
+  </details>
+</div>
+
+<div class="row">
+  <button class="ghost" onclick="validateCfg()">Validate</button>
+  <button onclick="saveCfg()">Save</button>
+  <button class="ghost" onclick="loadCfg()">Reload</button>
+</div>
+<p id="cfg-msg" class="muted"></p>
 {% endblock %}
 {% block scripts %}
 <script>
-  function parseEditor() {
-    return JSON.parse(document.getElementById('cfg-text').value);
-  }
-
-  async function loadCfg() {
-    const cfg = await api('GET', '/api/config');
-    document.getElementById('cfg-text').value = JSON.stringify(cfg, null, 2);
-    setMsg('muted', 'Loaded.');
-  }
+  let _cfg = {};
+  let _remotes = [];
 
   function setMsg(cls, text) {
     const m = document.getElementById('cfg-msg');
     m.className = cls; m.textContent = text;
   }
 
+  function selectTimezone(tz) {
+    const sel = document.getElementById('s-timezone');
+    let found = false;
+    for (const o of sel.options) { if (o.value === tz) { found = true; break; } }
+    if (!found) { sel.add(new Option(tz, tz)); }
+    sel.value = tz;
+  }
+
+  function renderRemotes() {
+    const tb = document.getElementById('remotes-body');
+    if (!_remotes.length) {
+      tb.innerHTML = '<tr><td colspan="3" class="muted">None.</td></tr>';
+      return;
+    }
+    tb.innerHTML = _remotes.map(function (r, i) {
+      return '<tr><td>' + (r.provider || 'rclone') + '</td><td>' + r.remote +
+        '</td><td><button class="danger" onclick="rmRemote(' + i +
+        ')">Remove</button></td></tr>';
+    }).join('');
+  }
+
+  function addRemote() {
+    const remote = document.getElementById('r-remote').value.trim();
+    if (!remote) { setMsg('err', 'Remote must not be empty.'); return; }
+    const provider = document.getElementById('r-provider').value.trim() || 'rclone';
+    _remotes.push({ provider, remote });
+    document.getElementById('r-remote').value = '';
+    renderRemotes();
+  }
+
+  function rmRemote(i) { _remotes.splice(i, 1); renderRemotes(); }
+
+  function fillForm(cfg) {
+    const s = cfg.settings || {};
+    document.getElementById('s-data_path').value = s.data_path || '';
+    selectTimezone(s.timezone || 'local');
+    document.getElementById('s-ui_host').value = s.ui_host || '';
+    document.getElementById('s-ui_port').value = s.ui_port != null ? s.ui_port : '';
+    document.getElementById('s-ui_auth_token').value = s.ui_auth_token || '';
+
+    const st = cfg.storage || {};
+    document.getElementById('st-sync_interval').value =
+      st.sync_interval != null ? st.sync_interval : '';
+    _remotes = (st.remotes || []).map(function (r) {
+      return { provider: r.provider || 'rclone', remote: r.remote };
+    });
+    renderRemotes();
+
+    const a = cfg.alerts || {};
+    document.getElementById('a-webhook_url').value = a.webhook_url || '';
+    document.getElementById('a-max_consecutive_errors').value =
+      a.max_consecutive_errors != null ? a.max_consecutive_errors : '';
+  }
+
+  // Merge form fields back into the last-loaded config object.
+  function collect() {
+    const out = JSON.parse(JSON.stringify(_cfg));
+    out.settings = out.settings || {};
+    out.settings.data_path = document.getElementById('s-data_path').value.trim();
+    out.settings.timezone = document.getElementById('s-timezone').value;
+    out.settings.ui_host = document.getElementById('s-ui_host').value.trim();
+    out.settings.ui_port = parseInt(document.getElementById('s-ui_port').value, 10);
+    const tok = document.getElementById('s-ui_auth_token').value.trim();
+    out.settings.ui_auth_token = tok || null;
+
+    out.storage = out.storage || {};
+    out.storage.sync_interval =
+      parseInt(document.getElementById('st-sync_interval').value, 10);
+    out.storage.remotes = _remotes.map(function (r) {
+      return { provider: r.provider || 'rclone', remote: r.remote };
+    });
+
+    out.alerts = out.alerts || {};
+    out.alerts.webhook_url =
+      document.getElementById('a-webhook_url').value.trim() || null;
+    out.alerts.max_consecutive_errors =
+      parseInt(document.getElementById('a-max_consecutive_errors').value, 10);
+    return out;
+  }
+
+  // The Advanced textarea wins when its <details> is open and holds valid JSON.
+  function buildBody() {
+    const ta = document.getElementById('cfg-text');
+    const details = ta.closest('details');
+    if (details && details.open) {
+      try { return JSON.parse(ta.value); }
+      catch (e) { throw new Error('Invalid JSON in Advanced: ' + e.message); }
+    }
+    return collect();
+  }
+
+  async function loadCfg() {
+    _cfg = await api('GET', '/api/config');
+    fillForm(_cfg);
+    document.getElementById('cfg-text').value = JSON.stringify(_cfg, null, 2);
+    setMsg('muted', 'Loaded.');
+  }
+
   async function validateCfg() {
     let body;
-    try { body = parseEditor(); }
-    catch (e) { setMsg('err', 'Invalid JSON: ' + e.message); return; }
+    try { body = buildBody(); } catch (e) { setMsg('err', e.message); return; }
     const r = await api('POST', '/api/config/validate', body);
     if (r.valid) setMsg('ok', 'Valid.');
     else setMsg('err', r.error);
@@ -41,10 +185,12 @@
 
   async function saveCfg() {
     let body;
-    try { body = parseEditor(); }
-    catch (e) { setMsg('err', 'Invalid JSON: ' + e.message); return; }
+    try { body = buildBody(); } catch (e) { setMsg('err', e.message); return; }
     try {
-      await api('PUT', '/api/config', body);
+      const saved = await api('PUT', '/api/config', body);
+      _cfg = saved;
+      fillForm(_cfg);
+      document.getElementById('cfg-text').value = JSON.stringify(_cfg, null, 2);
       setMsg('ok', 'Saved.');
     } catch (e) { setMsg('err', e.message); }
   }

--- a/dccd/daemon/ui/templates/inventory.html
+++ b/dccd/daemon/ui/templates/inventory.html
@@ -37,12 +37,6 @@
 <script>
   let bfExchange = null, bfPair = null, bfJobId = null, bfPoll = null;
 
-  function escapeHtml(s) {
-    return String(s).replace(/[&<>"']/g, function (c) {
-      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
-    });
-  }
-
   function rowHtml(s) {
     const btn = s.type === 'ohlc'
       ? '<button class="ghost" onclick="openBackfill(' +

--- a/dccd/daemon/ui/templates/jobs.html
+++ b/dccd/daemon/ui/templates/jobs.html
@@ -24,8 +24,9 @@
 <h2>Stream jobs</h2>
 <div class="card">
   <table>
-    <thead><tr><th>Exchange</th><th>Pairs</th><th>Channels</th><th>Step</th></tr></thead>
-    <tbody id="stream-body"><tr><td colspan="4" class="muted">Loading…</td></tr></tbody>
+    <thead><tr><th>Exchange</th><th>Pair</th><th>Channels</th><th>Step</th>
+      <th>Status</th><th></th></tr></thead>
+    <tbody id="stream-body"><tr><td colspan="6" class="muted">Loading…</td></tr></tbody>
   </table>
 </div>
 
@@ -76,12 +77,43 @@
       }).join('');
     }
 
+  }
+
+  async function loadStreams() {
+    let rows;
+    try { rows = await api('GET', '/api/streams'); } catch (e) { return; }
     const sb = document.getElementById('stream-body');
-    sb.innerHTML = data.stream_jobs.length ? data.stream_jobs.map(function (j) {
-      return '<tr><td>' + j.exchange + '</td><td>' + j.pairs.join(', ') +
-        '</td><td>' + j.channels.join(', ') + '</td><td>' + j.time_step +
-        '</td></tr>';
-    }).join('') : '<tr><td colspan="4" class="muted">None.</td></tr>';
+    if (!rows.length) {
+      sb.innerHTML = '<tr><td colspan="6" class="muted">None.</td></tr>';
+      return;
+    }
+    sb.innerHTML = rows.map(function (j) {
+      const chans = JSON.stringify(j.channels);
+      const status = j.running
+        ? '<span class="ok">running</span>' : '<span class="muted">stopped</span>';
+      const btn = j.running
+        ? '<button class="danger" onclick="stopStream(' + JSON.stringify(j.exchange) +
+          ',' + JSON.stringify(j.pair) + ',' + chans + ')">Stop</button>'
+        : '<button onclick="startStream(' + JSON.stringify(j.exchange) +
+          ',' + JSON.stringify(j.pair) + ',' + chans + ')">Start</button>';
+      return '<tr><td>' + escapeHtml(j.exchange) + '</td><td>' + escapeHtml(j.pair) +
+        '</td><td>' + escapeHtml(j.channels.join(', ')) + '</td><td>' + j.time_step +
+        '</td><td>' + status + '</td><td>' + btn + '</td></tr>';
+    }).join('');
+  }
+
+  async function startStream(exchange, pair, channels) {
+    try {
+      await api('POST', '/api/streams/start', { exchange, pair, channels });
+      loadStreams();
+    } catch (e) { alert(e.message); }
+  }
+
+  async function stopStream(exchange, pair, channels) {
+    try {
+      await api('POST', '/api/streams/stop', { exchange, pair, channels });
+      loadStreams();
+    } catch (e) { alert(e.message); }
   }
 
   async function addJob() {
@@ -143,13 +175,19 @@
         ? '<button class="danger" onclick="cancelBf(\'' + id + '\')">Stop</button>' : '';
       const statusCls = j.status === 'error' ? 'err'
         : (j.status === 'done' ? 'ok' : 'muted');
+      const logLines = (j.log || []);
+      const log = logLines.length
+        ? '<pre style="max-height:8rem; margin:.4rem 0 0;">' +
+          logLines.map(escapeHtml).join('\n') + '</pre>' : '';
       return '<div style="margin-bottom:1rem;"><div class="row"><strong>' + id +
         '</strong> <span class="' + statusCls + '">' + j.status + '</span> ' + cancel +
         '</div>' + prog + (j.error ? '<div class="err">' + j.error + '</div>' : '') +
-        '</div>';
+        log + '</div>';
     }).join('');
   });
 
   loadJobs();
+  loadStreams();
+  setInterval(loadStreams, 5000);
 </script>
 {% endblock %}

--- a/dccd/daemon/ui/templates/jobs.html
+++ b/dccd/daemon/ui/templates/jobs.html
@@ -38,12 +38,6 @@
 {% endblock %}
 {% block scripts %}
 <script>
-  function escapeHtml(s) {
-    return String(s).replace(/[&<>"']/g, function (c) {
-      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
-    });
-  }
-
   async function loadJobs() {
     const data = await api('GET', '/api/jobs');
     const root = document.getElementById('histo-root');

--- a/dccd/tests/test_backfill.py
+++ b/dccd/tests/test_backfill.py
@@ -14,6 +14,7 @@ from dccd.daemon.backfill import (
     _EXCHANGE_DEFAULTS,
     KrakenBackfill,
     OHLCBackfill,
+    has_matching_jobs,
     make_job,
     run_backfill,
 )
@@ -153,6 +154,17 @@ def _make_cfg(exchanges=('binance', 'kraken')):
         settings=SettingsConfig(data_path='/tmp/dccd_test', timezone='UTC'),
         histo_jobs=jobs,
     )
+
+
+def test_has_matching_jobs():
+    cfg = _make_cfg(exchanges=('binance', 'kraken'))
+    assert has_matching_jobs(cfg) is True
+    assert has_matching_jobs(cfg, exchange='binance') is True
+    assert has_matching_jobs(cfg, exchange='binance', pairs=['BTC/USDT']) is True
+    # configured exchange but unconfigured pair
+    assert has_matching_jobs(cfg, exchange='binance', pairs=['ETH/USDT']) is False
+    # exchange with no histo job at all
+    assert has_matching_jobs(cfg, exchange='coinbase') is False
 
 
 def test_run_backfill_exchange_filter(tmp_path):

--- a/dccd/tests/test_backfill.py
+++ b/dccd/tests/test_backfill.py
@@ -160,7 +160,7 @@ def test_run_backfill_exchange_filter(tmp_path):
     called = []
 
     def fake_run(start, dry_run=False, position=0,
-                 progress_callback=None, stop_event=None):
+                 progress_callback=None, stop_event=None, message_callback=None):
         called.append(self_label)
 
     with patch('dccd.daemon.backfill.make_job') as mock_make:
@@ -212,7 +212,7 @@ def test_cli_backfill_dry_run(tmp_path):
     assert result.exit_code == 0
     mock_job.run.assert_called_once_with(
         '2020-01-01 00:00:00', dry_run=True, position=0,
-        progress_callback=None, stop_event=None,
+        progress_callback=None, stop_event=None, message_callback=None,
     )
 
 
@@ -262,6 +262,30 @@ def test_run_iterates_intervals():
 
     assert fetched == [(1_000, 1_120), (1_120, 1_240), (2_000, 2_120)]
     assert obj.save.call_count == 3
+
+
+def test_run_forwards_log_lines_to_message_callback():
+    obj = _mock_obj(span=60)
+    obj._store.missing_intervals.return_value = [(1_000, 1_120)]
+    job = OHLCBackfill(obj, max_candles=2, sleep=0.0, form='parquet')
+    job._fetch_window = lambda current, end: 1  # type: ignore[method-assign]
+    job._advance      = lambda current, end: end  # type: ignore[method-assign]
+
+    lines: list[str] = []
+    with patch('dccd.daemon.backfill.time_mod'):
+        job.run('2020-01-01 00:00:00', message_callback=lines.append)
+
+    assert any('done' in line for line in lines)
+
+
+def test_run_up_to_date_message_callback():
+    obj = _mock_obj()
+    obj._store.missing_intervals.return_value = []
+    job = OHLCBackfill(obj, max_candles=990, sleep=0.0, form='parquet')
+    lines: list[str] = []
+    with patch('dccd.daemon.backfill.time_mod'):
+        job.run('2020-01-01 00:00:00', message_callback=lines.append)
+    assert any('already up to date' in line for line in lines)
 
 
 def test_run_retries_on_fetch_error():

--- a/dccd/tests/test_daemon_api.py
+++ b/dccd/tests/test_daemon_api.py
@@ -198,6 +198,13 @@ def test_backfill_unknown_404(client):
     assert client.delete('/api/backfill/nope').status_code == 404
 
 
+def test_backfill_no_matching_job_400(client):
+    # kraken has no configured histo job → reject instead of a silent no-op.
+    r = client.post('/api/backfill', json={'exchange': 'kraken'})
+    assert r.status_code == 400
+    assert 'histo job' in r.json()['detail']
+
+
 # ---------------------------------------------------------------------------
 # Collect
 # ---------------------------------------------------------------------------

--- a/dccd/tests/test_daemon_api.py
+++ b/dccd/tests/test_daemon_api.py
@@ -248,6 +248,67 @@ def test_collect_unknown_returns_404(client):
 
 
 # ---------------------------------------------------------------------------
+# Streams
+# ---------------------------------------------------------------------------
+
+_STREAM_EXTRA = {
+    'stream_jobs': [{
+        'exchange': 'binance', 'pairs': ['BTC/USDT'],
+        'channels': ['trades'], 'time_step': 60,
+    }],
+}
+
+
+def test_streams_list_reflects_config(tmp_path):
+    client = TestClient(create_app(_write_config(tmp_path, extra=_STREAM_EXTRA)))
+    rows = client.get('/api/streams').json()
+    assert len(rows) == 1
+    assert rows[0]['exchange'] == 'binance'
+    assert rows[0]['pair'] == 'BTC/USDT'
+    assert rows[0]['channels'] == ['trades']
+    assert rows[0]['running'] is False
+
+
+def test_streams_start_calls_manager(tmp_path):
+    app = create_app(_write_config(tmp_path, extra=_STREAM_EXTRA))
+    started = {}
+    app.state.stream_manager.start_one = (
+        lambda job, pair, channels: started.setdefault(
+            'key', f'{job.exchange}_{pair}_{channels}') or 'k'
+    )
+    client = TestClient(app)
+    r = client.post('/api/streams/start',
+                    json={'exchange': 'binance', 'pair': 'BTC/USDT', 'channels': ['trades']})
+    assert r.status_code == 202
+    assert started['key'] == "binance_BTC/USDT_['trades']"
+
+
+def test_streams_start_unknown_job_404(tmp_path):
+    client = TestClient(create_app(_write_config(tmp_path, extra=_STREAM_EXTRA)))
+    r = client.post('/api/streams/start',
+                    json={'exchange': 'kraken', 'pair': 'BTC/USD', 'channels': ['trades']})
+    assert r.status_code == 404
+
+
+def test_streams_stop_not_running(tmp_path):
+    client = TestClient(create_app(_write_config(tmp_path, extra=_STREAM_EXTRA)))
+    r = client.post('/api/streams/stop',
+                    json={'exchange': 'binance', 'pair': 'BTC/USDT', 'channels': ['trades']})
+    assert r.status_code == 200
+    assert r.json()['status'] == 'not_running'
+
+
+def test_create_app_uses_injected_stream_manager(tmp_path):
+    from dccd.daemon.config import load_config
+    from dccd.daemon.stream_manager import StreamManager
+
+    path = _write_config(tmp_path, extra=_STREAM_EXTRA)
+    sm = StreamManager(load_config(path))
+    app = create_app(path, sm)
+    assert app.state.stream_manager is sm
+
+
+# ---------------------------------------------------------------------------
 # Logs
 # ---------------------------------------------------------------------------
 

--- a/dccd/tests/test_daemon_stream_manager.py
+++ b/dccd/tests/test_daemon_stream_manager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -276,7 +277,19 @@ def test_run_forever_stops_immediately_if_stop_set(tmp_path):
     mgr._stop_event.set()
 
     with patch.object(mgr, '_run_once') as mock_once:
-        mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'])
+        mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'], threading.Event())
+
+    mock_once.assert_not_called()
+
+
+def test_run_forever_stops_on_per_key_stop(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    stop = threading.Event()
+    stop.set()
+
+    with patch.object(mgr, '_run_once') as mock_once:
+        mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'], stop)
 
     mock_once.assert_not_called()
 
@@ -284,6 +297,7 @@ def test_run_forever_stops_immediately_if_stop_set(tmp_path):
 def test_run_forever_restarts_on_exception(tmp_path):
     cfg = _make_config(tmp_path)
     mgr = StreamManager(cfg)
+    stop = threading.Event()
     call_count = 0
 
     def _side_effect(*args, **kwargs):
@@ -291,11 +305,11 @@ def test_run_forever_restarts_on_exception(tmp_path):
         call_count += 1
         if call_count == 1:
             raise RuntimeError('crash')
-        mgr._stop_event.set()  # stop after second call
+        stop.set()  # stop after second call
 
     with patch.object(mgr, '_run_once', side_effect=_side_effect):
-        with patch.object(mgr._stop_event, 'wait', return_value=False):
-            mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'])
+        with patch.object(stop, 'wait', return_value=False):
+            mgr._run_forever(_stream_job(), 'BTC/USDT', ['trades'], stop)
 
     assert call_count == 2
 
@@ -366,3 +380,98 @@ def test_run_once_bitfinex_sets_parser(tmp_path):
 
     mock_obj.get_parser.assert_called_once_with('trades')
     assert mock_obj.parser is mock_obj.get_parser.return_value
+
+
+# ---------------------------------------------------------------------------
+# StreamManager.start_one / stop_one / status / running_keys
+# ---------------------------------------------------------------------------
+
+def test_key_format():
+    assert StreamManager._key('binance', 'BTC/USDT', ['trades', 'book']) == \
+        'binance_BTC_USDT_trades_book'
+
+
+def test_start_one_starts_thread(tmp_path):
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):
+        key = mgr.start_one(job, 'BTC/USDT', ['trades'])
+
+    assert key == 'binance_BTC_USDT_trades'
+    assert key in mgr._threads
+    assert key in mgr._stops
+
+
+def test_start_one_idempotent_while_alive(tmp_path):
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    fake = MagicMock()
+    fake.is_alive.return_value = True
+    key = StreamManager._key('binance', 'BTC/USDT', ['trades'])
+    mgr._threads[key] = fake
+
+    with patch('threading.Thread') as mock_thread:
+        out = mgr.start_one(job, 'BTC/USDT', ['trades'])
+
+    assert out == key
+    mock_thread.assert_not_called()
+
+
+def test_stop_one_signals_event_and_downloader(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    key = StreamManager._key('binance', 'BTC/USDT', ['trades'])
+
+    ev = threading.Event()
+    mgr._stops[key] = ev
+    dl = MagicMock()
+    dl.until = time.time() + 9999
+    dl.is_connect = True
+    mgr._downloaders[key] = dl
+
+    assert mgr.stop_one(key) is True
+    assert ev.is_set()
+    assert dl.is_connect is False
+    assert dl.until <= time.time()
+
+
+def test_stop_one_unknown_key_returns_false(tmp_path):
+    cfg = _make_config(tmp_path)
+    mgr = StreamManager(cfg)
+    assert mgr.stop_one('nope') is False
+
+
+def test_status_reports_running_state(tmp_path):
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    with patch.object(mgr, '_run_forever'):
+        key = mgr.start_one(job, 'BTC/USDT', ['trades'])
+    # join the (patched, instant) thread so is_alive() is deterministic
+    mgr._threads[key].join(timeout=1)
+
+    st = mgr.status()
+    assert len(st) == 1
+    entry = st[0]
+    assert entry['key'] == key
+    assert entry['exchange'] == 'binance'
+    assert entry['pair'] == 'BTC/USDT'
+    assert entry['channels'] == ['trades']
+    # the patched _run_forever returns immediately → thread no longer alive
+    assert entry['running'] is False
+
+
+def test_status_no_streams_when_idle(tmp_path):
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+
+    st = mgr.status()
+    assert len(st) == 1
+    assert st[0]['running'] is False
+    assert mgr.running_keys() == []

--- a/dccd/tests/test_daemon_stream_manager.py
+++ b/dccd/tests/test_daemon_stream_manager.py
@@ -445,6 +445,65 @@ def test_stop_one_unknown_key_returns_false(tmp_path):
     assert mgr.stop_one('nope') is False
 
 
+def test_stop_one_frees_slot_for_restart(tmp_path):
+    # A stop immediately followed by a start must spawn a fresh thread rather
+    # than reuse the one still winding down (start-after-stop race).
+    job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+    key = StreamManager._key('binance', 'BTC/USDT', ['trades'])
+
+    winding_down = MagicMock()
+    winding_down.is_alive.return_value = True
+    mgr._threads[key] = winding_down
+    ev = threading.Event()
+    mgr._stops[key] = ev
+
+    assert mgr.stop_one(key) is True
+    assert ev.is_set()
+    assert key not in mgr._threads
+    assert key not in mgr._stops
+
+    with patch.object(mgr, '_run_forever'):
+        new_key = mgr.start_one(job, 'BTC/USDT', ['trades'])
+
+    assert new_key == key
+    assert mgr._threads[key] is not winding_down
+
+
+def test_run_once_finally_keeps_restarted_downloader(tmp_path):
+    # The dying thread must not remove a downloader a restart registered under
+    # the same key (identity-guarded cleanup).
+    import dccd.daemon.stream_manager as sm
+
+    job = _stream_job(exchange='binance', channels=['trades'])
+    cfg = _make_config(tmp_path, jobs=[job])
+    mgr = StreamManager(cfg)
+    key = StreamManager._key('binance', 'BTC/USDT', ['trades'])
+
+    fresh = MagicMock()  # downloader registered by the restarted thread
+    mock_cls = MagicMock(return_value=MagicMock())
+
+    original = sm._STREAM_CLASSES.copy()
+    sm._STREAM_CLASSES['binance'] = mock_cls
+    try:
+        with patch('asyncio.new_event_loop') as mock_loop_fn, \
+             patch('asyncio.set_event_loop'), \
+             patch('asyncio.gather'):
+            mock_loop = MagicMock()
+            mock_loop_fn.return_value = mock_loop
+            # Simulate a concurrent restart swapping in a fresh downloader
+            # while this run is inside run_until_complete.
+            def _swap(*a, **k):
+                mgr._downloaders[key] = fresh
+            mock_loop.run_until_complete.side_effect = _swap
+            mgr._run_once(job, 'BTC/USDT', ['trades'])
+    finally:
+        sm._STREAM_CLASSES.update(original)
+
+    assert mgr._downloaders[key] is fresh
+
+
 def test_status_reports_running_state(tmp_path):
     job = _stream_job(exchange='binance', pairs=['BTC/USDT'], channels=['trades'])
     cfg = _make_config(tmp_path, jobs=[job])


### PR DESCRIPTION
## Summary

Lot 2 of the web UI polish (follows #66). No new dependencies.

- **Config page as a form** — Settings (data_path, timezone, ui_host/port, auth token), Storage (sync_interval + editable remotes list) and Alerts (webhook_url, max_consecutive_errors), plus a collapsible **Advanced (raw JSON)** editor for everything else (jobs, retry fields). Reuses `PUT /api/config` and `/api/config/validate` — no API change.
- **Backfill logs in the UI** — `tqdm.write` output is now routed through a `message_callback` (`_BackfillBase._log`) into each tracked job's bounded `log` list, so backfill progress lines are visible on the Jobs page instead of only on the daemon's stdout.
- **Per-job stream start/stop** — `StreamManager` gains `start_one` / `stop_one` / `status` / `running_keys` (lock-protected, per-key stop events independent of the global stop). `create_app(cfg_path, stream_manager=None)` accepts an injected manager so `dccd start` shares its live one (the UI reflects/controls actually-running streams); standalone `dccd ui` creates a non-started manager. New endpoints `GET /api/streams`, `POST /api/streams/start`, `POST /api/streams/stop`; Jobs page shows Start/Stop per stream job with light polling.

## Test plan

- [x] `pytest` — 380 passed
- [x] `ruff check dccd/` — clean
- [x] `mypy` on changed daemon modules — clean
- [x] Live smoke: `/api/streams` lists configured jobs as stopped; stop → `not_running`; start of unknown job → 404; Config & Jobs pages render 200 with form fields present