### PR TITLE
chore: add workflow descriptor and Claude Code hooks

### DIFF
--- a/.claude/hooks/pr_decision_guard.py
+++ b/.claude/hooks/pr_decision_guard.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) safety net for `gh pr create`.
+
+If the branch changes structural code under <package_dir>/ (excluding tests) but
+adds no entry to the decision journal (<decisions>), ask the user to confirm
+before the PR is opened. This is only a net — the real capture is the
+`/finish-task` "décision" step; here we just make the omission visible.
+
+Emits a PreToolUse "ask" decision (human confirms / overrides) rather than a hard
+deny, so a genuinely decision-free PR isn't deterministically blocked. No-op for
+any command other than `gh pr create`, or if the project doesn't declare both a
+`package_dir` and a `decisions` path in .claude/workflow.json.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _allow() -> None:
+    """Exit without influencing the decision."""
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+
+    cmd = (payload.get("tool_input") or {}).get("command", "")
+    if "gh pr create" not in cmd:
+        _allow()
+
+    try:
+        cfg = json.loads((ROOT / ".claude" / "workflow.json").read_text())
+    except Exception:
+        _allow()
+
+    pkg = cfg.get("package_dir")
+    base = cfg.get("base_branch", "develop")
+    decisions = cfg.get("decisions")
+    if not pkg or not decisions:
+        _allow()  # project hasn't opted into the guard
+
+    try:
+        changed = subprocess.run(
+            ["git", "diff", f"{base}...HEAD", "--name-only"],
+            cwd=ROOT, capture_output=True, text=True, timeout=10,
+        ).stdout.split()
+    except Exception:
+        _allow()
+
+    def is_structural(path: str) -> bool:
+        name = path.rsplit("/", 1)[-1]
+        return (
+            path.startswith(f"{pkg}/")
+            and "/tests/" not in path
+            and not name.startswith("test_")
+        )
+
+    touched_code = any(is_structural(p) for p in changed)
+    if touched_code and decisions not in changed:
+        reason = (
+            f"This branch changes structural code under {pkg}/ but adds no entry "
+            f"to {decisions}. Capture the *why* (the /finish-task 'décision' step) "
+            f"before opening the PR — or confirm this PR genuinely needs no "
+            f"decision entry."
+        )
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "ask",
+                "permissionDecisionReason": reason,
+            }
+        }))
+        sys.exit(0)
+
+    _allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""SessionStart hook — cheap orientation.
+
+Prints the current branch, the number of open roadmap tasks, and the most recent
+dated decision-journal entry. Stdout is injected into the session context by
+Claude Code. Reads paths from .claude/workflow.json; degrades gracefully if the
+descriptor or any target file is missing (prints what it can, never errors out).
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]  # .claude/hooks/ -> repo root
+
+
+def _cfg() -> dict:
+    p = ROOT / ".claude" / "workflow.json"
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def _branch() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=ROOT, capture_output=True, text=True, timeout=5,
+        )
+        return out.stdout.strip() or "(detached)"
+    except Exception:
+        return "?"
+
+
+def main() -> None:
+    cfg = _cfg()
+    lines = [f"dccd workflow — branch: {_branch()}"]
+
+    roadmap_rel = cfg.get("roadmap", "doc/dev/07-roadmap.md")
+    roadmap = ROOT / roadmap_rel
+    if roadmap.exists():
+        open_n = len(re.findall(r"(?m)^\s*- \[ \] ", roadmap.read_text()))
+        lines.append(f"open roadmap tasks: {open_n}  ({roadmap_rel})")
+
+    decisions = ROOT / cfg.get("decisions", "doc/dev/03-decisions.md")
+    if decisions.exists():
+        # Journal is newest-first; dated entries are h3 `### YYYY-MM-DD …`.
+        m = re.search(r"(?m)^### (\d{4}-\d{2}-\d{2} .+)$", decisions.read_text())
+        if m:
+            lines.append(f"last decision: {m.group(1)}")
+
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/session_start.py\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr_decision_guard.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/workflow.json
+++ b/.claude/workflow.json
@@ -1,0 +1,11 @@
+{
+  "package_dir": "dccd",
+  "base_branch": "develop",
+  "roadmap": "doc/dev/07-roadmap.md",
+  "decisions": "doc/dev/03-decisions.md",
+  "status": "doc/dev/06-status.md",
+  "changelog": "CHANGELOG.md",
+  "test_cmd": "pytest",
+  "lint_cmd": "ruff check dccd/",
+  "docs_src": "doc/source"
+}


### PR DESCRIPTION
## Summary
- `.claude/workflow.json` — per-project descriptor (package dir, base branch, roadmap / decisions / status paths, test & lint commands) consumed by the generic workflow skills and the hooks.
- Two Claude Code hooks wired in `.claude/settings.json`:
  - **SessionStart** (`session_start.py`) — prints branch + open roadmap tasks + last decision (cheap orientation, injected into context).
  - **PreToolUse net** (`pr_decision_guard.py`) — on `gh pr create`, if the branch changed structural `dccd/` code (excl. tests) without a decision-journal entry, emits an `ask` decision so the omission is confirmed, not silent. The real capture stays in `/finish-task`.

## Why
Hooks *force the question*; skills *do the work*. The net catches a forgotten decision entry; SessionStart removes cold-start re-orientation. Both read the descriptor and degrade gracefully if files are missing.

## Verification
- Manually tested: SessionStart output; guard is silent on non-`gh` commands and on a `.claude/`-only PR; emits the `ask` decision on a throwaway branch that touched `dccd/domain/errors.py` with no decision entry.

## Test plan
- [x] pytest passes locally (182 passed)
- [ ] CI green

(Depends conceptually on #79 + #80 — the roadmap/decisions paths it points at. Skill generalization + new skills land user-level, outside this repo.)