### PR TITLE
docs: mark v3.0.0 released (close out roadmap + status)

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -21,12 +21,13 @@ an agent doesn't re-investigate settled ground or assume missing things are bugs
   CORS via `ui_allow_origins`.
 - **Quality gates**: ~191 unit tests + 3 network E2E (opt-in); `ruff` + `mypy`
   clean; Sphinx 0 warnings; CI matrix 3.11–3.13.
+- **Released**: `v3.0.0` tagged on `master` (2026-06-07), superseding `v2.4.0` —
+  GitHub Release published. `develop` and `master` are level; the next feature
+  merge into `develop` reopens the rolling release PR (`/release next-cycle`).
 
 ## Pending
 
-- **Release**: v3 is `3.0.0` in `pyproject` but lives on `develop` and is **not
-  tagged**. Last published tag is `v2.4.0`. Releasing = `develop → master` +
-  `v3.0.0` tag (use the `release-gate` skill).
+_(nothing release-blocking — see the roadmap for the next epics)_
 
 ## Known gaps / sharp edges (by design or deferred)
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -16,17 +16,6 @@ shipped; `03-decisions.md` for *why*). Keep it short and true.
 
 ---
 
-## Ship v3.0 (near-term)
-
-The hexagonal rewrite (P0–P8) is done and lives on `develop`; what remains is to
-release it and finish the v3-era docs.
-
-- [ ] **Release v3.0** — `develop → master` + `v3.0.0` tag. `pyproject` already
-  says `3.0.0`; last published tag is `v2.4.0`. Use the `release-gate` skill
-  before, the `release` skill to cut it.
-
----
-
 ## Epic A — Run the app on a remote server
 
 Goal: `dccd start` (scheduler + streams + UI) running 24/7 on a VPS/home server,


### PR DESCRIPTION
## Summary
Post-release housekeeping after `v3.0.0` was tagged and published.

## Changes
- **Roadmap**: remove the completed **Release v3.0** task and the now-empty
  "Ship v3.0 (near-term)" section. Next open work starts at Epic A.
- **Status**: move *Release* from Pending → Done (`v3.0.0` tagged on `master`,
  GitHub Release published; `develop`/`master` level; next-cycle reopens on the
  next feature merge).

## Test plan
- [x] Docs-only; `pytest`/`ruff`/`mypy` unaffected.
- [ ] CI green