### PR TITLE
docs: complete the remote-sync how-to (Epic C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transparent to readers (`Client.read`, `POST /api/read`). (#90)
 - Docs: the `how-to/sync-remote` guide now covers rclone provisioning, the
   `min_free_gb` free-space purge, read-through restore, and restore/integrity
-  (`rclone copy`/`rclone check`) — completing Epic C (tiered storage). (#XX)
+  (`rclone copy`/`rclone check`) — completing Epic C (tiered storage). (#91)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read-through restore: reading a dataset whose local Parquet was purged now pulls
   it back from the remote (`rclone copy`) before loading, so a purge is
   transparent to readers (`Client.read`, `POST /api/read`). (#90)
+- Docs: the `how-to/sync-remote` guide now covers rclone provisioning, the
+  `min_free_gb` free-space purge, read-through restore, and restore/integrity
+  (`rclone copy`/`rclone check`) — completing Epic C (tiered storage). (#XX)
 
 ### Changed
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -49,8 +49,9 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   are gone — local data can be dropped without a re-download. A **free-space
   purge** (`storage.min_free_gb`) drops the oldest already-synced files after each
   sync to stay above the floor, and **read-through restore** pulls a purged
-  dataset back from the remote on read. Remaining in Epic C: the rclone
-  provisioning / integrity how-to docs.
+  dataset back from the remote on read. **Epic C (tiered storage) is complete** —
+  provisioning, restore and integrity are documented in
+  `doc/source/how-to/sync-remote.rst`.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -58,22 +58,15 @@ Goal: open the dashboard securely from a laptop or phone, not just `localhost`.
 - [ ] **Threat model note** — write down the assumptions (LAN vs internet, tunnel
   vs public) in the deploy how-to.
 
-## Epic C — Sync data to a remote space
-
-Goal: the Parquet store is mirrored to off-box storage (S3/B2/Drive/…) so a server
-loss doesn't lose data.
-
-- [ ] **rclone provisioning docs** — how to configure a remote (`rclone config`)
-  in the container/host; mount or inject `rclone.conf` securely.
-- [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document
-  restore (pull a remote back into `data_path`). Consider a periodic verify
-  (counts/sizes) reusing the `data-e2e` skill.
+_Epic C — Sync data to a remote space: **done.** Scheduled rclone sync + UI,
+coverage manifest, free-space purge, read-through restore, and the
+`how-to/sync-remote` guide all shipped. See `06-status.md`._
 
 ---
 
 ## Suggested sequence
 
-1. **C (sync)** first — protect the data before exposing anything.
+1. ~~**C (sync)**~~ — done.
 2. **A (remote run)** — get it running unattended with restart safety.
 3. **B (remote access)** — only then expose the UI, behind TLS + auth.
 

--- a/doc/source/how-to/sync-remote.rst
+++ b/doc/source/how-to/sync-remote.rst
@@ -2,12 +2,81 @@
 Sync data to a remote (S3, GCS, …)
 ==================================
 
-Configure an `rclone <https://rclone.org/>`_ remote and a sync interval; the
-daemon pushes after each cycle:
+dccd can mirror your local Parquet store to off-box storage so a server loss
+doesn't lose data — and, optionally, **drop old local files** once they're safely
+copied, pulling them back on demand. The whole chain is built on
+`rclone <https://rclone.org/>`_.
+
+Provision a remote
+==================
+
+Install rclone and create a remote interactively:
+
+.. code-block:: bash
+
+   rclone config            # follow the prompts; name it e.g. "s3"
+   rclone listremotes       # -> s3:
+
+This writes ``~/.config/rclone/rclone.conf``. In a container, mount or inject
+that file (it holds credentials — keep it out of the image):
+
+.. code-block:: bash
+
+   docker run -v $HOME/.config/rclone:/root/.config/rclone:ro ... dccd start
+
+Configure sync
+==============
 
 .. code-block:: yaml
 
    storage:
      remotes:
        - {provider: rclone, remote: "s3:my-bucket/crypto"}
-     sync_interval: 3600
+     sync_interval: 3600        # seconds between sync cycles
+     min_free_gb: 0             # >0 enables the free-space purge (see below)
+
+With at least one remote configured, ``dccd start`` runs a periodic loop that
+mirrors the store every ``sync_interval`` seconds (one-way ``rclone sync`` —
+remote becomes a mirror of local). Each cycle is recorded as a ``sync`` run, so
+the **Storage** page shows the last/next sync, status and synced volume, with a
+**Sync now** button (``POST /api/storage/sync``). On failure the loop backs off
+exponentially.
+
+Free up disk: purge + restore
+=============================
+
+Set ``min_free_gb`` above ``0`` to let the daemon reclaim space. After **each
+successful sync** (so the data is already off-box), if free space on the store's
+filesystem is below the floor, dccd deletes the **oldest** Parquet files until it
+is back above it. The ``.dccd`` directory (run history + coverage manifest) is
+never touched.
+
+Two mechanisms make this safe:
+
+- **Backfill still resumes correctly.** A coverage manifest under ``.dccd``
+  records each dataset's extent, so ``start="last"`` resumes from where collection
+  left off even when the local files are gone — no accidental re-download.
+- **Reads pull data back.** Reading a dataset whose local files were purged
+  triggers a **read-through restore** (``rclone copy`` of that dataset directory
+  back into the store) before loading — transparent to ``Client.read`` and
+  ``POST /api/read``.
+
+Restore and integrity
+======================
+
+``rclone sync`` is a one-way mirror (local → remote); the remote is a faithful
+copy, deduplicated by dccd before upload. To rehydrate a fresh machine, pull the
+whole tree back:
+
+.. code-block:: bash
+
+   rclone copy s3:my-bucket/crypto /path/to/data/crypto
+
+To spot-check integrity, compare counts/sizes between local and remote:
+
+.. code-block:: bash
+
+   rclone check /path/to/data/crypto s3:my-bucket/crypto
+
+Because the coverage manifest lives under ``.dccd`` (also synced), a restored
+instance keeps its resume cursors and continues collecting without gaps.


### PR DESCRIPTION
## Summary
- Rewrites `how-to/sync-remote.rst` from a 2-line stub into a full guide: rclone provisioning (config + mounting `rclone.conf`), the `storage` config, scheduled sync + Sync-now, the `min_free_gb` free-space purge, read-through restore, and restore/integrity (`rclone copy`/`rclone check`). Closes the last two Epic C roadmap items and marks **Epic C (tiered storage) complete**. PR 6 (final) of the series.

## Why
- The how-to predated the implementation and claimed behaviour that only became real across #86–#90. This brings the user-facing docs in line with what ships, and gives operators the provisioning + restore procedures.

## Changes
- `doc/source/how-to/sync-remote.rst` — full rewrite (already in the toctree).
- `doc/dev/07-roadmap.md` — Epic C closed (items removed; sequence marks C done).
- `doc/dev/06-status.md` — Epic C complete, points to the how-to.

## Changelog
Added under [Unreleased]: docs completing Epic C.

## Test plan
- [x] `cd doc && make html` 0 warnings
- [x] `pytest` 211 passed (unchanged; docs-only) · `ruff` clean
- [ ] CI green