### PR TITLE
docs: narrated per-layer API reference (v2-style)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -2,138 +2,58 @@
 API Reference
 =============
 
-dccd v3 is a hexagonal architecture: a pure, synchronous **domain** with no I/O,
+dccd v3 is a hexagonal architecture (see :doc:`architecture`): a pure **domain**,
 an async **transport** layer, exchange **sources**, **storage**, an
-**application** layer of operations, and thin **interfaces** (CLI · HTTP API ·
-UI · Python ``Client``). See :doc:`architecture` for the big picture.
+**application** layer of operations, and thin **interfaces**. The reference is
+organised by layer — each page introduces the layer, then documents its members.
 
-Each object below links to its own page with the full signature, parameters and
-examples.
+Most users only need the :doc:`reference/client`.
 
-Client
-======
+.. grid:: 1 2 2 3
+   :gutter: 3
 
-The one-stop async facade — most users only need this.
+   .. grid-item-card:: Client
+      :link: reference/client
+      :link-type: doc
 
-.. currentmodule:: dccd
+      The one-stop async facade.
 
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
+   .. grid-item-card:: Domain
+      :link: reference/domain
+      :link-type: doc
 
-   Client
+      Pure value objects, capabilities and transforms — no I/O.
 
-Domain
-======
+   .. grid-item-card:: Transport
+      :link: reference/transport
+      :link-type: doc
 
-Pure, synchronous value objects and helpers — no I/O. All timestamps are
-nanoseconds UTC (``int64``).
+      Async HTTP, WebSocket base, rate limiter and paginators.
 
-.. currentmodule:: dccd.domain
+   .. grid-item-card:: Sources
+      :link: reference/sources
+      :link-type: doc
 
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
+      The ``Source`` protocols and the adapter registry.
 
-   symbol.Symbol
-   types.DataType
-   records.OHLCBar
-   records.Trade
-   records.OrderBookSnapshot
-   records.OrderBookLevel
-   capability.Capability
-   dataset.DatasetId
-   dataset.Provenance
+   .. grid-item-card:: Storage
+      :link: reference/storage
+      :link-type: doc
 
-Pure transforms and time helpers:
+      Parquet datasets, run history and v2→v3 migration.
 
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
+   .. grid-item-card:: Application
+      :link: reference/application
+      :link-type: doc
 
-   transforms.aggregate_ohlc
+      Operations, scheduler, jobs, events and config.
 
-Sources
-=======
+.. toctree::
+   :hidden:
 
-One adapter per exchange, implementing the fine-grained ``Source`` protocols,
-resolved through a registry. See :doc:`exchanges` for capabilities and fidelity.
-
-.. currentmodule:: dccd.sources
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-   registry.SourceRegistry
-   binance.BinanceSource
-   coinbase.CoinbaseSource
-   kraken.KrakenSource
-   bybit.BybitSource
-   okx.OKXSource
-   bitfinex.BitfinexSource
-   bitmex.BitMEXSource
-
-Transport
-=========
-
-Async I/O building blocks shared by every adapter.
-
-.. currentmodule:: dccd.transport
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-   http.AsyncHTTPClient
-   ws.WebSocketBase
-   ratelimit.RateLimiter
-   paginate.paginate_ohlc
-   paginate.paginate_trades
-
-Storage
-=======
-
-Parquet datasets (ns timestamps, provenance, per-type dedup) and the run history.
-
-.. currentmodule:: dccd.storage
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-   parquet.ParquetStore
-   runs_sqlite.RunsStore
-   migrate.migrate_parquet_to_ns
-
-Application
-===========
-
-The operations and orchestration that wire domain, sources and storage together.
-
-.. currentmodule:: dccd.application
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-   operations.backfill
-   operations.stream
-   operations.read
-   operations.inventory
-   scheduler.Scheduler
-   config.AppConfig
-   config.JobConfig
-   jobs.JobSpec
-   events.EventBus
-
-Interfaces
-==========
-
-.. currentmodule:: dccd.interfaces
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-   api.app.create_app
+   reference/client
+   reference/domain
+   reference/transport
+   reference/sources
+   reference/storage
+   reference/application

--- a/doc/source/binance.rst
+++ b/doc/source/binance.rst
@@ -26,4 +26,8 @@ Example
        await c.backfill("binance", "BTC/USDT", "ohlc", span=3600, start="2024-01-01")
        await c.backfill("binance", "BTC/USDT", "trades", start="2024-01-01")
 
