### PR TITLE
feat: surface remote sync status in the Storage UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a
   live `remote-sync` EventBus status. Previously `RemoteStorage` was implemented
   but never driven — a server synced nothing. (#86)
+- Storage page surfaces remote sync: last/next sync, status, configured remotes
+  and synced volume, plus a **Sync now** button — backed by
+  `GET`/`POST /api/storage/sync`. The shared `operations.sync_remote` primitive
+  records each cycle, so the manual button and the scheduled loop stay in sync. (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Storage page surfaces remote sync: last/next sync, status, configured remotes
   and synced volume, plus a **Sync now** button — backed by
   `GET`/`POST /api/storage/sync`. The shared `operations.sync_remote` primitive
-  records each cycle, so the manual button and the scheduled loop stay in sync. (#XX)
+  records each cycle, so the manual button and the scheduled loop stay in sync. (#87)
 
 ### Changed
 

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -28,9 +28,10 @@ from dccd.domain.types import DataType
 from dccd.sources.base import OHLCHistory, OrderBookSnapshotREST, TradesHistory
 from dccd.sources.registry import SourceRegistry
 from dccd.storage.parquet import ParquetStore
+from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
 
-__all__ = ["backfill", "stream", "read", "inventory"]
+__all__ = ["backfill", "stream", "read", "inventory", "sync_remote"]
 
 logger = logging.getLogger(__name__)
 
@@ -470,3 +471,66 @@ def read(
 def inventory(*, store: ParquetStore) -> list[dict[str, Any]]:
     """Return a list of dataset descriptors for all stored data."""
     return store.inventory()
+
+
+async def sync_remote(
+    remote: RemoteStorage,
+    *,
+    runs_store: RunsStore | None = None,
+    events: RunEvents | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Run one remote-sync cycle: mirror the local store to all rclone remotes.
+
+    Records the cycle as a ``sync`` run in *runs_store* (so the Storage UI can
+    show "last sync") and emits ``status``/``log`` on *events*. Shared by the
+    scheduler's periodic loop and the manual "Sync now" endpoint, so the
+    run-recording lives in exactly one place.
+
+    Parameters
+    ----------
+    remote : RemoteStorage
+    runs_store : RunsStore or None
+    events : RunEvents or None
+    run_id : str or None
+        Override the auto-generated run id.
+
+    Returns
+    -------
+    dict
+        ``{'run_id', 'results', 'ok'}`` — ``results`` maps remote → success;
+        ``ok`` is True only when every configured remote synced.
+    """
+    if run_id is None:
+        run_id = f"remote-sync@{time.time_ns()}"
+    if runs_store:
+        runs_store.create_run(run_id, "remote-sync", "sync", "-", "all", "-")
+    if events:
+        events.status("running")
+    try:
+        results = await remote.sync_all()
+    except Exception as exc:
+        msg = f"Remote sync error: {exc}"
+        if events:
+            events.log(msg, "error")
+            events.status("failed")
+        if runs_store:
+            runs_store.finish_run(run_id, "failed", error=str(exc))
+        return {"run_id": run_id, "results": {}, "ok": False}
+
+    failed = [r for r, ok in results.items() if not ok]
+    if failed:
+        msg = f"Remote sync failed for: {', '.join(failed)}"
+        if events:
+            events.log(msg, "error")
+            events.status("failed")
+        if runs_store:
+            runs_store.finish_run(run_id, "failed", error=msg)
+        return {"run_id": run_id, "results": results, "ok": False}
+
+    if events:
+        events.log(f"Synced {len(results)} remote(s)")
+        events.status("succeeded")
+    if runs_store:
+        runs_store.finish_run(run_id, "succeeded", rows_written=len(results))
+    return {"run_id": run_id, "results": results, "ok": True}

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -240,53 +240,31 @@ class Scheduler:
         """Periodically mirror the local store to the configured rclone remotes.
 
         Runs only when a :class:`~dccd.storage.remote.RemoteStorage` was wired in
-        (``storage.remotes`` non-empty). Each cycle is recorded as a ``sync`` run
-        in :class:`RunsStore` (so the Storage UI can show "last sync") and emitted
-        live on the ``remote-sync`` EventBus channel. On failure it backs off
-        exponentially (30s → capped at ``sync_interval``) so a flapping remote
-        doesn't hammer rclone.
+        (``storage.remotes`` non-empty). Each cycle is delegated to
+        :func:`dccd.application.operations.sync_remote` (which records a ``sync``
+        run in :class:`RunsStore` and emits live ``remote-sync`` EventBus status);
+        this loop only owns the cadence and the exponential backoff on failure
+        (30s → capped at ``sync_interval``) so a flapping remote doesn't hammer
+        rclone.
         """
+        from dccd.application.operations import sync_remote
         assert self._remote is not None
         run_events = self._events.for_run("remote-sync")
         backoff = 30.0
-        while self._running:
-            run_id = f"remote-sync@{time.time_ns()}"
-            if self._runs_store:
-                self._runs_store.create_run(
-                    run_id, "remote-sync", "sync", "-", "all", "-"
+        try:
+            while self._running:
+                result = await sync_remote(
+                    self._remote, runs_store=self._runs_store, events=run_events
                 )
-            run_events.status("running")
-            try:
-                results = await self._remote.sync_all()
-                failed = [r for r, ok in results.items() if not ok]
-                if failed:
-                    msg = f"Remote sync failed for: {', '.join(failed)}"
-                    run_events.log(msg, "error")
-                    run_events.status("failed")
-                    if self._runs_store:
-                        self._runs_store.finish_run(run_id, "failed", error=msg)
+                if result["ok"]:
+                    backoff = 30.0
+                    await asyncio.sleep(self._sync_interval)
+                else:
+                    logger.warning("Remote sync failed — retry in %ds", int(backoff))
                     await asyncio.sleep(min(backoff, self._sync_interval))
                     backoff = min(backoff * 2, float(self._sync_interval))
-                    continue
-                run_events.log(f"Synced {len(results)} remote(s)")
-                run_events.status("succeeded")
-                if self._runs_store:
-                    self._runs_store.finish_run(
-                        run_id, "succeeded", rows_written=len(results)
-                    )
-                backoff = 30.0
-                await asyncio.sleep(self._sync_interval)
-            except asyncio.CancelledError:
-                return
-            except Exception as exc:
-                msg = f"Remote sync error: {exc}"
-                logger.warning("%s — retry in %ds", msg, int(backoff))
-                run_events.log(msg, "error")
-                run_events.status("failed")
-                if self._runs_store:
-                    self._runs_store.finish_run(run_id, "failed", error=str(exc))
-                await asyncio.sleep(min(backoff, self._sync_interval))
-                backoff = min(backoff * 2, float(self._sync_interval))
+        except asyncio.CancelledError:
+            return
 
     async def _interval_loop(self, spec: JobSpec) -> None:
         every = spec.trigger.every or spec.target.span or 3600

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -41,10 +41,12 @@ from dccd.application.registry import REGISTRY
 from dccd.application.scheduler import Scheduler
 from dccd.application.service_factory import (
     build_registry,
+    build_remote,
     build_runs_store,
     build_store,
 )
 from dccd.domain.symbol import Symbol
+from dccd.domain.timeutils import NS
 from dccd.domain.types import DataType
 from dccd.storage.runs_sqlite import RunsStore
 
@@ -169,6 +171,10 @@ def create_app(
         app.state.runs_store = build_runs_store(cfg.settings.data_path)
         app.state.event_bus = EventBus()
         app.state.registry = build_registry()
+        # Remote sync target (None when storage.remotes is empty). Resolved from
+        # config — not the scheduler — so "Sync now" works in `dccd ui` mode too,
+        # where the standalone scheduler has no remote wired in.
+        app.state.remote = build_remote(cfg)
 
         if scheduler is not None:
             app.state.scheduler = scheduler
@@ -337,6 +343,58 @@ def create_app(
     async def get_inventory(request: Request) -> dict[str, Any]:
         """Return all stored datasets."""
         return {"datasets": _store(request).inventory()}
+
+    # -----------------------------------------------------------------------
+    # Remote sync
+    # -----------------------------------------------------------------------
+
+    @app.get("/api/storage/sync")
+    async def get_sync_status(request: Request) -> dict[str, Any]:
+        """Remote-sync status for the Storage page.
+
+        Reports whether remotes are configured, the last persisted ``sync`` run
+        (state/time/error), the next scheduled sync ETA, and the on-disk store
+        size (the "synced volume" proxy — after a successful mirror local equals
+        remote).
+        """
+        cfg = _cfg(request)
+        remotes = [r.remote for r in cfg.storage.remotes]
+        configured = bool(remotes)
+        interval = cfg.storage.sync_interval
+        runs = _runs(request).list_runs(spec_id="remote-sync", limit=1)
+        last = None
+        next_eta = None
+        if runs:
+            r = runs[0]
+            last = {
+                "state": r["state"],
+                "ended_at": r["ended_at"],
+                "error": r["error"],
+                "rows_written": r["rows_written"],
+            }
+            if configured and r["ended_at"]:
+                next_eta = r["ended_at"] + interval * NS
+        total_bytes = sum(d.get("bytes", 0) for d in _store(request).inventory())
+        return {
+            "configured": configured,
+            "remotes": remotes,
+            "sync_interval": interval,
+            "last": last,
+            "next_eta": next_eta,
+            "bytes": total_bytes,
+        }
+
+    @app.post("/api/storage/sync")
+    async def trigger_sync(request: Request) -> dict[str, Any]:
+        """Trigger a remote sync now (runs in the background)."""
+        remote = request.app.state.remote
+        if remote is None:
+            raise HTTPException(400, "no remotes configured")
+        from dccd.application.operations import sync_remote
+
+        events = request.app.state.event_bus.for_run("remote-sync")
+        _spawn(request, sync_remote(remote, runs_store=_runs(request), events=events))
+        return {"status": "started"}
 
     # -----------------------------------------------------------------------
     # Backfill

--- a/dccd/interfaces/ui/templates/storage.html
+++ b/dccd/interfaces/ui/templates/storage.html
@@ -4,12 +4,65 @@
 <h1>Storage</h1>
 
 <div class="card">
+  <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem">
+    <h2 style="margin:0">Remote sync</h2>
+    <button id="sync-now" type="button" onclick="syncNow()" style="display:none">Sync now</button>
+  </div>
+  <div id="sync-content" style="margin-top:.75rem"><span class="muted">Loading…</span></div>
+</div>
+
+<div class="card">
   <h2 style="margin-top:0">Datasets on disk</h2>
   <div id="inv-content"><span class="muted">Loading…</span></div>
 </div>
 {% endblock %}
 {% block scripts %}
 <script>
+const SYNC_DOT = { succeeded: 'fresh', running: 'stale', failed: 'dead' };
+
+async function loadSync() {
+  try {
+    const s = await api('GET', '/api/storage/sync');
+    const btn = document.getElementById('sync-now');
+    if (!s.configured) {
+      btn.style.display = 'none';
+      document.getElementById('sync-content').innerHTML =
+        '<span class="muted">No remote configured — add <code>storage.remotes</code> on the Config page.</span>';
+      return;
+    }
+    btn.style.display = '';
+    const st = s.last ? s.last.state : null;
+    const dot = SYNC_DOT[st] || 'dead';
+    const lastLabel = s.last && s.last.ended_at ? fmtFreshness(s.last.ended_at)
+      : (st === 'running' ? 'running…' : 'never');
+    let html = `<p style="margin:.2rem 0">
+      <span class="live-dot ${dot}"></span>
+      <strong>Last sync:</strong> ${escapeHtml(lastLabel)}${st ? ` <span class="muted">(${escapeHtml(st)})</span>` : ''}
+    </p>`;
+    if (s.next_eta) html += `<p class="muted" style="margin:.2rem 0">Next sync: ${fmtNs(s.next_eta)}</p>`;
+    html += `<p class="muted" style="margin:.2rem 0">Remotes: ${s.remotes.map(escapeHtml).join(', ')} · Synced volume: ${fmtBytes(s.bytes)}</p>`;
+    if (s.last && s.last.state === 'failed' && s.last.error)
+      html += `<p class="err" style="margin:.2rem 0">${escapeHtml(s.last.error)}</p>`;
+    document.getElementById('sync-content').innerHTML = html;
+  } catch (e) {
+    document.getElementById('sync-content').innerHTML = `<span class="err">${escapeHtml(e.message)}</span>`;
+  }
+}
+
+async function syncNow() {
+  const btn = document.getElementById('sync-now');
+  btn.disabled = true;
+  try {
+    await api('POST', '/api/storage/sync');
+    // Poll a few times so the result lands without a manual refresh.
+    for (const ms of [400, 1200, 3000]) setTimeout(loadSync, ms);
+  } catch (e) {
+    document.getElementById('sync-content').innerHTML = `<span class="err">${escapeHtml(e.message)}</span>`;
+  } finally {
+    setTimeout(() => { btn.disabled = false; }, 1000);
+  }
+}
+
 async function loadInventory() {
   try {
     const { datasets } = await api('GET', '/api/inventory');
@@ -48,6 +101,8 @@ async function loadInventory() {
   }
 }
 
+loadSync();
 loadInventory();
+setInterval(loadSync, 10000);
 </script>
 {% endblock %}

--- a/dccd/tests/v3/test_api.py
+++ b/dccd/tests/v3/test_api.py
@@ -4,7 +4,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from dccd.application.config import AppConfig
+from dccd.application.config import AppConfig, RemoteConfig
 from dccd.interfaces.api.app import create_app
 
 
@@ -65,6 +65,54 @@ class TestAuth:
 
     def test_no_token_means_open(self, client):
         assert client.get("/api/inventory").status_code == 200
+
+
+class _OkRemote:
+    """In-test remote that reports success without invoking rclone."""
+
+    async def sync_all(self):
+        return {"r:bucket": True}
+
+
+class TestRemoteSync:
+    @pytest.fixture
+    def synced_app(self, tmp_data_path):
+        cfg = AppConfig()
+        cfg.settings.data_path = tmp_data_path
+        cfg.storage.local_path = tmp_data_path
+        cfg.storage.remotes = [RemoteConfig(remote="r:bucket")]
+        cfg.storage.sync_interval = 1800
+        return create_app(config=cfg)
+
+    def test_get_sync_not_configured(self, client):
+        body = client.get("/api/storage/sync").json()
+        assert body["configured"] is False
+        assert body["remotes"] == []
+        assert body["last"] is None
+
+    def test_get_sync_configured_with_last(self, synced_app, tmp_data_path):
+        from dccd.application.service_factory import build_runs_store
+
+        with TestClient(synced_app) as c:
+            runs = build_runs_store(tmp_data_path)
+            runs.create_run("remote-sync@1", "remote-sync", "sync", "-", "all", "-")
+            runs.finish_run("remote-sync@1", "succeeded", rows_written=1)
+            body = c.get("/api/storage/sync").json()
+            assert body["configured"] is True
+            assert body["remotes"] == ["r:bucket"]
+            assert body["sync_interval"] == 1800
+            assert body["last"]["state"] == "succeeded"
+            assert body["next_eta"] is not None
+
+    def test_post_sync_no_remotes_400(self, client):
+        assert client.post("/api/storage/sync").status_code == 400
+
+    def test_post_sync_started(self, synced_app):
+        with TestClient(synced_app) as c:
+            c.app.state.remote = _OkRemote()  # avoid spawning a real rclone call
+            r = c.post("/api/storage/sync")
+            assert r.status_code == 200
+            assert r.json()["status"] == "started"
 
 
 class TestOperationsEndpoint:

--- a/dccd/tests/v3/test_remote_sync.py
+++ b/dccd/tests/v3/test_remote_sync.py
@@ -12,6 +12,7 @@ import asyncio
 
 from dccd.application.config import AppConfig, RemoteConfig, StorageConfig
 from dccd.application.events import EventBus, LogEvent, StatusEvent
+from dccd.application.operations import sync_remote
 from dccd.application.scheduler import Scheduler
 from dccd.application.service_factory import (
     build_registry,
@@ -127,3 +128,45 @@ class TestSyncLoop:
         assert any(
             r["operation"] == "sync" and r["state"] == "succeeded" for r in runs
         )
+
+
+# ---------------------------------------------------------------------------
+# sync_remote — the shared one-cycle primitive (loop + manual endpoint reuse it)
+# ---------------------------------------------------------------------------
+
+class TestSyncRemoteOnce:
+    async def test_success(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        bus = EventBus()
+        queue = bus.add_queue()
+        result = await sync_remote(
+            _FakeRemote(result={"r:bucket": True}),
+            runs_store=runs_store,
+            events=bus.for_run("remote-sync"),
+        )
+        assert result["ok"] is True
+        runs = runs_store.list_runs(spec_id="remote-sync", limit=1)
+        assert runs and runs[0]["state"] == "succeeded"
+        events = []
+        while not queue.empty():
+            events.append(queue.get_nowait())
+        assert any(
+            isinstance(e, StatusEvent) and e.state == "succeeded" for e in events
+        )
+
+    async def test_failure_persists_and_returns_not_ok(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        result = await sync_remote(
+            _FakeRemote(result={"r:bucket": False}),
+            runs_store=runs_store,
+        )
+        assert result["ok"] is False
+        runs = runs_store.list_runs(spec_id="remote-sync", limit=1)
+        assert runs and runs[0]["state"] == "failed"
+
+    async def test_exception_is_caught(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        result = await sync_remote(_FakeRemote(raises=True), runs_store=runs_store)
+        assert result["ok"] is False
+        runs = runs_store.list_runs(spec_id="remote-sync", limit=1)
+        assert runs and runs[0]["state"] == "failed"

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #XX) [accepted]
+- **Choice**: extract the single sync cycle (create run → `sync_all` → finish +
+  events) into `operations.sync_remote`, reused by both the scheduler loop and a
+  new manual `POST /api/storage/sync`. The Storage page reads `GET
+  /api/storage/sync` (last/next/volume/remotes) and gets a "Sync now" button. The
+  manual endpoint resolves the remote from **config** (`app.state.remote =
+  build_remote(cfg)` in the lifespan), not from the scheduler.
+- **Why**: in `dccd ui` mode the standalone scheduler has no remote wired in, so
+  reading it from the scheduler would make "Sync now" silently dead there;
+  resolving from config works in both `dccd ui` and `dccd start`. Sharing
+  `sync_remote` keeps run-recording in one place so the manual and scheduled
+  paths can't drift. The page persists status (a plain GET) via the existing
+  `sync` runs; no SSE — kept deliberately light per the user's ask.
+- **Rejected alternatives**: duplicate the run-recording in the endpoint (drift
+  risk); drive the sync from `scheduler._remote` (dead in `dccd ui`); push live
+  status over SSE on the Storage page (heavier than asked — a 10s poll suffices).
+
 ### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #86) [accepted]
 - **Choice**: schedule the existing `RemoteStorage.sync_all` from `dccd start` by
   giving `Scheduler` an optional `remote`/`sync_interval` and a `_sync_loop`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #XX) [accepted]
+### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #87) [accepted]
 - **Choice**: extract the single sync cycle (create run → `sync_all` → finish +
   events) into `operations.sync_remote`, reused by both the scheduler loop and a
   new manual `POST /api/storage/sync`. The Storage page reads `GET

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -43,8 +43,9 @@ _(nothing release-blocking — see the roadmap for the next epics)_
 - **Remote data sync** (`storage/remote.py`, rclone) is now **scheduled by
   `dccd start`** — a periodic loop mirrors the store off-box every
   `storage.sync_interval` (backoff + persisted `sync` runs + `remote-sync`
-  EventBus status). Still pending in Epic C: UI surfacing, a coverage manifest so
-  local files can be dropped without re-downloading, and free-space purge.
+  EventBus status), and the **Storage page shows last/next sync + volume with a
+  "Sync now" button**. Still pending in Epic C: a coverage manifest so local files
+  can be dropped without re-downloading, and free-space purge.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -63,9 +63,6 @@ Goal: open the dashboard securely from a laptop or phone, not just `localhost`.
 Goal: the Parquet store is mirrored to off-box storage (S3/B2/Drive/…) so a server
 loss doesn't lose data.
 
-- [ ] **Surface sync status in the UI** — last successful sync time + errors on
-  the Storage page; manual "Sync now" button (API endpoint). *(Next PR — the
-  daemon already persists `sync` runs + emits a `remote-sync` EventBus status.)*
 - [ ] **rclone provisioning docs** — how to configure a remote (`rclone config`)
   in the container/host; mount or inject `rclone.conf` securely.
 - [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document


### PR DESCRIPTION
## Summary
- The Storage page now shows remote-sync state — last/next sync, status, configured remotes, synced volume — plus a **Sync now** button. PR 2 of the Epic C tiered-storage series (after #86 wired the daemon sync).

## Why
- #86 made the daemon persist `sync` runs + emit `remote-sync` EventBus status, but nothing surfaced it. This closes the "Surface sync status in the UI" roadmap item.
- "Sync now" resolves the remote from **config** (`app.state.remote = build_remote(cfg)`), not the scheduler, because in `dccd ui` mode the standalone scheduler has no remote wired in — reading it there would make the button silently dead.
- Extracted `operations.sync_remote` as the single sync-cycle primitive reused by both the scheduled loop and the manual endpoint, so run-recording can't drift between them.

## Changes
- `operations.sync_remote(remote, *, runs_store, events, run_id)` — one cycle: create `sync` run → `sync_all` → finish + events. `Scheduler._sync_loop` now delegates to it (keeps only cadence + backoff).
- API: `GET /api/storage/sync` (configured/remotes/interval/last/next_eta/bytes) and `POST /api/storage/sync` (spawns a background sync; 400 when no remotes).
- UI: a "Remote sync" card in `storage.html` with status dot, last/next sync, remotes, synced volume, error line, and a "Sync now" button (10s light poll, no SSE).
- Tests: `sync_remote` happy/failure/exception; `GET`/`POST /api/storage/sync` shape + 400.

## Changelog
Added under [Unreleased]:
- Storage page surfaces remote sync (last/next/volume) + Sync now; `GET`/`POST /api/storage/sync`.

## Test plan
- [x] `pytest` (195 passed, 3 network deselected)
- [x] `ruff check dccd/` · `mypy dccd/` clean · `cd doc && make html` 0 warnings
- [x] Live smoke: `dccd ui` with a configured remote — card renders, Sync now records a run, next-sync ETA computed
- [ ] CI green