### PR TITLE
feat: coverage manifest so dropped local data isn't re-downloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and synced volume, plus a **Sync now** button — backed by
   `GET`/`POST /api/storage/sync`. The shared `operations.sync_remote` primitive
   records each cycle, so the manual button and the scheduled loop stay in sync. (#87)
+- Coverage manifest (`CoverageStore`, SQLite under `.dccd/`): backfill records each
+  dataset's `[min_ts, max_ts]` extent, and `start="last"` falls back to the
+  manifest's `max_ts` when no local file exists — so local data can be dropped to
+  free disk without forcing a re-download on the next backfill. (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Coverage manifest (`CoverageStore`, SQLite under `.dccd/`): backfill records each
   dataset's `[min_ts, max_ts]` extent, and `start="last"` falls back to the
   manifest's `max_ts` when no local file exists — so local data can be dropped to
-  free disk without forcing a re-download on the next backfill. (#XX)
+  free disk without forcing a re-download on the next backfill. (#88)
 
 ### Changed
 

--- a/dccd/__init__.py
+++ b/dccd/__init__.py
@@ -70,6 +70,7 @@ class Client:
         self._config: AppConfig | None = None
         self._store: ParquetStore | None = None
         self._registry: SourceRegistry | None = None
+        self._coverage_store: Any = None
 
     def _require_ready(self) -> tuple["SourceRegistry", "ParquetStore"]:
         if self._registry is None or self._store is None:
@@ -78,7 +79,11 @@ class Client:
 
     async def __aenter__(self) -> "Client":
         from dccd.application.config import AppConfig, load_config, resolve_config_path
-        from dccd.application.service_factory import build_registry, build_store
+        from dccd.application.service_factory import (
+            build_coverage_store,
+            build_registry,
+            build_store,
+        )
 
         try:
             path = resolve_config_path(self._config_path)
@@ -88,6 +93,7 @@ class Client:
 
         # Single source of truth for adapter wiring — same as CLI and API.
         self._store = build_store(self._config.settings.data_path)
+        self._coverage_store = build_coverage_store(self._config.settings.data_path)
         self._registry = build_registry()
         return self
 
@@ -156,7 +162,8 @@ class Client:
             origin="runtime",
         )
         registry, store = self._require_ready()
-        return await do_backfill(spec, registry=registry, store=store)
+        return await do_backfill(spec, registry=registry, store=store,
+                                 coverage_store=self._coverage_store)
 
     async def stream(self, exchange: str, symbol: str, data_type: str = "trades",
                      span: int | None = None, depth: int | None = None,

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -27,6 +27,7 @@ from dccd.domain.timeutils import NS, ns_now, ns_to_dt
 from dccd.domain.types import DataType
 from dccd.sources.base import OHLCHistory, OrderBookSnapshotREST, TradesHistory
 from dccd.sources.registry import SourceRegistry
+from dccd.storage.coverage_sqlite import CoverageStore
 from dccd.storage.parquet import ParquetStore
 from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
@@ -113,6 +114,7 @@ async def backfill(
     registry: SourceRegistry,
     store: ParquetStore,
     runs_store: RunsStore | None = None,
+    coverage_store: CoverageStore | None = None,
     events: RunEvents | None = None,
     stop_event: asyncio.Event | None = None,
     run_id: str | None = None,
@@ -137,6 +139,10 @@ async def backfill(
     registry : SourceRegistry
     store : ParquetStore
     runs_store : RunsStore or None
+    coverage_store : CoverageStore or None
+        When set, ``start="last"`` falls back to the manifest's recorded
+        ``max_ts`` if no local file exists (so a dropped store doesn't trigger a
+        re-download), and the dataset's extent is recorded on success.
     events : RunEvents or None
     stop_event : asyncio.Event or None
         Set externally to cancel mid-run cleanly.
@@ -170,6 +176,11 @@ async def backfill(
 
     if params.start == "last":
         last = store.last_timestamp(ds)
+        if last is None and coverage_store is not None:
+            # Local files may have been dropped to free disk; the coverage
+            # manifest remembers how far we got, so we resume from there instead
+            # of re-downloading from the bounded default lookback.
+            last = coverage_store.get_max_ts(ds)
         if last is not None:
             start_ns: int = last + 1
         else:
@@ -200,6 +211,17 @@ async def backfill(
 
     # Counts every item received from the paginator, including unflushed ones.
     _collected: list[int] = [0]
+
+    # Min/max timestamp seen this run, fed to the coverage manifest on success so
+    # the dataset's extent survives a local-data drop (see CoverageStore).
+    _run_min: list[int | None] = [None]
+    _run_max: list[int | None] = [None]
+
+    def _track_ts(ts: int) -> None:
+        if _run_min[0] is None or ts < _run_min[0]:
+            _run_min[0] = ts
+        if _run_max[0] is None or ts > _run_max[0]:
+            _run_max[0] = ts
 
     # Progress is reported by *time covered* of the requested window, which gives
     # a real, smooth bar for both OHLC and cursor-paginated trades (the latter
@@ -258,6 +280,7 @@ async def backfill(
                     break
                 bars.append(bar)
                 _collected[0] += 1
+                _track_ts(bar.ts)
                 if _collected[0] % 200 == 0:
                     _emit_time(bar.ts)
                 if len(bars) >= _FLUSH_BATCH:
@@ -296,6 +319,7 @@ async def backfill(
                     break
                 batch.append(trade)
                 _collected[0] += 1
+                _track_ts(trade.ts)
                 if _collected[0] % 1000 == 0:
                     _emit_time(trade.ts)  # progress by time covered, not page count
                 if len(batch) >= _FLUSH_BATCH:
@@ -310,6 +334,7 @@ async def backfill(
                 raise NoCapability(target.exchange, "orderbook", "snapshot")
             depth = params.depth or 50
             snap = await adapter.fetch_orderbook(target.symbol, depth)
+            _track_ts(snap.ts)
             total_written += await _flush(store, ds, [snap], prov_src)
 
     except Exception as exc:
@@ -328,6 +353,12 @@ async def backfill(
         events.status(state)
     if runs_store:
         runs_store.finish_run(run_id, state, rows_written=total_written)
+
+    # Record coverage so this dataset's extent survives a later local-data drop.
+    if coverage_store is not None and _run_max[0] is not None:
+        coverage_store.record(
+            ds, min_ts=_run_min[0], max_ts=_run_max[0], rows_added=total_written
+        )
 
     return {"run_id": run_id, "rows_written": total_written, "start_ns": start_ns, "end_ns": end_ns}
 

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -9,6 +9,7 @@ import time
 from dccd.application.events import EventBus
 from dccd.application.jobs import JobSpec
 from dccd.sources.registry import SourceRegistry
+from dccd.storage.coverage_sqlite import CoverageStore
 from dccd.storage.parquet import ParquetStore
 from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
@@ -106,6 +107,7 @@ class Scheduler:
         events: EventBus | None = None,
         remote: RemoteStorage | None = None,
         sync_interval: int = 3600,
+        coverage_store: CoverageStore | None = None,
     ) -> None:
         self._registry = registry
         self._store = store
@@ -113,6 +115,7 @@ class Scheduler:
         self._events = events or EventBus()
         self._remote = remote
         self._sync_interval = sync_interval
+        self._coverage_store = coverage_store
         self._sync_task: asyncio.Task[None] | None = None
         self._streams: dict[str, _StreamWorker] = {}
         self._interval_tasks: list[asyncio.Task[None]] = []
@@ -281,6 +284,7 @@ class Scheduler:
                 registry=self._registry,
                 store=self._store,
                 runs_store=self._runs_store,
+                coverage_store=self._coverage_store,
                 events=run_events,
             )
         except Exception as exc:

--- a/dccd/application/service_factory.py
+++ b/dccd/application/service_factory.py
@@ -13,11 +13,18 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from dccd.application.config import AppConfig
     from dccd.sources.registry import SourceRegistry
+    from dccd.storage.coverage_sqlite import CoverageStore
     from dccd.storage.parquet import ParquetStore
     from dccd.storage.remote import RemoteStorage
     from dccd.storage.runs_sqlite import RunsStore
 
-__all__ = ["build_registry", "build_store", "build_runs_store", "build_remote"]
+__all__ = [
+    "build_registry",
+    "build_store",
+    "build_runs_store",
+    "build_remote",
+    "build_coverage_store",
+]
 
 
 def build_registry() -> "SourceRegistry":
@@ -79,6 +86,26 @@ def build_runs_store(data_path: str | pathlib.Path) -> "RunsStore":
     from dccd.storage.runs_sqlite import RunsStore
 
     return RunsStore(pathlib.Path(data_path) / ".dccd" / "runs.db")
+
+
+def build_coverage_store(data_path: str | pathlib.Path) -> "CoverageStore":
+    """Return a :class:`~dccd.storage.coverage_sqlite.CoverageStore`.
+
+    The database lives at ``{data_path}/.dccd/coverage.db`` — the manifest that
+    lets local data be dropped without forcing a re-download on the next
+    backfill.
+
+    Parameters
+    ----------
+    data_path : str or Path
+
+    Returns
+    -------
+    CoverageStore
+    """
+    from dccd.storage.coverage_sqlite import CoverageStore
+
+    return CoverageStore(pathlib.Path(data_path) / ".dccd" / "coverage.db")
 
 
 def build_remote(cfg: "AppConfig") -> "RemoteStorage | None":

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -40,6 +40,7 @@ from dccd.application.jobs import JobParams, JobSpec, JobTarget, Trigger
 from dccd.application.registry import REGISTRY
 from dccd.application.scheduler import Scheduler
 from dccd.application.service_factory import (
+    build_coverage_store,
     build_registry,
     build_remote,
     build_runs_store,
@@ -169,6 +170,7 @@ def create_app(
         app.state.config_path = config_path
         app.state.store = build_store(cfg.settings.data_path)
         app.state.runs_store = build_runs_store(cfg.settings.data_path)
+        app.state.coverage_store = build_coverage_store(cfg.settings.data_path)
         app.state.event_bus = EventBus()
         app.state.registry = build_registry()
         # Remote sync target (None when storage.remotes is empty). Resolved from
@@ -184,6 +186,7 @@ def create_app(
                 app.state.store,
                 app.state.runs_store,
                 app.state.event_bus,
+                coverage_store=app.state.coverage_store,
             )
 
         # Register stream workers from config so they can be started/stopped
@@ -308,6 +311,7 @@ def create_app(
         reg = _reg(request)
         store = _store(request)
         runs_store = _runs(request)
+        coverage_store = request.app.state.coverage_store
         bus = _bus(request)
         stops = request.app.state.backfill_stops
         stop_event = asyncio.Event()
@@ -317,6 +321,7 @@ def create_app(
             from dccd.application.operations import backfill
             try:
                 await backfill(spec, registry=reg, store=store, runs_store=runs_store,
+                               coverage_store=coverage_store,
                                events=bus.for_run(run_id), run_id=run_id,
                                stop_event=stop_event)
             except Exception as exc:

--- a/dccd/interfaces/cli/main.py
+++ b/dccd/interfaces/cli/main.py
@@ -45,6 +45,7 @@ def cmd_backfill(
     from dccd.application.jobs import JobParams, JobSpec, JobTarget, Trigger
     from dccd.application.operations import backfill as do_backfill
     from dccd.application.service_factory import (
+        build_coverage_store,
         build_registry,
         build_runs_store,
         build_store,
@@ -55,6 +56,7 @@ def cmd_backfill(
     cfg, _ = _load_cfg(config)
     store = build_store(cfg.settings.data_path)
     runs_store = build_runs_store(cfg.settings.data_path)
+    coverage_store = build_coverage_store(cfg.settings.data_path)
     registry = build_registry()
 
     specs: list[JobSpec] = []
@@ -81,7 +83,8 @@ def cmd_backfill(
     async def _run():
         for spec in specs:
             typer.echo(f"Backfilling {spec.id}…")
-            result = await do_backfill(spec, registry=registry, store=store, runs_store=runs_store)
+            result = await do_backfill(spec, registry=registry, store=store,
+                                       runs_store=runs_store, coverage_store=coverage_store)
             if err := result.get("error"):
                 typer.echo(f"  ✗ {err}", err=True)
             else:
@@ -145,6 +148,7 @@ def cmd_start(
     from dccd.application.events import EventBus
     from dccd.application.scheduler import Scheduler
     from dccd.application.service_factory import (
+        build_coverage_store,
         build_registry,
         build_remote,
         build_runs_store,
@@ -155,12 +159,14 @@ def cmd_start(
     cfg, cfg_path = _load_cfg(config)
     store = build_store(cfg.settings.data_path)
     runs_store = build_runs_store(cfg.settings.data_path)
+    coverage_store = build_coverage_store(cfg.settings.data_path)
     registry = build_registry()
     bus = EventBus()
     remote = build_remote(cfg)
     scheduler = Scheduler(
         registry, store, runs_store, bus,
         remote=remote, sync_interval=cfg.storage.sync_interval,
+        coverage_store=coverage_store,
     )
     if remote is not None:
         typer.echo(

--- a/dccd/storage/coverage_sqlite.py
+++ b/dccd/storage/coverage_sqlite.py
@@ -1,0 +1,134 @@
+"""SQLite-backed coverage manifest.
+
+Records, per dataset, the extent of data we have collected — independent of the
+Parquet files themselves. This is what lets local data be **dropped** (to free
+disk) without forcing a re-download: ``backfill(start="last")`` falls back to the
+manifest's ``max_ts`` when no local file is present, so it resumes from where
+collection left off instead of from the bounded default lookback.
+
+Lives at ``{data_path}/.dccd/coverage.db`` — the ``.dccd`` directory is never
+purged, so the manifest survives a local-data drop.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import sqlite3
+import time
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Generator
+
+if TYPE_CHECKING:
+    from dccd.domain.dataset import DatasetId
+
+__all__ = ["CoverageStore"]
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+
+CREATE TABLE IF NOT EXISTS coverage (
+    dataset_id  TEXT PRIMARY KEY,
+    exchange    TEXT NOT NULL,
+    symbol      TEXT NOT NULL,
+    data_type   TEXT NOT NULL,
+    span        INTEGER,
+    min_ts      INTEGER,
+    max_ts      INTEGER,
+    rows        INTEGER DEFAULT 0,
+    updated_at  INTEGER NOT NULL
+);
+"""
+
+
+class CoverageStore:
+    """Per-dataset coverage manifest (min/max ts + row count).
+
+    Parameters
+    ----------
+    db_path : str or Path
+        Path to the SQLite database file. Created if absent.
+    """
+
+    def __init__(self, db_path: str | pathlib.Path) -> None:
+        self._path = pathlib.Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as conn:
+            conn.executescript(_SCHEMA)
+
+    @contextmanager
+    def _conn(self) -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(str(self._path))
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def record(
+        self,
+        ds: "DatasetId",
+        *,
+        min_ts: int | None,
+        max_ts: int | None,
+        rows_added: int = 0,
+    ) -> None:
+        """Upsert coverage for *ds*, widening the [min_ts, max_ts] envelope.
+
+        ``min_ts``/``max_ts`` are merged with any existing row (min of mins, max
+        of maxes), so a later backfill never *narrows* the recorded extent;
+        ``rows_added`` accumulates (an approximate stored-row tally for display).
+        """
+        key = str(ds)
+        now = int(time.time() * 1_000_000_000)
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT min_ts, max_ts, rows FROM coverage WHERE dataset_id=?",
+                (key,),
+            ).fetchone()
+            if row is not None:
+                new_min = _merge(row["min_ts"], min_ts, min)
+                new_max = _merge(row["max_ts"], max_ts, max)
+                new_rows = (row["rows"] or 0) + rows_added
+                conn.execute(
+                    "UPDATE coverage SET min_ts=?, max_ts=?, rows=?, updated_at=? "
+                    "WHERE dataset_id=?",
+                    (new_min, new_max, new_rows, now, key),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO coverage (dataset_id, exchange, symbol, "
+                    "data_type, span, min_ts, max_ts, rows, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (key, ds.exchange, str(ds.symbol), ds.data_type.value,
+                     ds.span, min_ts, max_ts, rows_added, now),
+                )
+
+    def get_max_ts(self, ds: "DatasetId") -> int | None:
+        """Return the recorded ``max_ts`` for *ds*, or ``None`` if unknown."""
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT max_ts FROM coverage WHERE dataset_id=?", (str(ds),)
+            ).fetchone()
+            return row["max_ts"] if row else None
+
+    def list_all(self) -> list[dict[str, Any]]:
+        """Return every coverage row (most recently updated first)."""
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM coverage ORDER BY updated_at DESC"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+
+def _merge(existing: int | None, incoming: int | None, op: Any) -> int | None:
+    """Combine two optional ints with *op* (min/max), ignoring ``None``."""
+    vals = [v for v in (existing, incoming) if v is not None]
+    return op(vals) if vals else None

--- a/dccd/tests/v3/test_coverage.py
+++ b/dccd/tests/v3/test_coverage.py
@@ -1,0 +1,140 @@
+"""Coverage manifest: remember a dataset's extent so dropped local data isn't
+re-downloaded on the next ``backfill(start="last")``.
+"""
+
+from __future__ import annotations
+
+from dccd.application.jobs import JobParams, JobSpec, JobTarget, Trigger
+from dccd.application.operations import backfill
+from dccd.domain.capability import Capability
+from dccd.domain.dataset import DatasetId
+from dccd.domain.records import OHLCBar
+from dccd.domain.symbol import Symbol
+from dccd.domain.timeutils import NS, ns_now
+from dccd.domain.types import DataType
+from dccd.sources.base import OHLCHistory
+from dccd.storage.coverage_sqlite import CoverageStore
+from dccd.storage.parquet import ParquetStore
+
+_SPAN = 3600
+_SYMBOL = Symbol(base="BTC", quote="USDT")
+
+
+def _ds() -> DatasetId:
+    return DatasetId(exchange="fake", symbol=_SYMBOL, data_type=DataType.OHLC, span=_SPAN)
+
+
+class _FakeOHLC(OHLCHistory):
+    """OHLC adapter that records the start_ns it is asked for and optionally
+    serves a fixed set of bars on the first page."""
+
+    exchange = "fake"
+
+    def __init__(self, bars: list[OHLCBar] | None = None) -> None:
+        self.calls: list[int] = []
+        self._bars = bars or []
+        self._served = False
+
+    def capabilities(self) -> list[Capability]:
+        return [
+            Capability(data_type=DataType.OHLC, transport="rest", mode="historical",
+                       history="full", max_per_request=1000, page_direction="forward"),
+        ]
+
+    async def fetch_ohlc_page(self, symbol, span, start_ns, end_ns, limit):
+        self.calls.append(start_ns)
+        if self._served:
+            return []
+        self._served = True
+        return [b for b in self._bars if start_ns <= b.ts <= end_ns]
+
+
+class _FakeReg:
+    def __init__(self, src): self._s = src
+    def get(self, ex): return self._s
+
+
+# ---------------------------------------------------------------------------
+# CoverageStore unit
+# ---------------------------------------------------------------------------
+
+class TestCoverageStore:
+    def test_record_and_get_max(self, tmp_path):
+        cov = CoverageStore(tmp_path / "coverage.db")
+        ds = _ds()
+        assert cov.get_max_ts(ds) is None
+        cov.record(ds, min_ts=100, max_ts=500, rows_added=5)
+        assert cov.get_max_ts(ds) == 500
+
+    def test_envelope_widens_never_narrows(self, tmp_path):
+        cov = CoverageStore(tmp_path / "coverage.db")
+        ds = _ds()
+        cov.record(ds, min_ts=100, max_ts=500, rows_added=5)
+        # A later run with a narrower window must not shrink the recorded extent.
+        cov.record(ds, min_ts=300, max_ts=400, rows_added=2)
+        rows = cov.list_all()
+        assert len(rows) == 1
+        assert rows[0]["min_ts"] == 100
+        assert rows[0]["max_ts"] == 500
+        assert rows[0]["rows"] == 7  # accumulated
+        # A genuinely later max extends it.
+        cov.record(ds, min_ts=600, max_ts=900, rows_added=1)
+        assert cov.get_max_ts(ds) == 900
+
+    def test_none_timestamps_ignored(self, tmp_path):
+        cov = CoverageStore(tmp_path / "coverage.db")
+        ds = _ds()
+        cov.record(ds, min_ts=None, max_ts=None, rows_added=0)
+        assert cov.get_max_ts(ds) is None
+
+
+# ---------------------------------------------------------------------------
+# backfill integration — resume + record
+# ---------------------------------------------------------------------------
+
+class TestBackfillCoverage:
+    async def test_resumes_from_manifest_when_local_empty(self, tmp_path):
+        """Local files dropped → start='last' resumes from the manifest's max_ts."""
+        cov = CoverageStore(tmp_path / ".dccd" / "coverage.db")
+        ds = _ds()
+        # Span-aligned, ~10 bars ago (OHLC start snaps to the bar boundary).
+        recorded_max = (ns_now() // (_SPAN * NS) - 10) * (_SPAN * NS)
+        cov.record(ds, min_ts=recorded_max - 100 * _SPAN * NS, max_ts=recorded_max)
+
+        src = _FakeOHLC()
+        store = ParquetStore(tmp_path)  # empty → last_timestamp is None
+        target = JobTarget(exchange="fake", symbol=_SYMBOL,
+                           data_type=DataType.OHLC, span=_SPAN)
+        spec = JobSpec(id="x", operation="backfill", target=target,
+                       trigger=Trigger(kind="once"), params=JobParams(start="last"))
+        await backfill(spec, registry=_FakeReg(src), store=store, coverage_store=cov)
+
+        assert src.calls, "adapter never called"
+        # Resumed from the manifest (within a bar of recorded_max), NOT the
+        # 30-day bounded default an empty store would otherwise use.
+        assert abs(src.calls[0] - recorded_max) <= _SPAN * NS
+        default_start = ns_now() - 30 * 86400 * NS
+        assert src.calls[0] > default_start + 86400 * NS
+
+    async def test_records_extent_on_success(self, tmp_path):
+        cov = CoverageStore(tmp_path / ".dccd" / "coverage.db")
+        ds = _ds()
+        base = ns_now() - 5 * _SPAN * NS
+        bars = [
+            OHLCBar(ts=base + i * _SPAN * NS, open=1.0, high=2.0, low=0.5,
+                    close=1.5, volume=10.0)
+            for i in range(3)
+        ]
+        src = _FakeOHLC(bars=bars)
+        store = ParquetStore(tmp_path)
+        target = JobTarget(exchange="fake", symbol=_SYMBOL,
+                           data_type=DataType.OHLC, span=_SPAN)
+        # Explicit ns start just before the bars so they fall in the first page.
+        spec = JobSpec(id="x", operation="backfill", target=target,
+                       trigger=Trigger(kind="once"),
+                       params=JobParams(start=str(base - _SPAN * NS)))
+        await backfill(spec, registry=_FakeReg(src), store=store, coverage_store=cov)
+
+        assert cov.get_max_ts(ds) == bars[-1].ts
+        rows = cov.list_all()
+        assert rows and rows[0]["min_ts"] == bars[0].ts

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,24 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #XX) [accepted]
+- **Choice**: a `CoverageStore` (SQLite at `.dccd/coverage.db`) records each
+  dataset's `[min_ts, max_ts]` + row count on every successful backfill;
+  `backfill(start="last")` consults it (`get_max_ts`) when `store.last_timestamp`
+  returns `None`, i.e. the local Parquet is gone. Wired through `service_factory`
+  and threaded into backfill by every caller (Client, CLI, API, Scheduler).
+- **Why**: backfill resume reads the cursor from *local Parquet only*, so dropping
+  files to free disk (the point of Epic C) would make the next run re-download
+  from the bounded default lookback. A small manifest that lives outside the data
+  files (and is never purged) is the cheapest durable cursor. Chosen over a
+  remote-aware inventory (rclone listing on every run — network + remote-availability
+  coupling). The envelope only ever *widens* (min of mins, max of maxes) so a
+  narrow re-backfill can't shrink recorded coverage.
+- **Rejected alternatives**: query the remote for what exists (slow, couples
+  resume to remote uptime); store the cursor inside the Parquet footer (lost with
+  the file — the exact failure we're avoiding); reuse `RunsStore` (runs are an
+  event log, coverage is current-state per dataset — different shape and lifecycle).
+
 ### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #87) [accepted]
 - **Choice**: extract the single sync cycle (create run → `sync_all` → finish +
   events) into `operations.sync_remote`, reused by both the scheduler loop and a

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #XX) [accepted]
+### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #88) [accepted]
 - **Choice**: a `CoverageStore` (SQLite at `.dccd/coverage.db`) records each
   dataset's `[min_ts, max_ts]` + row count on every successful backfill;
   `backfill(start="last")` consults it (`get_max_ts`) when `store.last_timestamp`

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -44,8 +44,11 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   `dccd start`** — a periodic loop mirrors the store off-box every
   `storage.sync_interval` (backoff + persisted `sync` runs + `remote-sync`
   EventBus status), and the **Storage page shows last/next sync + volume with a
-  "Sync now" button**. Still pending in Epic C: a coverage manifest so local files
-  can be dropped without re-downloading, and free-space purge.
+  "Sync now" button**. A **coverage manifest** (`CoverageStore`, `.dccd/`) now
+  records each dataset's extent so `start="last"` resumes from it when local files
+  are gone — local data can be dropped without a re-download. Still pending in
+  Epic C: the free-space purge that actually drops synced files, and read-through
+  restore.
 
 ## Tooling & infra present in the repo
 

--- a/doc/source/reference/storage.rst
+++ b/doc/source/reference/storage.rst
@@ -76,3 +76,9 @@ Run history
 
 .. autoclass:: dccd.storage.runs_sqlite.RunsStore
    :members:
+
+Coverage manifest
+=================
+
+.. autoclass:: dccd.storage.coverage_sqlite.CoverageStore
+   :members:


### PR DESCRIPTION
## Summary
- Adds a `CoverageStore` (SQLite under `.dccd/`) that remembers each dataset's `[min_ts, max_ts]` extent independently of the Parquet files. `backfill(start="last")` falls back to it when local files are gone — so local data can be dropped to free disk without forcing a re-download. PR 3 of the Epic C tiered-storage series.

## Why
- Backfill resume reads the cursor from **local Parquet only** (`store.last_timestamp`). Dropping files — the whole point of Epic C — would make the next run restart from the bounded default lookback and re-download. A small durable manifest outside the data files (and never purged) is the cheapest fix, and the keystone PR4 (free-space purge) needs.
- Envelope only ever **widens** (min of mins, max of maxes) so a narrow re-backfill can't shrink recorded coverage.

## Changes
- `dccd/storage/coverage_sqlite.py` — `CoverageStore.record/get_max_ts/list_all`.
- `service_factory.build_coverage_store`.
- `operations.backfill` — new `coverage_store` param: resume fallback + record extent on success (tracks min/max ts during pagination).
- Threaded through every caller: `Client`, CLI (`backfill`/`start`), API (`_run_backfill_tracked` + standalone scheduler), `Scheduler`.
- Tests: `CoverageStore` unit (record/widen/none) + backfill integration (resumes from manifest when local empty; records extent on success) with a fake adapter (no network).
- Docs: `CoverageStore` autodoc in `storage.rst`.

## Changelog
Added under [Unreleased]:
- Coverage manifest so local data can be dropped without re-download.

## Test plan
- [x] `pytest` (200 passed, 3 network deselected)
- [x] `ruff` · `mypy` (45 files) clean · `make html` 0 warnings
- [ ] CI green