-See :class:`~dccd.sources.binance.BinanceSource` for the full API.
+API
+===
+
+.. autoclass:: dccd.sources.binance.BinanceSource
+   :members:

--- a/doc/source/bitfinex.rst
+++ b/doc/source/bitfinex.rst
@@ -30,4 +30,8 @@ Example
    async with Client() as c:
        await c.backfill("bitfinex", "BTC/USDT", "ohlc", span=3600, start="2024-01-01")
 
-See :class:`~dccd.sources.bitfinex.BitfinexSource` for the full API.
+API
+===
+
+.. autoclass:: dccd.sources.bitfinex.BitfinexSource
+   :members:

--- a/doc/source/bitmex.rst
+++ b/doc/source/bitmex.rst
@@ -28,4 +28,8 @@ Example
        await c.backfill("bitmex", "BTC/USD", "ohlc", span=3600, start="2024-01-01")
        await c.backfill("bitmex", "BTC/USD", "trades", start="2024-01-01")
 
-See :class:`~dccd.sources.bitmex.BitMEXSource` for the full API.
+API
+===
+
+.. autoclass:: dccd.sources.bitmex.BitMEXSource
+   :members:

--- a/doc/source/bybit.rst
+++ b/doc/source/bybit.rst
@@ -28,4 +28,8 @@ Example
    async with Client() as c:
        await c.backfill("bybit", "BTC/USDT", "ohlc", span=3600, start="2024-01-01")
 
-See :class:`~dccd.sources.bybit.BybitSource` for the full API.
+API
+===
+
+.. autoclass:: dccd.sources.bybit.BybitSource
+   :members:

--- a/doc/source/coinbase.rst
+++ b/doc/source/coinbase.rst
@@ -30,4 +30,8 @@ Example
    async with Client() as c:
        await c.backfill("coinbase", "BTC/USD", "ohlc", span=3600, start="2024-01-01")
 
-See :class:`~dccd.sources.coinbase.CoinbaseSource` for the full API.
+API
+===
+
+.. autoclass:: dccd.sources.coinbase.CoinbaseSource
+   :members:

--- a/doc/source/kraken.rst
+++ b/doc/source/kraken.rst
@@ -31,4 +31,8 @@ Example
        await c.backfill("kraken", "BTC/USD", "trades", start="2024-01-01")  # full history
        await c.backfill("kraken", "BTC/USD", "ohlc", span=3600, start="last")  # 720 recent
 
-See :class:`~dccd.sources.kraken.KrakenSource` for the full API.
+API
+===
+
+.. autoclass:: dccd.sources.kraken.KrakenSource
+   :members:

--- a/doc/source/okx.rst
+++ b/doc/source/okx.rst
@@ -23,4 +23,8 @@ Example
    async with Client() as c:
        await c.backfill("okx", "BTC/USDT", "trades", start="2024-01-01")
 
-See :class:`~dccd.sources.okx.OKXSource` for the full API.
+API
+===
+
+.. autoclass:: dccd.sources.okx.OKXSource
+   :members:

--- a/doc/source/reference/application.rst
+++ b/doc/source/reference/application.rst
@@ -1,0 +1,55 @@
+===========
+Application
+===========
+
+The application layer wires domain, sources and storage into the four
+operations, plus the orchestration that schedules them and the events they emit.
+
+Operations
+==========
+
+``backfill`` / ``stream`` / ``read`` / ``inventory`` are the verbs; everything
+else is plumbing. They take their infrastructure (registry, store, events) as
+keyword arguments so call sites stay explicit and testable.
+
+.. automodule:: dccd.application.operations
+   :members:
+
+Jobs
+====
+
+A :class:`~dccd.application.jobs.JobSpec` is a declarative unit of work
+(operation + target + trigger + params); the config expands one
+:class:`~dccd.application.config.JobConfig` into one spec per pair.
+
+.. automodule:: dccd.application.jobs
+   :members:
+
+Scheduler
+=========
+
+Routes each spec by trigger kind — supervised → stream worker (auto-reconnect),
+interval/cron → periodic backfill, once → one-shot.
+
+.. autoclass:: dccd.application.scheduler.Scheduler
+   :members:
+
+Events
+======
+
+.. automodule:: dccd.application.events
+   :members:
+
+Configuration
+=============
+
+The Pydantic config models — :class:`~dccd.application.config.AppConfig` and its
+sections — are documented in the :doc:`/configuration` reference.
+
+Service factory
+===============
+
+The single place that wires every adapter — edit it to add an exchange.
+
+.. automodule:: dccd.application.service_factory
+   :members:

