### PR TITLE
docs: define the tooled dev loop and ADR decision journal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,36 @@ Do not add `Co-Authored-By` trailers to commits — this is a personal repo.
 
 **Before every commit:** run `pytest`. It must pass.
 
+**One PR = one concern, small and disposable.** Even a large plan ships as
+*several* small atomic PRs — never one fourre-tout branch. A PR you couldn't throw
+away without losing unrelated good work is too big: split it. This is what makes
+`/abandon-task` (kill a bad PR, keep the lesson) viable.
+
+### Dev loop & docs of record
+
+The iterative loop is tooled by skills, with three tracked docs as the sources of
+truth:
+
+| Doc | Holds | Updated by |
+|-----|-------|-----------|
+| `doc/dev/07-roadmap.md` | open work (single source) | `/pick-task` reads · `/finish-task`, `/abandon-task` update |
+| `doc/dev/03-decisions.md` | the *why* — ADR journal (+ settled rationale) | `/finish-task` (accepted), `/abandon-task` (rejected/tombstone) |
+| `doc/dev/06-status.md` | where things stand | `/finish-task`, `/groom-docs` |
+
+`CHANGELOG.md` + git log stay authoritative for *what* shipped. The loop:
+`/pick-task` (smallest slice → branch) → plan (split big plans into small PRs) →
+`/finish-task` (tests, ADR entry, status, PR) **or** `/abandon-task` (salvage the
+lesson + close the PR); `/groom-docs` periodically keeps `doc/dev/` lean and true.
+
+**Model per task** (advisory — you set it via `/model`, or a skill spawns a
+subagent with an explicit `model`; subagents otherwise *inherit* the parent):
+
+| Model | For |
+|-------|-----|
+| `opus` | judgement, design, decisions, planning, review |
+| `sonnet` | implementation — code, tests, docstrings |
+| `haiku` | mechanical fan-out (doc scans, checklists) — spawn it explicitly as a subagent |
+
 ## Architecture (v3 — hexagonal)
 
 ### Three usage modes

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -96,3 +96,40 @@ on real data**: a green unit suite said nothing about a backfill that wrote 0
 rows or a store that lost half its trades. See `05-testing.md`. The most recent
 round (the UI rework + order-book liveness fixes) followed the same method:
 drive the real UI, read what renders, compare to the feed.
+
+## Decision journal (ADR)
+
+Append-only, dated log of choices made since the v3 brief — fed by `/finish-task`
+(accepted) and `/abandon-task` (rejected / tombstone). The prose above is the
+*settled* rationale; this journal is the *running* one. **Newest first.**
+
+Conventions:
+- One entry per significant choice; skip the trivial (those live in
+  git/`CHANGELOG.md`).
+- `[tombstone]` = a feature was removed. Keep one line on *why it's gone* here and
+  **purge its implementation rationale from the prose above** — negative knowledge
+  so it isn't silently re-added later.
+
+Template:
+```
+### YYYY-MM-DD — <short title> (PR #NN)  [accepted|rejected|tombstone]
+- **Choice**: …
+- **Why**: …
+- **Rejected alternatives**: …
+```
+
+<!-- new entries below, newest first -->
+
+### 2026-06-07 — Tooled dev loop + single-source roadmap (PR #79) [accepted]
+- **Choice**: `doc/dev/07-roadmap.md` is the single source of open work (root
+  `TODO.md` dropped); the dev loop is tooled by `/pick-task` → `/finish-task` /
+  `/abandon-task`, with this journal capturing the *why* of each PR and
+  `/groom-docs` keeping `doc/dev/` lean.
+- **Why**: the roadmap was duplicated (gitignored `TODO.md` vs tracked roadmap)
+  and decisions/negative knowledge weren't captured — the exact drift the v3
+  retrospective flagged ("doc périmée"). One tracked source + capture-at-PR-time
+  kills it.
+- **Rejected alternatives**: a git hook that writes decisions from the diff
+  (can't reconstruct the *why* post-hoc — capture must happen while the context
+  is live, i.e. in the skills); keeping the `TODO.md` / roadmap split (leaves a
+  clean checkout blind to the backlog).


### PR DESCRIPTION
## Summary
- Add the **dev-workflow contract** to `CLAUDE.md`: *one PR = one disposable concern*, the `/pick-task → /finish-task / /abandon-task` loop, the three docs of record (roadmap / decisions / status), and an advisory **model-per-task** table (opus/sonnet/haiku).
- Open an append-only, dated **ADR journal** at the end of `doc/dev/03-decisions.md` (with a `[tombstone]` convention for removed features), seeded with the first entry.

## Why
Choices and *negative* knowledge (why an approach was dropped) were never captured — the drift the v3 retrospective flagged. Capturing at PR time, while the context is live, is the fix; a git hook parsing a diff can't reconstruct the *why*.

## Changes
- `CLAUDE.md`: new PR-size rule + "Dev loop & docs of record" + model table under Git Flow.
- `doc/dev/03-decisions.md`: `## Decision journal (ADR)` section (prose rationale above is untouched).

## Test plan
- [x] pytest passes locally (182 passed)
- [ ] CI green

(Part of the dev-workflow effort; pairs with #79. Hooks + skill generalization follow in a separate PR / user-level config.)