### PR TITLE
feat: schedule rclone remote sync in the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd start` now schedules rclone remote sync: when `storage.remotes` is set,
+  the daemon mirrors the store off-box every `storage.sync_interval` seconds with
+  exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a
+  live `remote-sync` EventBus status. Previously `RemoteStorage` was implemented
+  but never driven — a server synced nothing. (#XX)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the daemon mirrors the store off-box every `storage.sync_interval` seconds with
   exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a
   live `remote-sync` EventBus status. Previously `RemoteStorage` was implemented
-  but never driven — a server synced nothing. (#XX)
+  but never driven — a server synced nothing. (#86)
 
 ### Changed
 

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -10,6 +10,7 @@ from dccd.application.events import EventBus
 from dccd.application.jobs import JobSpec
 from dccd.sources.registry import SourceRegistry
 from dccd.storage.parquet import ParquetStore
+from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
 
 __all__ = ["Scheduler"]
@@ -90,6 +91,11 @@ class Scheduler:
     store : ParquetStore
     runs_store : RunsStore or None
     events : EventBus
+    remote : RemoteStorage or None
+        When set (rclone remotes configured), :meth:`start` launches a periodic
+        loop that mirrors the local store off-box every ``sync_interval`` seconds.
+    sync_interval : int
+        Seconds between remote-sync cycles (default 3600).
     """
 
     def __init__(
@@ -98,11 +104,16 @@ class Scheduler:
         store: ParquetStore,
         runs_store: RunsStore | None = None,
         events: EventBus | None = None,
+        remote: RemoteStorage | None = None,
+        sync_interval: int = 3600,
     ) -> None:
         self._registry = registry
         self._store = store
         self._runs_store = runs_store
         self._events = events or EventBus()
+        self._remote = remote
+        self._sync_interval = sync_interval
+        self._sync_task: asyncio.Task[None] | None = None
         self._streams: dict[str, _StreamWorker] = {}
         self._interval_tasks: list[asyncio.Task[None]] = []
         # Per-spec recurring backfill loops, keyed by spec id, with the interval
@@ -186,6 +197,8 @@ class Scheduler:
     async def start(self, specs: list[JobSpec]) -> None:
         """Start all enabled specs (full daemon mode)."""
         self._running = True
+        if self._remote is not None and self._sync_task is None:
+            self._sync_task = asyncio.create_task(self._sync_loop())
         for spec in specs:
             if not spec.enabled:
                 continue
@@ -207,6 +220,13 @@ class Scheduler:
     async def stop(self) -> None:
         """Stop all running jobs."""
         self._running = False
+        if self._sync_task is not None:
+            self._sync_task.cancel()
+            try:
+                await self._sync_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._sync_task = None
         for task in self._interval_tasks:
             task.cancel()
         for task, _ in self._interval_loops.values():
@@ -215,6 +235,58 @@ class Scheduler:
             await worker.stop()
         self._interval_tasks.clear()
         self._interval_loops.clear()
+
+    async def _sync_loop(self) -> None:
+        """Periodically mirror the local store to the configured rclone remotes.
+
+        Runs only when a :class:`~dccd.storage.remote.RemoteStorage` was wired in
+        (``storage.remotes`` non-empty). Each cycle is recorded as a ``sync`` run
+        in :class:`RunsStore` (so the Storage UI can show "last sync") and emitted
+        live on the ``remote-sync`` EventBus channel. On failure it backs off
+        exponentially (30s → capped at ``sync_interval``) so a flapping remote
+        doesn't hammer rclone.
+        """
+        assert self._remote is not None
+        run_events = self._events.for_run("remote-sync")
+        backoff = 30.0
+        while self._running:
+            run_id = f"remote-sync@{time.time_ns()}"
+            if self._runs_store:
+                self._runs_store.create_run(
+                    run_id, "remote-sync", "sync", "-", "all", "-"
+                )
+            run_events.status("running")
+            try:
+                results = await self._remote.sync_all()
+                failed = [r for r, ok in results.items() if not ok]
+                if failed:
+                    msg = f"Remote sync failed for: {', '.join(failed)}"
+                    run_events.log(msg, "error")
+                    run_events.status("failed")
+                    if self._runs_store:
+                        self._runs_store.finish_run(run_id, "failed", error=msg)
+                    await asyncio.sleep(min(backoff, self._sync_interval))
+                    backoff = min(backoff * 2, float(self._sync_interval))
+                    continue
+                run_events.log(f"Synced {len(results)} remote(s)")
+                run_events.status("succeeded")
+                if self._runs_store:
+                    self._runs_store.finish_run(
+                        run_id, "succeeded", rows_written=len(results)
+                    )
+                backoff = 30.0
+                await asyncio.sleep(self._sync_interval)
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                msg = f"Remote sync error: {exc}"
+                logger.warning("%s — retry in %ds", msg, int(backoff))
+                run_events.log(msg, "error")
+                run_events.status("failed")
+                if self._runs_store:
+                    self._runs_store.finish_run(run_id, "failed", error=str(exc))
+                await asyncio.sleep(min(backoff, self._sync_interval))
+                backoff = min(backoff * 2, float(self._sync_interval))
 
     async def _interval_loop(self, spec: JobSpec) -> None:
         every = spec.trigger.every or spec.target.span or 3600

--- a/dccd/application/service_factory.py
+++ b/dccd/application/service_factory.py
@@ -11,11 +11,13 @@ import pathlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from dccd.application.config import AppConfig
     from dccd.sources.registry import SourceRegistry
     from dccd.storage.parquet import ParquetStore
+    from dccd.storage.remote import RemoteStorage
     from dccd.storage.runs_sqlite import RunsStore
 
-__all__ = ["build_registry", "build_store", "build_runs_store"]
+__all__ = ["build_registry", "build_store", "build_runs_store", "build_remote"]
 
 
 def build_registry() -> "SourceRegistry":
@@ -77,3 +79,30 @@ def build_runs_store(data_path: str | pathlib.Path) -> "RunsStore":
     from dccd.storage.runs_sqlite import RunsStore
 
     return RunsStore(pathlib.Path(data_path) / ".dccd" / "runs.db")
+
+
+def build_remote(cfg: "AppConfig") -> "RemoteStorage | None":
+    """Return a :class:`~dccd.storage.remote.RemoteStorage`, or ``None``.
+
+    Returns ``None`` when no rclone remotes are configured (``storage.remotes``
+    empty) — there is nothing to sync, so the daemon skips the sync loop. The
+    local root is ``settings.data_path`` (the canonical store root used by
+    :func:`build_store`).
+
+    Parameters
+    ----------
+    cfg : AppConfig
+
+    Returns
+    -------
+    RemoteStorage or None
+    """
+    if not cfg.storage.remotes:
+        return None
+
+    from dccd.storage.remote import RemoteStorage
+
+    return RemoteStorage(
+        cfg.settings.data_path,
+        [r.model_dump() for r in cfg.storage.remotes],
+    )

--- a/dccd/interfaces/cli/main.py
+++ b/dccd/interfaces/cli/main.py
@@ -146,6 +146,7 @@ def cmd_start(
     from dccd.application.scheduler import Scheduler
     from dccd.application.service_factory import (
         build_registry,
+        build_remote,
         build_runs_store,
         build_store,
     )
@@ -156,7 +157,16 @@ def cmd_start(
     runs_store = build_runs_store(cfg.settings.data_path)
     registry = build_registry()
     bus = EventBus()
-    scheduler = Scheduler(registry, store, runs_store, bus)
+    remote = build_remote(cfg)
+    scheduler = Scheduler(
+        registry, store, runs_store, bus,
+        remote=remote, sync_interval=cfg.storage.sync_interval,
+    )
+    if remote is not None:
+        typer.echo(
+            f"Remote sync every {cfg.storage.sync_interval}s "
+            f"→ {len(cfg.storage.remotes)} remote(s)"
+        )
 
     # Run *all* configured jobs, not just streams: the scheduler routes each by
     # trigger kind (supervised → stream worker; interval/cron → periodic

--- a/dccd/tests/v3/test_remote_sync.py
+++ b/dccd/tests/v3/test_remote_sync.py
@@ -1,0 +1,129 @@
+"""Tests for daemon-scheduled rclone remote sync.
+
+Covers the wiring added so ``dccd start`` actually drives the existing
+:class:`~dccd.storage.remote.RemoteStorage` on a periodic loop (it was
+implemented but never instantiated outside tests). No rclone is invoked — a fake
+remote stands in for ``sync_all``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from dccd.application.config import AppConfig, RemoteConfig, StorageConfig
+from dccd.application.events import EventBus, LogEvent, StatusEvent
+from dccd.application.scheduler import Scheduler
+from dccd.application.service_factory import (
+    build_registry,
+    build_remote,
+    build_runs_store,
+    build_store,
+)
+from dccd.storage.remote import RemoteStorage
+
+
+class _FakeRemote:
+    """Stand-in for RemoteStorage.sync_all that counts calls (no rclone)."""
+
+    def __init__(self, result: dict[str, bool] | None = None, raises: bool = False):
+        self._result = result if result is not None else {"r:bucket": True}
+        self._raises = raises
+        self.calls = 0
+
+    async def sync_all(self) -> dict[str, bool]:
+        self.calls += 1
+        if self._raises:
+            raise RuntimeError("boom")
+        return self._result
+
+
+def _scheduler(tmp_path, *, remote, sync_interval=0.02, runs_store=None, bus=None):
+    return Scheduler(
+        build_registry(),
+        build_store(tmp_path),
+        runs_store,
+        bus or EventBus(),
+        remote=remote,
+        sync_interval=sync_interval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_remote factory
+# ---------------------------------------------------------------------------
+
+class TestBuildRemote:
+    def test_none_without_remotes(self):
+        assert build_remote(AppConfig()) is None
+
+    def test_remote_rooted_at_data_path(self):
+        cfg = AppConfig(
+            settings={"data_path": "/tmp/dccd-store"},
+            storage=StorageConfig(remotes=[RemoteConfig(remote="myremote:bucket")]),
+        )
+        remote = build_remote(cfg)
+        assert isinstance(remote, RemoteStorage)
+        # Local root is settings.data_path (the canonical store root).
+        assert str(remote._local) == "/tmp/dccd-store"
+
+
+# ---------------------------------------------------------------------------
+# Scheduler sync loop
+# ---------------------------------------------------------------------------
+
+class TestSyncLoop:
+    async def test_daemon_drives_sync(self, tmp_path):
+        """The regression guard: start() must schedule the sync loop."""
+        fake = _FakeRemote()
+        sched = _scheduler(tmp_path, remote=fake)
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        assert fake.calls >= 1
+        assert sched._sync_task is None
+
+    async def test_no_remote_no_task(self, tmp_path):
+        sched = _scheduler(tmp_path, remote=None)
+        await sched.start([])
+        assert sched._sync_task is None
+        await sched.stop()  # clean
+
+    async def test_failure_surfaces_and_loop_survives(self, tmp_path):
+        bus = EventBus()
+        queue = bus.add_queue()
+        runs_store = build_runs_store(tmp_path)
+        fake = _FakeRemote(result={"r:bucket": False})
+        sched = _scheduler(tmp_path, remote=fake, runs_store=runs_store, bus=bus)
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+
+        # Loop kept running despite failures.
+        assert fake.calls >= 1
+        # A failed status + an error log were emitted on the remote-sync channel.
+        events = []
+        while not queue.empty():
+            events.append(queue.get_nowait())
+        assert any(
+            isinstance(e, StatusEvent) and e.run_id == "remote-sync"
+            and e.state == "failed"
+            for e in events
+        )
+        assert any(
+            isinstance(e, LogEvent) and e.level == "error" for e in events
+        )
+        # And the failure was persisted as a `sync` run.
+        runs = runs_store.list_runs(limit=50)
+        assert any(r["operation"] == "sync" and r["state"] == "failed" for r in runs)
+
+    async def test_success_persisted(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        fake = _FakeRemote(result={"r:bucket": True})
+        sched = _scheduler(tmp_path, remote=fake, runs_store=runs_store)
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        runs = runs_store.list_runs(limit=50)
+        assert any(
+            r["operation"] == "sync" and r["state"] == "succeeded" for r in runs
+        )

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #XX) [accepted]
+### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #86) [accepted]
 - **Choice**: schedule the existing `RemoteStorage.sync_all` from `dccd start` by
   giving `Scheduler` an optional `remote`/`sync_interval` and a `_sync_loop`
   (mirroring the existing interval-loop pattern), and record each cycle as a

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,24 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #XX) [accepted]
+- **Choice**: schedule the existing `RemoteStorage.sync_all` from `dccd start` by
+  giving `Scheduler` an optional `remote`/`sync_interval` and a `_sync_loop`
+  (mirroring the existing interval-loop pattern), and record each cycle as a
+  `sync` run in `RunsStore` (zero schema change) while emitting live `remote-sync`
+  EventBus status. Wiring goes through `service_factory.build_remote`.
+- **Why**: `RemoteStorage` was fully implemented but never instantiated outside
+  tests, so a server `dccd start` mirrored nothing off-box. Owning the loop in the
+  Scheduler makes it unit-testable without rclone and gives clean teardown via the
+  existing `stop()`. Persisting a run row makes the sync observable after the fact
+  (the Storage page is a plain GET) — the keystone the upcoming UI (PR2) reads.
+  This is PR 1 of a 4-PR Epic C (tiered storage: sync → UI → coverage manifest →
+  free-space purge).
+- **Rejected alternatives**: firing rclone directly from `cmd_start` (untestable,
+  no reconcile/stop, no status surface); a new always-on service object (more
+  wiring than a scheduler loop for no gain); EventBus-only with no persistence
+  (status vanishes on UI refresh, so the Storage page couldn't show "last sync").
+
 ### 2026-06-07 — v3 docs sweep: drop the v2 migration story, consolidate examples (PR #82) [accepted]
 - **Choice**: removed the README "Migrating from v2" section (and every `dccd
   migrate` mention) outright rather than keeping a slim note; consolidated

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -40,8 +40,11 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   impractical.
 - **Order-book history** doesn't exist on any exchange for free — you build it by
   recording the live WS over time (snapshot per `snapshot_interval`).
-- **Remote data sync** (`storage/remote.py`, rclone) exists; confirm it's actually
-  scheduled by `dccd start` before relying on it unattended (see roadmap).
+- **Remote data sync** (`storage/remote.py`, rclone) is now **scheduled by
+  `dccd start`** — a periodic loop mirrors the store off-box every
+  `storage.sync_interval` (backoff + persisted `sync` runs + `remote-sync`
+  EventBus status). Still pending in Epic C: UI surfacing, a coverage manifest so
+  local files can be dropped without re-downloading, and free-space purge.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -63,14 +63,9 @@ Goal: open the dashboard securely from a laptop or phone, not just `localhost`.
 Goal: the Parquet store is mirrored to off-box storage (S3/B2/Drive/…) so a server
 loss doesn't lose data.
 
-- [~] **rclone sync exists** — `storage/remote.py` (`RemoteStorage.sync_one/
-  sync_all`) + `StorageConfig.remotes` + `sync_interval`. **Verify it's actually
-  scheduled** by `dccd start` (a periodic task), not just callable.
-- [ ] **Scheduled sync in the daemon** — if not wired, add a periodic sync task
-  (interval = `sync_interval`) with backoff + failure surfacing via EventBus/UI
-  ("last sync: …", already a v2 concept).
 - [ ] **Surface sync status in the UI** — last successful sync time + errors on
-  the Storage page; manual "Sync now" button (API endpoint).
+  the Storage page; manual "Sync now" button (API endpoint). *(Next PR — the
+  daemon already persists `sync` runs + emits a `remote-sync` EventBus status.)*
 - [ ] **rclone provisioning docs** — how to configure a remote (`rclone config`)
   in the container/host; mount or inject `rclone.conf` securely.
 - [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document


### PR DESCRIPTION
## Summary
- `dccd start` now actually drives the existing `RemoteStorage` on a periodic loop — previously it was implemented but never instantiated outside tests, so a server synced **nothing** off-box.

## Why
- First PR of a 4-PR Epic C (tiered storage). `RemoteStorage.sync_all` was dead code from the daemon's perspective; `cmd_start` never scheduled it and `Scheduler` had no remote-sync concept.
- The loop is owned by `Scheduler` (mirrors the existing interval-loop pattern) so it's unit-testable without rclone and gets clean teardown via `stop()`. Each cycle is persisted as a `sync` run in `RunsStore` (zero schema change) so the upcoming Storage UI (PR2) can show "last sync" — the page is a plain GET.

## Changes
- `service_factory.build_remote(cfg)` — returns a `RemoteStorage` rooted at `settings.data_path`, or `None` when no remotes are configured.
- `Scheduler` — new `remote`/`sync_interval` kwargs; `start()` launches `_sync_loop` (exponential backoff 30s→cap, persisted `sync` runs, live `remote-sync` EventBus status); `stop()` cancels it cleanly.
- `cmd_start` — wires `build_remote(cfg)` in and logs the cadence on startup.
- `test_remote_sync.py` — 6 tests incl. the regression guard "the daemon drives the sync", failure-surfacing + persistence.

## Changelog
Added under [Unreleased]:
- Daemon schedules rclone remote sync (`storage.remotes`/`sync_interval`) with backoff, persisted run history + live EventBus status.

## Test plan
- [x] `pytest` passes locally (188 passed, 3 network deselected)
- [x] `ruff check dccd/` passes
- [x] `mypy dccd/` clean · `cd doc && make html` 0 warnings
- [ ] CI green