--- a/doc/source/reference/client.rst
+++ b/doc/source/reference/client.rst
@@ -1,0 +1,23 @@
+======
+Client
+======
+
+The async :class:`dccd.Client` is the one-stop entry point: it wires every
+exchange adapter and the local store and exposes the four operations as methods.
+Use it as an async context manager.
+
+.. code-block:: python
+
+   import asyncio
+   from dccd import Client
+
+   async def main():
+       async with Client() as c:
+           await c.backfill("binance", "BTC/USDT", "ohlc", span=3600, start="2024-01-01")
+           df = c.read("binance", "BTC/USDT", "ohlc", span=3600)
+           print(df.tail())
+
+   asyncio.run(main())
+
+.. autoclass:: dccd.Client
+   :members:

--- a/doc/source/reference/domain.rst
+++ b/doc/source/reference/domain.rst
@@ -1,0 +1,65 @@
+======
+Domain
+======
+
+The domain is pure and synchronous — value objects and transforms with **no
+I/O**. Every timestamp is **nanoseconds UTC** (``int64``). Exchange payloads are
+validated into these Pydantic models before anything is stored, so corrupt data
+never reaches Parquet.
+
+Records at a glance
+===================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 28 50
+
+   * - Model
+     - Key fields
+     - Notes
+   * - :class:`~dccd.domain.records.OHLCBar`
+     - ``ts, open, high, low, close, volume``
+     - ``quote_volume`` / ``trades`` may be null (see :doc:`/exchanges`).
+   * - :class:`~dccd.domain.records.Trade`
+     - ``ts, price, amount, side, tid``
+     - ``side`` ∈ {buy, sell}; ``tid`` is the dedup key.
+   * - :class:`~dccd.domain.records.OrderBookSnapshot`
+     - ``ts, bids, asks, is_snapshot``
+     - ``is_snapshot=False`` is an incremental delta.
+
+Symbol & types
+==============
+
+.. automodule:: dccd.domain.symbol
+   :members:
+
+.. automodule:: dccd.domain.types
+   :members:
+
+Records
+=======
+
+.. automodule:: dccd.domain.records
+   :members:
+
+Capabilities
+============
+
+A :class:`~dccd.domain.capability.Capability` is what an adapter declares it can
+do for a ``(data_type × transport × mode)``; the engine resolves against it and
+raises :class:`~dccd.domain.errors.NoCapability` early. See :doc:`/architecture`.
+
+.. automodule:: dccd.domain.capability
+   :members:
+
+.. automodule:: dccd.domain.dataset
+   :members:
+
+.. automodule:: dccd.domain.errors
+   :members:
+
+Transforms
+==========
+
+.. automodule:: dccd.domain.transforms
+   :members:

--- a/doc/source/reference/sources.rst
+++ b/doc/source/reference/sources.rst
@@ -1,0 +1,31 @@
+=======
+Sources
+=======
+
+One adapter per exchange, each implementing the fine-grained ``Source``
+protocols and declaring its :class:`~dccd.domain.capability.Capability` set. The
+engine resolves an adapter from the registry; you drive them through
+:class:`dccd.Client`.
+
+For each exchange's capabilities, quirks and adapter class, see the
+:doc:`per-exchange pages </exchanges>`.
+
+Adding an exchange
+==================
+
+Implement the relevant protocol mixins below and a ``capabilities()`` method,
+then register the adapter in
+:func:`~dccd.application.service_factory.build_registry`.
+
+Registry
+========
+
+.. autoclass:: dccd.sources.registry.SourceRegistry
+   :members:
+
+Source protocols
+================
+
+.. automodule:: dccd.sources.base
+   :members:
+   :show-inheritance:

