### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added (v3 remediation, pre-3.0.0)
+### Added
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.0.0] - 2026-06-07
+
+### Added
 
 - Reworked web UI split by concern: a read-only enriched **Inventory** (data
   freshness, OHLC gap detection, on-disk size, per-exchange totals) and two


### PR DESCRIPTION
Freezes `CHANGELOG.md` `[Unreleased]` into **`[3.0.0] - 2026-06-07`** and opens a
fresh empty `[Unreleased]`. No version-file bump: `pyproject.toml` already
declares `3.0.0` (the version set during the v3 hexagonal rewrite); `dccd`
resolves its version via `importlib.metadata`, so `pyproject` is the single
source.

## Release v3.0.0 — highlights
v3 is a full **hexagonal rewrite** (domain / transport / sources / storage /
application / interfaces) with four iso-functional interfaces (Python `Client`,
CLI, HTTP API, Web UI). It **removes** the v2 daemon web UI (`dccd/daemon/*`) and
the v2→v3 Parquet migration tool.

Major correctness fixes that justify the major bump:
- **Cursor-based trades pagination** — fixes silent loss of >95% of trades.
- **Order-book best bid/ask** — adapters now use full snapshots; no crossed book.
- **Kraken live OHLC timestamps** — read `interval_begin` (were epoch 0).
- Provenance actually written to the Parquet footer; no silent overwrite of
  legacy v2 files on merge.

Full detail in the `[3.0.0]` CHANGELOG section.

## Test plan
- [x] `pytest` (182 passed), `ruff`, `mypy` all green on `develop`
- [x] Sphinx `make html` → 0 warnings
- [x] `pytest -m network` (real-exchange E2E) → 3 passed
- [ ] CI green on this branch