### PR TITLE
docs: make 07-roadmap.md the single source of open work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ __pycache__/
 .pytest_cache/
 
 # Local only (not committed)
-TODO.md
 todo/
 done/
 config.yml

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -8,8 +8,24 @@ off-box."** Much of the scaffolding already exists (`Dockerfile`,
 UX*, not greenfield.
 
 Status legend: `[ ]` todo · `[~]` partially in place · `[x]` done.
-(Operational/local scratch backlog stays in the gitignored root `TODO.md`; this
-file is the tracked, Claude-oriented plan.)
+
+This file is the **single source of truth** for open work — it is read by
+`/pick-task` and updated by `/finish-task` / `/abandon-task`. Finished work is
+*removed* from here (git log + `CHANGELOG.md` are authoritative for *what*
+shipped; `03-decisions.md` for *why*). Keep it short and true.
+
+---
+
+## Ship v3.0 (near-term)
+
+The hexagonal rewrite (P0–P8) is done and lives on `develop`; what remains is to
+release it and finish the v3-era docs.
+
+- [ ] **Release v3.0** — `develop → master` + `v3.0.0` tag. `pyproject` already
+  says `3.0.0`; last published tag is `v2.4.0`. Use the `release-gate` skill
+  before, the `release` skill to cut it.
+- [ ] **v3 docs sweep** — confirm `CLAUDE.md`, `README`, Sphinx (`doc/source/`)
+  and `examples/` all describe the v3 hexagonal architecture (no v2 leftovers).
 
 ---
 
@@ -86,3 +102,20 @@ loss doesn't lose data.
 
 Each epic should ship with a `doc/source/` how-to and, where it touches data,
 a pass of the `data-e2e` skill.
+
+---
+
+## Deferred — M3 (post-3.0)
+
+Larger axes intentionally parked until after the 3.0 release. Not started; do not
+treat as bugs (see `06-status.md`).
+
+- [ ] **MCP interface** — `interfaces/mcp/` mapped onto the operation registry
+  (same parity contract as API/CLI).
+- [ ] **Kraken deep OHLC from trades** — a `DerivedOHLCSource` wiring
+  `domain/transforms.aggregate_ohlc` into the resolver (REST only gives 720 recent
+  bars; the transform exists but isn't wired).
+- [ ] **Derivative markets** — `DataType` for funding / open-interest /
+  liquidations, `Symbol.market=perp`.
+- [ ] **Auth/secrets for private endpoints** — credential injection into
+  `transport/` for authenticated exchange endpoints.

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -36,6 +36,7 @@ rules live in the repo-root `CLAUDE.md`.
 ## Conventions for keeping this current
 
 - This is descriptive, not aspirational: write what the repo **is**, not what it
-  should become (put plans in `TODO.md`, history in git/CHANGELOG).
+  should become (put plans in [`07-roadmap.md`](07-roadmap.md) — the single source
+  of open work — and history in git/CHANGELOG).
 - A prior snapshot of these docs (the v3 planning/retrospective set) is archived
   under `doc/dev/_archive/` — **gitignored**, kept locally for reference only.


### PR DESCRIPTION
## Summary
- Fold the few still-open items from the gitignored root `TODO.md` into the tracked `doc/dev/07-roadmap.md` (the v3 refonte plan was ~90% done — checked items dropped, git log + CHANGELOG are authoritative for *what* shipped).
- Declare `07-roadmap.md` the **single source of truth** for open work, read by `/pick-task` and updated by `/finish-task` / `/abandon-task`.
- Remove `TODO.md` and its `.gitignore` entry; fix the `doc/dev/README.md` pointer.

## Why
The roadmap was duplicated (gitignored `TODO.md` vs tracked `07-roadmap.md`), so an agent on a clean checkout couldn't see the backlog. One tracked source kills the drift.

## Changes
- `doc/dev/07-roadmap.md`: new **Ship v3.0** (release + v3 docs) and **Deferred — M3** (MCP, Kraken OHLC derivation, derivative markets, private-endpoint auth) sections; header declares single-source.
- `doc/dev/README.md`: pointer now `07-roadmap.md`.
- `.gitignore`: drop `TODO.md`; root `TODO.md` deleted.

## Test plan
- [x] pytest passes locally (182 passed)
- [ ] CI green

(First PR of a larger dev-workflow effort — kept doc-only and atomic.)