--- a/doc/source/reference/storage.rst
+++ b/doc/source/reference/storage.rst
@@ -1,0 +1,84 @@
+=======
+Storage
+=======
+
+.. currentmodule:: dccd.storage
+
+The storage layer persists every data type to **Parquet** with nanosecond
+timestamps, provenance and per-type deduplication, and keeps an append-only run
+history in SQLite. :class:`~dccd.storage.parquet.ParquetStore` is the unified
+read/write interface; you rarely touch it directly — :class:`dccd.Client` and the
+operations use it for you.
+
+Directory layout
+================
+
+::
+
+    {data_path}/{exchange}/ohlc/{pair}/{span}/YYYY.parquet
+    {data_path}/{exchange}/trades/{pair}/YYYY-MM-DD.parquet
+    {data_path}/{exchange}/orderbook/{pair}/YYYY-MM-DD.parquet
+
+- *exchange* — lowercase (``binance``, ``kraken``, …).
+- *pair* — ``BTC-USDT`` (slash replaced by hyphen).
+- *span* — seconds label (``3600s``); OHLC only.
+- OHLC files are **annual**; trades and order-book files are **daily**.
+
+Schema & integrity
+==================
+
+All timestamps are ``TS`` — **nanoseconds UTC** (``int64``). Each write merges
+into the existing file and deduplicates on the **natural key** per data type:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 35 45
+
+   * - Data type
+     - Dedup key
+     - Notes
+   * - OHLC
+     - ``TS``
+     - One bar per span window.
+   * - trades
+     - ``tid`` (else ``TS, price, amount, side``)
+     - Many trades share a ``TS`` — keying on ``TS`` alone would lose them.
+   * - order book
+     - ``TS, side, price``
+     - A snapshot's levels all share one ``TS``.
+
+Writes are **atomic** (temp file + ``os.replace``) and serialised per file, so a
+reader never sees a half-written Parquet and concurrent writers can't corrupt it.
+
+Reading data
+============
+
+.. code-block:: python
+
+   from dccd.storage.parquet import ParquetStore
+   from dccd.domain.dataset import DatasetId
+   from dccd.domain.symbol import Symbol
+   from dccd.domain.types import DataType
+
+   store = ParquetStore("/data/crypto")
+   ds = DatasetId(exchange="binance", symbol=Symbol(base="BTC", quote="USDT"),
+                  data_type=DataType.OHLC, span=3600)
+   df = store.load(ds)          # a polars.DataFrame, sorted by TS
+
+ParquetStore
+============
+
+.. autoclass:: dccd.storage.parquet.ParquetStore
+   :members:
+
+Run history
+===========
+
+.. autoclass:: dccd.storage.runs_sqlite.RunsStore
+   :members:
+
+Migration
+=========
+
+.. automodule:: dccd.storage.migrate
+   :members:

--- a/doc/source/reference/transport.rst
+++ b/doc/source/reference/transport.rst
@@ -1,0 +1,42 @@
+=========
+Transport
+=========
+
+The async I/O building blocks every adapter shares: an HTTP client with
+retry/backoff, a reconnecting WebSocket base, a token-bucket rate limiter, and
+the generic paginators.
+
+Pagination
+==========
+
+OHLC is paged by **fixed time windows** sized to one request
+(``span × max_per_request``), snapped to the bar. Trades are paged by an
+**opaque per-adapter cursor** that drains the whole window — this is what fixes
+the capped-single-page data loss on liquid pairs. The application binds the
+adapter's ``fetch_*_page`` in a closure and hands it to the paginator.
+
+.. automodule:: dccd.transport.paginate
+   :members:
+
+HTTP client
+===========
+
+Shared by every adapter and reference-counted, so concurrent operations on the
+same exchange don't close it out from under each other.
+
+.. autoclass:: dccd.transport.http.AsyncHTTPClient
+   :members:
+
+.. autoexception:: dccd.transport.http.HTTPError
+
+WebSocket base
+==============
+
+.. autoclass:: dccd.transport.ws.WebSocketBase
+   :members:
+
+Rate limiter
+============
+
+.. autoclass:: dccd.transport.ratelimit.RateLimiter
+   :members:


### PR DESCRIPTION
The v3 autosummary reference was a flat list of 37 one-object pages — accurate
but dry and fragmented; the v2 reference (narrated module guides) read better.

This restructures the API reference into **one narrated page per layer**
(Client / Domain / Transport / Sources / Storage / Application): intro prose,
"at a glance" tables, directory layouts and workflow examples, then
`automodule :members:` rendering the rich docstrings inline. `api.rst` is now a
card grid over the layers; each adapter is documented on its per-exchange page.

`make html` 0 warnings.
🤖 Generated with [Claude Code](https://claude.com/claude-code)