### PR TITLE
feat: free-space purge of oldest synced files under disk pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dataset's `[min_ts, max_ts]` extent, and `start="last"` falls back to the
   manifest's `max_ts` when no local file exists — so local data can be dropped to
   free disk without forcing a re-download on the next backfill. (#88)
+- Free-space purge: `storage.min_free_gb` (default `0` = off). After each
+  successful sync the daemon drops the oldest already-synced Parquet files until
+  free space is back above the floor (the coverage manifest keeps the resume
+  cursor, `.dccd/` is never touched). (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Free-space purge: `storage.min_free_gb` (default `0` = off). After each
   successful sync the daemon drops the oldest already-synced Parquet files until
   free space is back above the floor (the coverage manifest keeps the resume
-  cursor, `.dccd/` is never touched). (#XX)
+  cursor, `.dccd/` is never touched). (#89)
 
 ### Changed
 

--- a/dccd/application/config.py
+++ b/dccd/application/config.py
@@ -70,10 +70,12 @@ class RemoteConfig(BaseModel):
 
 
 class StorageConfig(BaseModel):
-    """Storage settings: local path, rclone remotes, and sync interval."""
+    """Storage settings: local path, rclone remotes, sync interval, and the
+    free-space floor (GiB) that triggers purging already-synced local files."""
     local_path: str = ""
     remotes: list[RemoteConfig] = Field(default_factory=list)
     sync_interval: int = 3600
+    min_free_gb: float = 0.0
 
 
 class AlertConfig(BaseModel):

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 
-from dccd.application.events import EventBus
+from dccd.application.events import EventBus, RunEvents
 from dccd.application.jobs import JobSpec
 from dccd.sources.registry import SourceRegistry
 from dccd.storage.coverage_sqlite import CoverageStore
@@ -108,6 +108,8 @@ class Scheduler:
         remote: RemoteStorage | None = None,
         sync_interval: int = 3600,
         coverage_store: CoverageStore | None = None,
+        data_path: str | None = None,
+        min_free_gb: float = 0.0,
     ) -> None:
         self._registry = registry
         self._store = store
@@ -116,6 +118,8 @@ class Scheduler:
         self._remote = remote
         self._sync_interval = sync_interval
         self._coverage_store = coverage_store
+        self._data_path = data_path
+        self._min_free_gb = min_free_gb
         self._sync_task: asyncio.Task[None] | None = None
         self._streams: dict[str, _StreamWorker] = {}
         self._interval_tasks: list[asyncio.Task[None]] = []
@@ -260,6 +264,10 @@ class Scheduler:
                     self._remote, runs_store=self._runs_store, events=run_events
                 )
                 if result["ok"]:
+                    # Remote is now up to date → safe to free disk by dropping the
+                    # oldest already-synced files (the coverage manifest keeps the
+                    # resume cursor). Runs only when a floor is configured.
+                    await self._maybe_purge(run_events)
                     backoff = 30.0
                     await asyncio.sleep(self._sync_interval)
                 else:
@@ -268,6 +276,30 @@ class Scheduler:
                     backoff = min(backoff * 2, float(self._sync_interval))
         except asyncio.CancelledError:
             return
+
+    async def _maybe_purge(self, run_events: RunEvents) -> None:
+        """Free disk by dropping oldest synced files when below the floor.
+
+        Called right after a successful sync (remote is current), so dropped
+        files are recoverable from the remote. No-op unless ``min_free_gb`` and a
+        ``data_path`` are configured.
+        """
+        if self._min_free_gb <= 0 or not self._data_path:
+            return
+        from dccd.storage.purge import purge_to_free_space
+        try:
+            res = await asyncio.to_thread(
+                purge_to_free_space, self._data_path, self._min_free_gb
+            )
+        except Exception as exc:
+            logger.warning("Purge failed: %s", exc)
+            return
+        if res["removed"]:
+            run_events.log(
+                f"Purged {len(res['removed'])} file(s), "
+                f"freed ~{res['freed_bytes'] / (1024 ** 3):.2f} GiB to stay above "
+                f"{self._min_free_gb} GiB free"
+            )
 
     async def _interval_loop(self, spec: JobSpec) -> None:
         every = spec.trigger.every or spec.target.span or 3600

--- a/dccd/interfaces/cli/main.py
+++ b/dccd/interfaces/cli/main.py
@@ -167,6 +167,7 @@ def cmd_start(
         registry, store, runs_store, bus,
         remote=remote, sync_interval=cfg.storage.sync_interval,
         coverage_store=coverage_store,
+        data_path=cfg.settings.data_path, min_free_gb=cfg.storage.min_free_gb,
     )
     if remote is not None:
         typer.echo(

--- a/dccd/storage/purge.py
+++ b/dccd/storage/purge.py
@@ -1,0 +1,105 @@
+"""Free-space purge: drop the oldest already-synced Parquet files under disk
+pressure.
+
+**Safety contract**: this deletes local data that is recoverable only from the
+remote, so it must be called **only when the remote mirror is up to date** — in
+practice, right after a successful :func:`~dccd.application.operations.sync_remote`
+cycle. The coverage manifest (``CoverageStore``) preserves the resume cursor, so a
+later ``backfill(start="last")`` still continues from where collection left off;
+reads of purged ranges return what's local until read-through restore pulls them
+back.
+
+The ``.dccd`` directory (runs DB, coverage manifest) is never touched.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import shutil
+from typing import Any, Callable
+
+__all__ = ["purge_to_free_space", "free_bytes"]
+
+logger = logging.getLogger(__name__)
+
+_GB = 1024 ** 3
+
+
+def free_bytes(path: str | pathlib.Path) -> int:
+    """Return free bytes on the filesystem holding *path*."""
+    return shutil.disk_usage(str(path)).free
+
+
+def purge_to_free_space(
+    data_path: str | pathlib.Path,
+    min_free_gb: float,
+    *,
+    dry_run: bool = False,
+    free_fn: Callable[[], int] | None = None,
+) -> dict[str, Any]:
+    """Delete oldest Parquet files until free space reaches ``min_free_gb``.
+
+    Files are removed oldest-first (by mtime), so recent data stays local while
+    old data — already mirrored off-box — is dropped. The ``.dccd`` directory is
+    excluded. No-op when ``min_free_gb <= 0`` or free space is already above the
+    threshold.
+
+    Parameters
+    ----------
+    data_path : str or Path
+        Root of the local store.
+    min_free_gb : float
+        Target free space in GiB. ``<= 0`` disables purging.
+    dry_run : bool, default False
+        Report what would be removed without deleting.
+    free_fn : callable or None
+        Override for the *initial* free-bytes probe (testing). Defaults to a real
+        ``shutil.disk_usage`` of *data_path*. Freeing is then simulated by adding
+        each removed file's size, so the result is deterministic.
+
+    Returns
+    -------
+    dict
+        ``{'freed_bytes', 'removed', 'free_after'}`` — ``removed`` is the list of
+        deleted file paths (oldest first).
+    """
+    root = pathlib.Path(data_path)
+    start_free = (free_fn or (lambda: free_bytes(root)))()
+    result: dict[str, Any] = {
+        "freed_bytes": 0, "removed": [], "free_after": start_free,
+    }
+    if min_free_gb <= 0:
+        return result
+
+    target = int(min_free_gb * _GB)
+    if start_free >= target:
+        return result
+
+    files = [f for f in root.rglob("*.parquet") if ".dccd" not in f.parts]
+    files.sort(key=lambda f: f.stat().st_mtime)  # oldest first
+
+    freed = 0
+    removed: list[str] = []
+    for f in files:
+        if start_free + freed >= target:
+            break
+        size = f.stat().st_size
+        if not dry_run:
+            try:
+                f.unlink()
+            except OSError as exc:
+                logger.warning("Could not purge %s: %s", f, exc)
+                continue
+        freed += size
+        removed.append(str(f))
+
+    result["freed_bytes"] = freed
+    result["removed"] = removed
+    result["free_after"] = start_free + freed
+    if removed:
+        logger.info(
+            "Purged %d file(s), freed ~%.2f GiB (free now %.2f GiB)",
+            len(removed), freed / _GB, result["free_after"] / _GB,
+        )
+    return result

--- a/dccd/tests/v3/test_purge.py
+++ b/dccd/tests/v3/test_purge.py
@@ -1,0 +1,104 @@
+"""Free-space purge: drop oldest already-synced Parquet files under disk pressure."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+
+from dccd.application.events import EventBus
+from dccd.application.scheduler import Scheduler
+from dccd.application.service_factory import build_registry, build_store
+from dccd.storage.purge import free_bytes, purge_to_free_space
+
+_GB = 1024 ** 3
+
+
+class _OkRemote:
+    async def sync_all(self):
+        return {"r:bucket": True}
+
+
+def _make_store(tmp_path: pathlib.Path) -> dict[str, pathlib.Path]:
+    """Create 4 parquet files (ascending mtime) + a .dccd file to be preserved."""
+    files = {}
+    for i, name in enumerate(["a", "b", "c", "d"]):
+        p = tmp_path / "binance" / "ohlc" / f"{name}.parquet"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"x" * ((i + 1) * 10))  # 10, 20, 30, 40 bytes
+        os.utime(p, (1000 + i, 1000 + i))     # a oldest … d newest
+        files[name] = p
+    dcache = tmp_path / ".dccd" / "coverage.db"
+    dcache.parent.mkdir(parents=True, exist_ok=True)
+    dcache.write_bytes(b"manifest")
+    files["dcache"] = dcache
+    return files
+
+
+class TestPurge:
+    def test_disabled_when_min_free_zero(self, tmp_path):
+        f = _make_store(tmp_path)
+        res = purge_to_free_space(tmp_path, 0.0, free_fn=lambda: 0)
+        assert res["removed"] == []
+        assert f["a"].exists()
+
+    def test_noop_when_already_above_floor(self, tmp_path):
+        _make_store(tmp_path)
+        # Plenty free → nothing removed.
+        res = purge_to_free_space(tmp_path, 1.0, free_fn=lambda: 2 * _GB)
+        assert res["removed"] == []
+
+    def test_drops_oldest_first_until_floor(self, tmp_path):
+        f = _make_store(tmp_path)
+        target = 1 * _GB
+        # Start just short by the two oldest files' sizes (10 + 20 = 30 bytes).
+        start_free = target - 30
+        res = purge_to_free_space(tmp_path, 1.0, free_fn=lambda: start_free)
+        removed = [pathlib.Path(p).name for p in res["removed"]]
+        assert removed == ["a.parquet", "b.parquet"]  # oldest first, stops at floor
+        assert not f["a"].exists() and not f["b"].exists()
+        assert f["c"].exists() and f["d"].exists()
+        assert f["dcache"].exists()  # .dccd never touched
+        assert res["freed_bytes"] == 30
+
+    def test_dry_run_keeps_files(self, tmp_path):
+        f = _make_store(tmp_path)
+        res = purge_to_free_space(
+            tmp_path, 1.0, dry_run=True, free_fn=lambda: 1 * _GB - 30
+        )
+        assert [pathlib.Path(p).name for p in res["removed"]] == ["a.parquet", "b.parquet"]
+        # Nothing actually deleted.
+        assert f["a"].exists() and f["b"].exists()
+
+
+class TestSchedulerPurge:
+    async def test_purges_after_successful_sync(self, tmp_path):
+        """A successful sync cycle triggers the purge when below the floor."""
+        p = tmp_path / "binance" / "ohlc" / "old.parquet"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"x" * 100)
+        # A floor far above real free space → purge must drop the file.
+        huge = free_bytes(tmp_path) / _GB + 1000
+        sched = Scheduler(
+            build_registry(), build_store(tmp_path), None, EventBus(),
+            remote=_OkRemote(), sync_interval=0.02,
+            data_path=str(tmp_path), min_free_gb=huge,
+        )
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        assert not p.exists()  # purged after sync
+
+    async def test_no_purge_without_floor(self, tmp_path):
+        p = tmp_path / "binance" / "ohlc" / "keep.parquet"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"x" * 100)
+        sched = Scheduler(
+            build_registry(), build_store(tmp_path), None, EventBus(),
+            remote=_OkRemote(), sync_interval=0.02,
+            data_path=str(tmp_path), min_free_gb=0.0,
+        )
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        assert p.exists()  # no floor → never purged

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Free-space purge runs right after a successful sync (PR #XX) [accepted]
+- **Choice**: a `storage.purge.purge_to_free_space` drops the **oldest** Parquet
+  files (by mtime, `.dccd/` excluded) until free space is back above
+  `storage.min_free_gb`. The Scheduler calls it **only after a successful sync
+  cycle**, off-thread. Free accounting is simulated (start probe + summed file
+  sizes) so it's deterministic and unit-testable via a `free_fn` injection.
+- **Why**: dropping local files is only safe once they're mirrored off-box;
+  tying the purge to a just-completed sync gives that guarantee without tracking
+  per-file sync state. Oldest-first keeps recent data local (most likely to be
+  read) and offloads cold data. The coverage manifest (#88) preserves the resume
+  cursor, so a purged dataset still resumes correctly on the next backfill.
+- **Rejected alternatives**: a fixed local-size cap or age-based retention (the
+  user asked specifically for "when I run low on disk" → a free-space floor); a
+  standalone purge daemon/timer (the sync loop is already the natural,
+  safety-gated trigger); deleting during the sync itself (must be strictly after
+  the mirror confirms).
+
 ### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #88) [accepted]
 - **Choice**: a `CoverageStore` (SQLite at `.dccd/coverage.db`) records each
   dataset's `[min_ts, max_ts]` + row count on every successful backfill;

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Free-space purge runs right after a successful sync (PR #XX) [accepted]
+### 2026-06-09 — Free-space purge runs right after a successful sync (PR #89) [accepted]
 - **Choice**: a `storage.purge.purge_to_free_space` drops the **oldest** Parquet
   files (by mtime, `.dccd/` excluded) until free space is back above
   `storage.min_free_gb`. The Scheduler calls it **only after a successful sync

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -46,9 +46,11 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   EventBus status), and the **Storage page shows last/next sync + volume with a
   "Sync now" button**. A **coverage manifest** (`CoverageStore`, `.dccd/`) now
   records each dataset's extent so `start="last"` resumes from it when local files
-  are gone — local data can be dropped without a re-download. Still pending in
-  Epic C: the free-space purge that actually drops synced files, and read-through
-  restore.
+  are gone — local data can be dropped without a re-download. A **free-space
+  purge** (`storage.min_free_gb`) drops the oldest already-synced files after each
+  sync to stay above the floor. Still pending in Epic C: **read-through restore**
+  (pull a purged file back from the remote on read) and the deploy/rclone how-to
+  docs.
 
 ## Tooling & infra present in the repo
 

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -96,6 +96,8 @@ storage:
     # - provider: rclone
     #   remote: "s3:mybucket/crypto/"  # secondary destination (S3 backup)
   sync_interval: 3600          # seconds between sync cycles (0 = disable)
+  min_free_gb: 0               # free-space floor (GiB); >0 drops oldest synced
+                               # files after each sync to stay above it (0 = off)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `storage.min_free_gb` (default `0` = off). After each successful sync, the daemon drops the **oldest already-synced** Parquet files until free disk is back above the floor. PR 4 of the Epic C tiered-storage series — the "drop local when I run low on space" the user asked for.

## Why
- Dropping local files is only safe once they're mirrored off-box, so the purge is triggered **strictly after a successful sync cycle**. Oldest-first keeps recent (most-read) data local and offloads cold data. The coverage manifest (#88) preserves the resume cursor, so a purged dataset still resumes correctly on the next backfill. `.dccd/` (runs + manifest) is never touched.

## Changes
- `dccd/storage/purge.py` — `purge_to_free_space(data_path, min_free_gb, *, dry_run, free_fn)`; deterministic free-accounting (injectable `free_fn` for tests).
- `StorageConfig.min_free_gb` + `examples/config.example.yml` doc.
- `Scheduler` — `data_path`/`min_free_gb` params; `_maybe_purge` runs off-thread after a successful sync. Wired from `cmd_start`.
- Tests: purge ordering / floor / dry-run / `.dccd` preservation, **and** a scheduler integration test (purge fires after a sync cycle; no floor → never purges).

## Changelog
Added under [Unreleased]:
- Free-space purge (`storage.min_free_gb`) of oldest synced files after each sync.

## Test plan
- [x] `pytest` (206 passed, 3 network deselected)
- [x] `ruff` · `mypy` (46 files) clean · `make html` 0 warnings
- [ ] CI green