### PR TITLE
feat: read-through restore pulls purged datasets back from the remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cursor, `.dccd/` is never touched). (#89)
 - Read-through restore: reading a dataset whose local Parquet was purged now pulls
   it back from the remote (`rclone copy`) before loading, so a purge is
-  transparent to readers (`Client.read`, `POST /api/read`). (#XX)
+  transparent to readers (`Client.read`, `POST /api/read`). (#90)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   successful sync the daemon drops the oldest already-synced Parquet files until
   free space is back above the floor (the coverage manifest keeps the resume
   cursor, `.dccd/` is never touched). (#89)
+- Read-through restore: reading a dataset whose local Parquet was purged now pulls
+  it back from the remote (`rclone copy`) before loading, so a purge is
+  transparent to readers (`Client.read`, `POST /api/read`). (#XX)
 
 ### Changed
 

--- a/dccd/__init__.py
+++ b/dccd/__init__.py
@@ -71,6 +71,7 @@ class Client:
         self._store: ParquetStore | None = None
         self._registry: SourceRegistry | None = None
         self._coverage_store: Any = None
+        self._remote: Any = None
 
     def _require_ready(self) -> tuple["SourceRegistry", "ParquetStore"]:
         if self._registry is None or self._store is None:
@@ -82,6 +83,7 @@ class Client:
         from dccd.application.service_factory import (
             build_coverage_store,
             build_registry,
+            build_remote,
             build_store,
         )
 
@@ -94,6 +96,7 @@ class Client:
         # Single source of truth for adapter wiring — same as CLI and API.
         self._store = build_store(self._config.settings.data_path)
         self._coverage_store = build_coverage_store(self._config.settings.data_path)
+        self._remote = build_remote(self._config)
         self._registry = build_registry()
         return self
 
@@ -256,7 +259,8 @@ class Client:
         _, store = self._require_ready()
         target = JobTarget(exchange=exchange, symbol=Symbol.parse(symbol),
                            data_type=DataType(data_type), span=span)
-        return cast("pl.DataFrame", do_read(target, store=store, start_ns=start_ns, end_ns=end_ns))
+        return cast("pl.DataFrame", do_read(target, store=store, start_ns=start_ns,
+                                            end_ns=end_ns, remote=self._remote))
 
     def inventory(self) -> list[dict[str, Any]]:
         """List every stored dataset with its coverage.

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -493,9 +493,21 @@ def read(
     store: ParquetStore,
     start_ns: int | None = None,
     end_ns: int | None = None,
+    remote: RemoteStorage | None = None,
 ) -> Any:
-    """Read stored data for *target* in the given nanosecond range."""
+    """Read stored data for *target* in the given nanosecond range.
+
+    Read-through restore: when *remote* is set and the dataset has no local
+    Parquet (e.g. it was purged to free disk), the dataset directory is pulled
+    back from the remote (``rclone copy``) before loading, so a purge is
+    transparent to readers.
+    """
     ds = _make_dataset_id(target)
+    if remote is not None:
+        directory = store.directory(ds)
+        if not any(directory.glob("*.parquet")):
+            rel = directory.relative_to(store.root)
+            remote.restore(str(rel))
     return store.load(ds, start_ns, end_ns)
 
 

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -648,7 +648,11 @@ def create_app(
             exchange=body.exchange, symbol=sym,
             data_type=DataType(body.data_type), span=body.span,
         )
-        df = read(target, store=_store(request), start_ns=body.start_ns, end_ns=body.end_ns)
+        # Off-thread: read-through restore may shell out to rclone (blocking).
+        df = await asyncio.to_thread(
+            read, target, store=_store(request), start_ns=body.start_ns,
+            end_ns=body.end_ns, remote=request.app.state.remote,
+        )
         rows = df.to_dicts() if hasattr(df, "to_dicts") else []
         return {"rows": len(rows), "data": rows[:1000]}
 

--- a/dccd/storage/parquet.py
+++ b/dccd/storage/parquet.py
@@ -119,6 +119,11 @@ class ParquetStore:
         self._file_locks: dict[str, threading.Lock] = {}
         self._file_locks_guard = threading.Lock()
 
+    @property
+    def root(self) -> pathlib.Path:
+        """Root directory of the local store."""
+        return self._root
+
     def _lock_for(self, file_path: pathlib.Path) -> threading.Lock:
         key = str(file_path)
         with self._file_locks_guard:

--- a/dccd/storage/remote.py
+++ b/dccd/storage/remote.py
@@ -52,6 +52,46 @@ class RemoteStorage:
             logger.error("rclone sync to %s timed out", remote)
             return False
 
+    def restore(self, rel_path: str) -> bool:
+        """Pull *rel_path* back from the first configured remote into the store.
+
+        Runs ``rclone copy {remote}/{rel_path} {local}/{rel_path}`` — **copy**,
+        not sync, so nothing is ever deleted. Used for read-through restore when a
+        dataset's local Parquet was purged but still exists off-box. Returns True
+        on success (or no-op when no remote is configured).
+
+        Parameters
+        ----------
+        rel_path : str
+            Dataset directory relative to the local store root.
+        """
+        if not self._remotes:
+            return False
+        remote = self._remotes[0].get("remote", "")
+        if not remote:
+            return False
+        src = remote.rstrip("/") + "/" + rel_path
+        dst = self._local / rel_path
+        try:
+            dst.mkdir(parents=True, exist_ok=True)
+            result = subprocess.run(
+                ["rclone", "copy", src, str(dst), "--quiet"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                logger.error("rclone restore of %s failed: %s", rel_path, result.stderr)
+                return False
+            logger.info("Restored %s from %s", rel_path, remote)
+            return True
+        except FileNotFoundError:
+            logger.error("rclone not found in PATH")
+            return False
+        except subprocess.TimeoutExpired:
+            logger.error("rclone restore of %s timed out", rel_path)
+            return False
+
     async def sync_all(self) -> dict[str, bool]:
         """Sync to all configured remotes concurrently."""
         if not self._remotes:

--- a/dccd/tests/v3/test_restore.py
+++ b/dccd/tests/v3/test_restore.py
@@ -1,0 +1,79 @@
+"""Read-through restore: a purged dataset is pulled back from the remote on read."""
+
+from __future__ import annotations
+
+from dccd.application.jobs import JobTarget
+from dccd.application.operations import read
+from dccd.domain.dataset import DatasetId, Provenance
+from dccd.domain.records import OHLCBar
+from dccd.domain.symbol import Symbol
+from dccd.domain.types import DataType
+from dccd.storage.parquet import ParquetStore
+from dccd.storage.remote import RemoteStorage
+
+_SYM = Symbol(base="BTC", quote="USDT")
+
+
+def _target() -> JobTarget:
+    return JobTarget(exchange="binance", symbol=_SYM, data_type=DataType.OHLC, span=3600)
+
+
+def _ds() -> DatasetId:
+    return DatasetId(exchange="binance", symbol=_SYM, data_type=DataType.OHLC, span=3600)
+
+
+def _bar(ts: int = 1_700_000_000_000_000_000) -> OHLCBar:
+    return OHLCBar(ts=ts, open=1.0, high=2.0, low=0.5, close=1.5, volume=10.0)
+
+
+class _RestoringRemote:
+    """Fake remote whose restore() re-materialises the dataset (simulates rclone)."""
+
+    def __init__(self, store: ParquetStore, ds: DatasetId, bar: OHLCBar):
+        self._store, self._ds, self._bar = store, ds, bar
+        self.restored = False
+
+    def restore(self, rel_path: str) -> bool:
+        self.restored = True
+        self._store.save(self._ds, [self._bar], Provenance(source="remote"))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# RemoteStorage.restore
+# ---------------------------------------------------------------------------
+
+class TestRemoteRestore:
+    def test_no_remotes_returns_false(self, tmp_path):
+        assert RemoteStorage(tmp_path, []).restore("any/path") is False
+
+    def test_missing_rclone_is_graceful(self, tmp_path):
+        # rclone is not a test dependency → FileNotFoundError handled → False.
+        rs = RemoteStorage(tmp_path, [{"remote": "dummy:bucket"}])
+        assert rs.restore("binance/ohlc/BTC-USDT/3600") is False
+
+
+# ---------------------------------------------------------------------------
+# operations.read read-through
+# ---------------------------------------------------------------------------
+
+class TestReadThrough:
+    def test_restores_when_local_empty(self, tmp_path):
+        store = ParquetStore(tmp_path)
+        remote = _RestoringRemote(store, _ds(), _bar())
+        df = read(_target(), store=store, remote=remote)
+        assert remote.restored is True
+        assert len(df) == 1
+
+    def test_no_restore_when_files_present(self, tmp_path):
+        store = ParquetStore(tmp_path)
+        store.save(_ds(), [_bar()], Provenance(source="local"))
+        remote = _RestoringRemote(store, _ds(), _bar())
+        df = read(_target(), store=store, remote=remote)
+        assert remote.restored is False  # local present → no remote hit
+        assert len(df) == 1
+
+    def test_no_remote_is_unchanged(self, tmp_path):
+        store = ParquetStore(tmp_path)
+        df = read(_target(), store=store, remote=None)
+        assert len(df) == 0  # empty in, empty out, no error

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Read-through restore in operations.read, whole-dir copy (PR #XX) [accepted]
+- **Choice**: when `operations.read` finds no local Parquet for a dataset and a
+  remote is configured, it `rclone copy`s the dataset's **whole directory** back
+  (via `RemoteStorage.restore`, copy not sync — never deletes) before loading.
+  The remote is resolved from config (`build_remote`) and threaded into
+  `Client.read` and `POST /api/read` (off-thread there, since restore shells out).
+- **Why**: the free-space purge (#89) makes a dataset's local files disappear;
+  backfill resume already survives via the coverage manifest (#88), but *reads*
+  would silently return empty. Pulling the dataset back on a read-miss makes the
+  purge transparent. Whole-dir copy keeps it simple and matches the coarse
+  annual/daily file layout — a time-sliced restore would add rclone-filter
+  complexity for little gain.
+- **Rejected alternatives**: restore only the period files overlapping the read
+  window (more rclone plumbing, marginal benefit at this file granularity); teach
+  `ParquetStore` about remotes (breaks the storage/remote separation — the
+  application layer already owns this orchestration, as with sync/purge).
+
 ### 2026-06-09 — Free-space purge runs right after a successful sync (PR #89) [accepted]
 - **Choice**: a `storage.purge.purge_to_free_space` drops the **oldest** Parquet
   files (by mtime, `.dccd/` excluded) until free space is back above

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Read-through restore in operations.read, whole-dir copy (PR #XX) [accepted]
+### 2026-06-09 — Read-through restore in operations.read, whole-dir copy (PR #90) [accepted]
 - **Choice**: when `operations.read` finds no local Parquet for a dataset and a
   remote is configured, it `rclone copy`s the dataset's **whole directory** back
   (via `RemoteStorage.restore`, copy not sync — never deletes) before loading.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -48,9 +48,9 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   records each dataset's extent so `start="last"` resumes from it when local files
   are gone — local data can be dropped without a re-download. A **free-space
   purge** (`storage.min_free_gb`) drops the oldest already-synced files after each
-  sync to stay above the floor. Still pending in Epic C: **read-through restore**
-  (pull a purged file back from the remote on read) and the deploy/rclone how-to
-  docs.
+  sync to stay above the floor, and **read-through restore** pulls a purged
+  dataset back from the remote on read. Remaining in Epic C: the rclone
+  provisioning / integrity how-to docs.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -68,8 +68,6 @@ loss doesn't lose data.
 - [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document
   restore (pull a remote back into `data_path`). Consider a periodic verify
   (counts/sizes) reusing the `data-e2e` skill.
-- [ ] **Optional: read-through restore** — ability to point a fresh instance at a
-  remote and hydrate the local store.
 
 ---
 


### PR DESCRIPTION
## Summary
- After the free-space purge (#89) drops a dataset's local Parquet, reading it pulled back nothing. Now `operations.read` detects a local read-miss and `rclone copy`s the dataset directory back from the remote before loading — purge is transparent to readers. PR 5 of the Epic C tiered-storage series.

## Why
- Backfill resume already survives a purge via the coverage manifest (#88), but reads (`Client.read`, `POST /api/read`) would silently return empty. Read-through closes that gap.
- The remote is resolved from config (`build_remote`), same as sync/purge — so it works in `dccd ui` mode too. Whole-dir copy keeps it simple and matches the coarse annual/daily file layout.

## Changes
- `RemoteStorage.restore(rel_path)` — `rclone copy {remote}/{rel} {local}/{rel}` (copy, never deletes; graceful when rclone is absent).
- `ParquetStore.root` property (read needs the dataset dir relative to the store root).
- `operations.read(..., remote=None)` — restore on local read-miss, then load. Threaded into `Client.read` and `POST /api/read` (off-thread in the async endpoint).
- Tests: `RemoteStorage.restore` (no remotes / missing rclone) + `operations.read` read-through (restores when empty, skips when present, unchanged with `remote=None`).

## Verification
- `pytest` 211 passed, 3 network deselected; `ruff` · `mypy` (46 files) clean; `make html` 0 warnings.
- **Real-tool E2E** (cp-based rclone stand-in): write→sync→purge→`read` pulled the dataset back (1 row), proving the real `RemoteStorage.restore` subprocess path.

## Changelog
Added under [Unreleased]: read-through restore on read-miss.

## Test plan
- [x] pytest / ruff / mypy / docs green
- [x] real-tool restore E2E
- [ ] CI green