### PR TITLE
chore: release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.1.0] - 2026-06-09
+
+### Added
+
 - `dccd start` now schedules rclone remote sync: when `storage.remotes` is set,
   the daemon mirrors the store off-box every `storage.sync_interval` seconds with
   exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.0.0"
+version = "3.1.0"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v3.1.0

Freezes the `[Unreleased]` changelog into `## [3.1.0] - 2026-06-09` and bumps
`pyproject.toml` to `3.1.0`. This release ships **Epic C — tiered storage**.

### Added
- `dccd start` schedules rclone remote sync (off-box mirror every `sync_interval`, backoff, persisted `sync` runs, `remote-sync` EventBus status). (#86)
- Storage page surfaces sync status (last/next, remotes, volume) + **Sync now** button via `GET`/`POST /api/storage/sync`. (#87)
- Coverage manifest (`CoverageStore`, `.dccd/`): `start="last"` resumes from the manifest when local files are gone — drop disk without re-downloading. (#88)
- Free-space purge (`storage.min_free_gb`): drops oldest already-synced files after each sync to stay above the floor. (#89)
- Read-through restore: reading a purged dataset pulls it back from the remote first (`Client.read`, `POST /api/read`). (#90)
- `how-to/sync-remote` guide: rclone provisioning, purge, restore/integrity. (#91)

## Test plan
- [x] `ruff check dccd/` — clean
- [x] `pytest` — 211 passed, 3 network deselected
- [ ] CI green