### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dataset's `[min_ts, max_ts]` extent, and `start="last"` falls back to the
   manifest's `max_ts` when no local file exists — so local data can be dropped to
   free disk without forcing a re-download on the next backfill. (#88)
+- Free-space purge: `storage.min_free_gb` (default `0` = off). After each
+  successful sync the daemon drops the oldest already-synced Parquet files until
+  free space is back above the floor (the coverage manifest keeps the resume
+  cursor, `.dccd/` is never touched). (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and synced volume, plus a **Sync now** button — backed by
   `GET`/`POST /api/storage/sync`. The shared `operations.sync_remote` primitive
   records each cycle, so the manual button and the scheduled loop stay in sync. (#87)
+- Coverage manifest (`CoverageStore`, SQLite under `.dccd/`): backfill records each
+  dataset's `[min_ts, max_ts]` extent, and `start="last"` falls back to the
+  manifest's `max_ts` when no local file exists — so local data can be dropped to
+  free disk without forcing a re-download on the next backfill. (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cursor, `.dccd/` is never touched). (#89)
 - Read-through restore: reading a dataset whose local Parquet was purged now pulls
   it back from the remote (`rclone copy`) before loading, so a purge is
-  transparent to readers (`Client.read`, `POST /api/read`). (#XX)
+  transparent to readers (`Client.read`, `POST /api/read`). (#90)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transparent to readers (`Client.read`, `POST /api/read`). (#90)
 - Docs: the `how-to/sync-remote` guide now covers rclone provisioning, the
   `min_free_gb` free-space purge, read-through restore, and restore/integrity
-  (`rclone copy`/`rclone check`) — completing Epic C (tiered storage). (#XX)
+  (`rclone copy`/`rclone check`) — completing Epic C (tiered storage). (#91)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   successful sync the daemon drops the oldest already-synced Parquet files until
   free space is back above the floor (the coverage manifest keeps the resume
   cursor, `.dccd/` is never touched). (#89)
+- Read-through restore: reading a dataset whose local Parquet was purged now pulls
+  it back from the remote (`rclone copy`) before loading, so a purge is
+  transparent to readers (`Client.read`, `POST /api/read`). (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Coverage manifest (`CoverageStore`, SQLite under `.dccd/`): backfill records each
   dataset's `[min_ts, max_ts]` extent, and `start="last"` falls back to the
   manifest's `max_ts` when no local file exists — so local data can be dropped to
-  free disk without forcing a re-download on the next backfill. (#XX)
+  free disk without forcing a re-download on the next backfill. (#88)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dccd start` now schedules rclone remote sync: when `storage.remotes` is set,
+  the daemon mirrors the store off-box every `storage.sync_interval` seconds with
+  exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a
+  live `remote-sync` EventBus status. Previously `RemoteStorage` was implemented
+  but never driven — a server synced nothing. (#XX)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the daemon mirrors the store off-box every `storage.sync_interval` seconds with
   exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a
   live `remote-sync` EventBus status. Previously `RemoteStorage` was implemented
-  but never driven — a server synced nothing. (#XX)
+  but never driven — a server synced nothing. (#86)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a
   live `remote-sync` EventBus status. Previously `RemoteStorage` was implemented
   but never driven — a server synced nothing. (#86)
+- Storage page surfaces remote sync: last/next sync, status, configured remotes
+  and synced volume, plus a **Sync now** button — backed by
+  `GET`/`POST /api/storage/sync`. The shared `operations.sync_remote` primitive
+  records each cycle, so the manual button and the scheduled loop stay in sync. (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Storage page surfaces remote sync: last/next sync, status, configured remotes
   and synced volume, plus a **Sync now** button — backed by
   `GET`/`POST /api/storage/sync`. The shared `operations.sync_remote` primitive
-  records each cycle, so the manual button and the scheduled loop stay in sync. (#XX)
+  records each cycle, so the manual button and the scheduled loop stay in sync. (#87)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read-through restore: reading a dataset whose local Parquet was purged now pulls
   it back from the remote (`rclone copy`) before loading, so a purge is
   transparent to readers (`Client.read`, `POST /api/read`). (#90)
+- Docs: the `how-to/sync-remote` guide now covers rclone provisioning, the
+  `min_free_gb` free-space purge, read-through restore, and restore/integrity
+  (`rclone copy`/`rclone check`) — completing Epic C (tiered storage). (#XX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.1.0] - 2026-06-09
+
+### Added
+
 - `dccd start` now schedules rclone remote sync: when `storage.remotes` is set,
   the daemon mirrors the store off-box every `storage.sync_interval` seconds with
   exponential backoff, persisted run history (`sync` runs in `RunsStore`) and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Free-space purge: `storage.min_free_gb` (default `0` = off). After each
   successful sync the daemon drops the oldest already-synced Parquet files until
   free space is back above the floor (the coverage manifest keeps the resume
-  cursor, `.dccd/` is never touched). (#XX)
+  cursor, `.dccd/` is never touched). (#89)
 
 ### Changed
 

--- a/dccd/__init__.py
+++ b/dccd/__init__.py
@@ -70,6 +70,7 @@ class Client:
         self._config: AppConfig | None = None
         self._store: ParquetStore | None = None
         self._registry: SourceRegistry | None = None
+        self._coverage_store: Any = None
 
     def _require_ready(self) -> tuple["SourceRegistry", "ParquetStore"]:
         if self._registry is None or self._store is None:
@@ -78,7 +79,11 @@ class Client:
 
     async def __aenter__(self) -> "Client":
         from dccd.application.config import AppConfig, load_config, resolve_config_path
-        from dccd.application.service_factory import build_registry, build_store
+        from dccd.application.service_factory import (
+            build_coverage_store,
+            build_registry,
+            build_store,
+        )
 
         try:
             path = resolve_config_path(self._config_path)
@@ -88,6 +93,7 @@ class Client:
 
         # Single source of truth for adapter wiring — same as CLI and API.
         self._store = build_store(self._config.settings.data_path)
+        self._coverage_store = build_coverage_store(self._config.settings.data_path)
         self._registry = build_registry()
         return self
 
@@ -156,7 +162,8 @@ class Client:
             origin="runtime",
         )
         registry, store = self._require_ready()
-        return await do_backfill(spec, registry=registry, store=store)
+        return await do_backfill(spec, registry=registry, store=store,
+                                 coverage_store=self._coverage_store)
 
     async def stream(self, exchange: str, symbol: str, data_type: str = "trades",
                      span: int | None = None, depth: int | None = None,

--- a/dccd/__init__.py
+++ b/dccd/__init__.py
@@ -71,6 +71,7 @@ class Client:
         self._store: ParquetStore | None = None
         self._registry: SourceRegistry | None = None
         self._coverage_store: Any = None
+        self._remote: Any = None
 
     def _require_ready(self) -> tuple["SourceRegistry", "ParquetStore"]:
         if self._registry is None or self._store is None:
@@ -82,6 +83,7 @@ class Client:
         from dccd.application.service_factory import (
             build_coverage_store,
             build_registry,
+            build_remote,
             build_store,
         )
 
@@ -94,6 +96,7 @@ class Client:
         # Single source of truth for adapter wiring — same as CLI and API.
         self._store = build_store(self._config.settings.data_path)
         self._coverage_store = build_coverage_store(self._config.settings.data_path)
+        self._remote = build_remote(self._config)
         self._registry = build_registry()
         return self
 
@@ -256,7 +259,8 @@ class Client:
         _, store = self._require_ready()
         target = JobTarget(exchange=exchange, symbol=Symbol.parse(symbol),
                            data_type=DataType(data_type), span=span)
-        return cast("pl.DataFrame", do_read(target, store=store, start_ns=start_ns, end_ns=end_ns))
+        return cast("pl.DataFrame", do_read(target, store=store, start_ns=start_ns,
+                                            end_ns=end_ns, remote=self._remote))
 
     def inventory(self) -> list[dict[str, Any]]:
         """List every stored dataset with its coverage.

--- a/dccd/application/config.py
+++ b/dccd/application/config.py
@@ -70,10 +70,12 @@ class RemoteConfig(BaseModel):
 
 
 class StorageConfig(BaseModel):
-    """Storage settings: local path, rclone remotes, and sync interval."""
+    """Storage settings: local path, rclone remotes, sync interval, and the
+    free-space floor (GiB) that triggers purging already-synced local files."""
     local_path: str = ""
     remotes: list[RemoteConfig] = Field(default_factory=list)
     sync_interval: int = 3600
+    min_free_gb: float = 0.0
 
 
 class AlertConfig(BaseModel):

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -28,9 +28,10 @@ from dccd.domain.types import DataType
 from dccd.sources.base import OHLCHistory, OrderBookSnapshotREST, TradesHistory
 from dccd.sources.registry import SourceRegistry
 from dccd.storage.parquet import ParquetStore
+from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
 
-__all__ = ["backfill", "stream", "read", "inventory"]
+__all__ = ["backfill", "stream", "read", "inventory", "sync_remote"]
 
 logger = logging.getLogger(__name__)
 
@@ -470,3 +471,66 @@ def read(
 def inventory(*, store: ParquetStore) -> list[dict[str, Any]]:
     """Return a list of dataset descriptors for all stored data."""
     return store.inventory()
+
+
+async def sync_remote(
+    remote: RemoteStorage,
+    *,
+    runs_store: RunsStore | None = None,
+    events: RunEvents | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Run one remote-sync cycle: mirror the local store to all rclone remotes.
+
+    Records the cycle as a ``sync`` run in *runs_store* (so the Storage UI can
+    show "last sync") and emits ``status``/``log`` on *events*. Shared by the
+    scheduler's periodic loop and the manual "Sync now" endpoint, so the
+    run-recording lives in exactly one place.
+
+    Parameters
+    ----------
+    remote : RemoteStorage
+    runs_store : RunsStore or None
+    events : RunEvents or None
+    run_id : str or None
+        Override the auto-generated run id.
+
+    Returns
+    -------
+    dict
+        ``{'run_id', 'results', 'ok'}`` — ``results`` maps remote → success;
+        ``ok`` is True only when every configured remote synced.
+    """
+    if run_id is None:
+        run_id = f"remote-sync@{time.time_ns()}"
+    if runs_store:
+        runs_store.create_run(run_id, "remote-sync", "sync", "-", "all", "-")
+    if events:
+        events.status("running")
+    try:
+        results = await remote.sync_all()
+    except Exception as exc:
+        msg = f"Remote sync error: {exc}"
+        if events:
+            events.log(msg, "error")
+            events.status("failed")
+        if runs_store:
+            runs_store.finish_run(run_id, "failed", error=str(exc))
+        return {"run_id": run_id, "results": {}, "ok": False}
+
+    failed = [r for r, ok in results.items() if not ok]
+    if failed:
+        msg = f"Remote sync failed for: {', '.join(failed)}"
+        if events:
+            events.log(msg, "error")
+            events.status("failed")
+        if runs_store:
+            runs_store.finish_run(run_id, "failed", error=msg)
+        return {"run_id": run_id, "results": results, "ok": False}
+
+    if events:
+        events.log(f"Synced {len(results)} remote(s)")
+        events.status("succeeded")
+    if runs_store:
+        runs_store.finish_run(run_id, "succeeded", rows_written=len(results))
+    return {"run_id": run_id, "results": results, "ok": True}

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -27,6 +27,7 @@ from dccd.domain.timeutils import NS, ns_now, ns_to_dt
 from dccd.domain.types import DataType
 from dccd.sources.base import OHLCHistory, OrderBookSnapshotREST, TradesHistory
 from dccd.sources.registry import SourceRegistry
+from dccd.storage.coverage_sqlite import CoverageStore
 from dccd.storage.parquet import ParquetStore
 from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
@@ -113,6 +114,7 @@ async def backfill(
     registry: SourceRegistry,
     store: ParquetStore,
     runs_store: RunsStore | None = None,
+    coverage_store: CoverageStore | None = None,
     events: RunEvents | None = None,
     stop_event: asyncio.Event | None = None,
     run_id: str | None = None,
@@ -137,6 +139,10 @@ async def backfill(
     registry : SourceRegistry
     store : ParquetStore
     runs_store : RunsStore or None
+    coverage_store : CoverageStore or None
+        When set, ``start="last"`` falls back to the manifest's recorded
+        ``max_ts`` if no local file exists (so a dropped store doesn't trigger a
+        re-download), and the dataset's extent is recorded on success.
     events : RunEvents or None
     stop_event : asyncio.Event or None
         Set externally to cancel mid-run cleanly.
@@ -170,6 +176,11 @@ async def backfill(
 
     if params.start == "last":
         last = store.last_timestamp(ds)
+        if last is None and coverage_store is not None:
+            # Local files may have been dropped to free disk; the coverage
+            # manifest remembers how far we got, so we resume from there instead
+            # of re-downloading from the bounded default lookback.
+            last = coverage_store.get_max_ts(ds)
         if last is not None:
             start_ns: int = last + 1
         else:
@@ -200,6 +211,17 @@ async def backfill(
 
     # Counts every item received from the paginator, including unflushed ones.
     _collected: list[int] = [0]
+
+    # Min/max timestamp seen this run, fed to the coverage manifest on success so
+    # the dataset's extent survives a local-data drop (see CoverageStore).
+    _run_min: list[int | None] = [None]
+    _run_max: list[int | None] = [None]
+
+    def _track_ts(ts: int) -> None:
+        if _run_min[0] is None or ts < _run_min[0]:
+            _run_min[0] = ts
+        if _run_max[0] is None or ts > _run_max[0]:
+            _run_max[0] = ts
 
     # Progress is reported by *time covered* of the requested window, which gives
     # a real, smooth bar for both OHLC and cursor-paginated trades (the latter
@@ -258,6 +280,7 @@ async def backfill(
                     break
                 bars.append(bar)
                 _collected[0] += 1
+                _track_ts(bar.ts)
                 if _collected[0] % 200 == 0:
                     _emit_time(bar.ts)
                 if len(bars) >= _FLUSH_BATCH:
@@ -296,6 +319,7 @@ async def backfill(
                     break
                 batch.append(trade)
                 _collected[0] += 1
+                _track_ts(trade.ts)
                 if _collected[0] % 1000 == 0:
                     _emit_time(trade.ts)  # progress by time covered, not page count
                 if len(batch) >= _FLUSH_BATCH:
@@ -310,6 +334,7 @@ async def backfill(
                 raise NoCapability(target.exchange, "orderbook", "snapshot")
             depth = params.depth or 50
             snap = await adapter.fetch_orderbook(target.symbol, depth)
+            _track_ts(snap.ts)
             total_written += await _flush(store, ds, [snap], prov_src)
 
     except Exception as exc:
@@ -328,6 +353,12 @@ async def backfill(
         events.status(state)
     if runs_store:
         runs_store.finish_run(run_id, state, rows_written=total_written)
+
+    # Record coverage so this dataset's extent survives a later local-data drop.
+    if coverage_store is not None and _run_max[0] is not None:
+        coverage_store.record(
+            ds, min_ts=_run_min[0], max_ts=_run_max[0], rows_added=total_written
+        )
 
     return {"run_id": run_id, "rows_written": total_written, "start_ns": start_ns, "end_ns": end_ns}
 

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -493,9 +493,21 @@ def read(
     store: ParquetStore,
     start_ns: int | None = None,
     end_ns: int | None = None,
+    remote: RemoteStorage | None = None,
 ) -> Any:
-    """Read stored data for *target* in the given nanosecond range."""
+    """Read stored data for *target* in the given nanosecond range.
+
+    Read-through restore: when *remote* is set and the dataset has no local
+    Parquet (e.g. it was purged to free disk), the dataset directory is pulled
+    back from the remote (``rclone copy``) before loading, so a purge is
+    transparent to readers.
+    """
     ds = _make_dataset_id(target)
+    if remote is not None:
+        directory = store.directory(ds)
+        if not any(directory.glob("*.parquet")):
+            rel = directory.relative_to(store.root)
+            remote.restore(str(rel))
     return store.load(ds, start_ns, end_ns)
 
 

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -9,6 +9,7 @@ import time
 from dccd.application.events import EventBus
 from dccd.application.jobs import JobSpec
 from dccd.sources.registry import SourceRegistry
+from dccd.storage.coverage_sqlite import CoverageStore
 from dccd.storage.parquet import ParquetStore
 from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
@@ -106,6 +107,7 @@ class Scheduler:
         events: EventBus | None = None,
         remote: RemoteStorage | None = None,
         sync_interval: int = 3600,
+        coverage_store: CoverageStore | None = None,
     ) -> None:
         self._registry = registry
         self._store = store
@@ -113,6 +115,7 @@ class Scheduler:
         self._events = events or EventBus()
         self._remote = remote
         self._sync_interval = sync_interval
+        self._coverage_store = coverage_store
         self._sync_task: asyncio.Task[None] | None = None
         self._streams: dict[str, _StreamWorker] = {}
         self._interval_tasks: list[asyncio.Task[None]] = []
@@ -281,6 +284,7 @@ class Scheduler:
                 registry=self._registry,
                 store=self._store,
                 runs_store=self._runs_store,
+                coverage_store=self._coverage_store,
                 events=run_events,
             )
         except Exception as exc:

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -240,53 +240,31 @@ class Scheduler:
         """Periodically mirror the local store to the configured rclone remotes.
 
         Runs only when a :class:`~dccd.storage.remote.RemoteStorage` was wired in
-        (``storage.remotes`` non-empty). Each cycle is recorded as a ``sync`` run
-        in :class:`RunsStore` (so the Storage UI can show "last sync") and emitted
-        live on the ``remote-sync`` EventBus channel. On failure it backs off
-        exponentially (30s → capped at ``sync_interval``) so a flapping remote
-        doesn't hammer rclone.
+        (``storage.remotes`` non-empty). Each cycle is delegated to
+        :func:`dccd.application.operations.sync_remote` (which records a ``sync``
+        run in :class:`RunsStore` and emits live ``remote-sync`` EventBus status);
+        this loop only owns the cadence and the exponential backoff on failure
+        (30s → capped at ``sync_interval``) so a flapping remote doesn't hammer
+        rclone.
         """
+        from dccd.application.operations import sync_remote
         assert self._remote is not None
         run_events = self._events.for_run("remote-sync")
         backoff = 30.0
-        while self._running:
-            run_id = f"remote-sync@{time.time_ns()}"
-            if self._runs_store:
-                self._runs_store.create_run(
-                    run_id, "remote-sync", "sync", "-", "all", "-"
+        try:
+            while self._running:
+                result = await sync_remote(
+                    self._remote, runs_store=self._runs_store, events=run_events
                 )
-            run_events.status("running")
-            try:
-                results = await self._remote.sync_all()
-                failed = [r for r, ok in results.items() if not ok]
-                if failed:
-                    msg = f"Remote sync failed for: {', '.join(failed)}"
-                    run_events.log(msg, "error")
-                    run_events.status("failed")
-                    if self._runs_store:
-                        self._runs_store.finish_run(run_id, "failed", error=msg)
+                if result["ok"]:
+                    backoff = 30.0
+                    await asyncio.sleep(self._sync_interval)
+                else:
+                    logger.warning("Remote sync failed — retry in %ds", int(backoff))
                     await asyncio.sleep(min(backoff, self._sync_interval))
                     backoff = min(backoff * 2, float(self._sync_interval))
-                    continue
-                run_events.log(f"Synced {len(results)} remote(s)")
-                run_events.status("succeeded")
-                if self._runs_store:
-                    self._runs_store.finish_run(
-                        run_id, "succeeded", rows_written=len(results)
-                    )
-                backoff = 30.0
-                await asyncio.sleep(self._sync_interval)
-            except asyncio.CancelledError:
-                return
-            except Exception as exc:
-                msg = f"Remote sync error: {exc}"
-                logger.warning("%s — retry in %ds", msg, int(backoff))
-                run_events.log(msg, "error")
-                run_events.status("failed")
-                if self._runs_store:
-                    self._runs_store.finish_run(run_id, "failed", error=str(exc))
-                await asyncio.sleep(min(backoff, self._sync_interval))
-                backoff = min(backoff * 2, float(self._sync_interval))
+        except asyncio.CancelledError:
+            return
 
     async def _interval_loop(self, spec: JobSpec) -> None:
         every = spec.trigger.every or spec.target.span or 3600

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 
-from dccd.application.events import EventBus
+from dccd.application.events import EventBus, RunEvents
 from dccd.application.jobs import JobSpec
 from dccd.sources.registry import SourceRegistry
 from dccd.storage.coverage_sqlite import CoverageStore
@@ -108,6 +108,8 @@ class Scheduler:
         remote: RemoteStorage | None = None,
         sync_interval: int = 3600,
         coverage_store: CoverageStore | None = None,
+        data_path: str | None = None,
+        min_free_gb: float = 0.0,
     ) -> None:
         self._registry = registry
         self._store = store
@@ -116,6 +118,8 @@ class Scheduler:
         self._remote = remote
         self._sync_interval = sync_interval
         self._coverage_store = coverage_store
+        self._data_path = data_path
+        self._min_free_gb = min_free_gb
         self._sync_task: asyncio.Task[None] | None = None
         self._streams: dict[str, _StreamWorker] = {}
         self._interval_tasks: list[asyncio.Task[None]] = []
@@ -260,6 +264,10 @@ class Scheduler:
                     self._remote, runs_store=self._runs_store, events=run_events
                 )
                 if result["ok"]:
+                    # Remote is now up to date → safe to free disk by dropping the
+                    # oldest already-synced files (the coverage manifest keeps the
+                    # resume cursor). Runs only when a floor is configured.
+                    await self._maybe_purge(run_events)
                     backoff = 30.0
                     await asyncio.sleep(self._sync_interval)
                 else:
@@ -268,6 +276,30 @@ class Scheduler:
                     backoff = min(backoff * 2, float(self._sync_interval))
         except asyncio.CancelledError:
             return
+
+    async def _maybe_purge(self, run_events: RunEvents) -> None:
+        """Free disk by dropping oldest synced files when below the floor.
+
+        Called right after a successful sync (remote is current), so dropped
+        files are recoverable from the remote. No-op unless ``min_free_gb`` and a
+        ``data_path`` are configured.
+        """
+        if self._min_free_gb <= 0 or not self._data_path:
+            return
+        from dccd.storage.purge import purge_to_free_space
+        try:
+            res = await asyncio.to_thread(
+                purge_to_free_space, self._data_path, self._min_free_gb
+            )
+        except Exception as exc:
+            logger.warning("Purge failed: %s", exc)
+            return
+        if res["removed"]:
+            run_events.log(
+                f"Purged {len(res['removed'])} file(s), "
+                f"freed ~{res['freed_bytes'] / (1024 ** 3):.2f} GiB to stay above "
+                f"{self._min_free_gb} GiB free"
+            )
 
     async def _interval_loop(self, spec: JobSpec) -> None:
         every = spec.trigger.every or spec.target.span or 3600

--- a/dccd/application/scheduler.py
+++ b/dccd/application/scheduler.py
@@ -10,6 +10,7 @@ from dccd.application.events import EventBus
 from dccd.application.jobs import JobSpec
 from dccd.sources.registry import SourceRegistry
 from dccd.storage.parquet import ParquetStore
+from dccd.storage.remote import RemoteStorage
 from dccd.storage.runs_sqlite import RunsStore
 
 __all__ = ["Scheduler"]
@@ -90,6 +91,11 @@ class Scheduler:
     store : ParquetStore
     runs_store : RunsStore or None
     events : EventBus
+    remote : RemoteStorage or None
+        When set (rclone remotes configured), :meth:`start` launches a periodic
+        loop that mirrors the local store off-box every ``sync_interval`` seconds.
+    sync_interval : int
+        Seconds between remote-sync cycles (default 3600).
     """
 
     def __init__(
@@ -98,11 +104,16 @@ class Scheduler:
         store: ParquetStore,
         runs_store: RunsStore | None = None,
         events: EventBus | None = None,
+        remote: RemoteStorage | None = None,
+        sync_interval: int = 3600,
     ) -> None:
         self._registry = registry
         self._store = store
         self._runs_store = runs_store
         self._events = events or EventBus()
+        self._remote = remote
+        self._sync_interval = sync_interval
+        self._sync_task: asyncio.Task[None] | None = None
         self._streams: dict[str, _StreamWorker] = {}
         self._interval_tasks: list[asyncio.Task[None]] = []
         # Per-spec recurring backfill loops, keyed by spec id, with the interval
@@ -186,6 +197,8 @@ class Scheduler:
     async def start(self, specs: list[JobSpec]) -> None:
         """Start all enabled specs (full daemon mode)."""
         self._running = True
+        if self._remote is not None and self._sync_task is None:
+            self._sync_task = asyncio.create_task(self._sync_loop())
         for spec in specs:
             if not spec.enabled:
                 continue
@@ -207,6 +220,13 @@ class Scheduler:
     async def stop(self) -> None:
         """Stop all running jobs."""
         self._running = False
+        if self._sync_task is not None:
+            self._sync_task.cancel()
+            try:
+                await self._sync_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._sync_task = None
         for task in self._interval_tasks:
             task.cancel()
         for task, _ in self._interval_loops.values():
@@ -215,6 +235,58 @@ class Scheduler:
             await worker.stop()
         self._interval_tasks.clear()
         self._interval_loops.clear()
+
+    async def _sync_loop(self) -> None:
+        """Periodically mirror the local store to the configured rclone remotes.
+
+        Runs only when a :class:`~dccd.storage.remote.RemoteStorage` was wired in
+        (``storage.remotes`` non-empty). Each cycle is recorded as a ``sync`` run
+        in :class:`RunsStore` (so the Storage UI can show "last sync") and emitted
+        live on the ``remote-sync`` EventBus channel. On failure it backs off
+        exponentially (30s → capped at ``sync_interval``) so a flapping remote
+        doesn't hammer rclone.
+        """
+        assert self._remote is not None
+        run_events = self._events.for_run("remote-sync")
+        backoff = 30.0
+        while self._running:
+            run_id = f"remote-sync@{time.time_ns()}"
+            if self._runs_store:
+                self._runs_store.create_run(
+                    run_id, "remote-sync", "sync", "-", "all", "-"
+                )
+            run_events.status("running")
+            try:
+                results = await self._remote.sync_all()
+                failed = [r for r, ok in results.items() if not ok]
+                if failed:
+                    msg = f"Remote sync failed for: {', '.join(failed)}"
+                    run_events.log(msg, "error")
+                    run_events.status("failed")
+                    if self._runs_store:
+                        self._runs_store.finish_run(run_id, "failed", error=msg)
+                    await asyncio.sleep(min(backoff, self._sync_interval))
+                    backoff = min(backoff * 2, float(self._sync_interval))
+                    continue
+                run_events.log(f"Synced {len(results)} remote(s)")
+                run_events.status("succeeded")
+                if self._runs_store:
+                    self._runs_store.finish_run(
+                        run_id, "succeeded", rows_written=len(results)
+                    )
+                backoff = 30.0
+                await asyncio.sleep(self._sync_interval)
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                msg = f"Remote sync error: {exc}"
+                logger.warning("%s — retry in %ds", msg, int(backoff))
+                run_events.log(msg, "error")
+                run_events.status("failed")
+                if self._runs_store:
+                    self._runs_store.finish_run(run_id, "failed", error=str(exc))
+                await asyncio.sleep(min(backoff, self._sync_interval))
+                backoff = min(backoff * 2, float(self._sync_interval))
 
     async def _interval_loop(self, spec: JobSpec) -> None:
         every = spec.trigger.every or spec.target.span or 3600

--- a/dccd/application/service_factory.py
+++ b/dccd/application/service_factory.py
@@ -11,11 +11,13 @@ import pathlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from dccd.application.config import AppConfig
     from dccd.sources.registry import SourceRegistry
     from dccd.storage.parquet import ParquetStore
+    from dccd.storage.remote import RemoteStorage
     from dccd.storage.runs_sqlite import RunsStore
 
-__all__ = ["build_registry", "build_store", "build_runs_store"]
+__all__ = ["build_registry", "build_store", "build_runs_store", "build_remote"]
 
 
 def build_registry() -> "SourceRegistry":
@@ -77,3 +79,30 @@ def build_runs_store(data_path: str | pathlib.Path) -> "RunsStore":
     from dccd.storage.runs_sqlite import RunsStore
 
     return RunsStore(pathlib.Path(data_path) / ".dccd" / "runs.db")
+
+
+def build_remote(cfg: "AppConfig") -> "RemoteStorage | None":
+    """Return a :class:`~dccd.storage.remote.RemoteStorage`, or ``None``.
+
+    Returns ``None`` when no rclone remotes are configured (``storage.remotes``
+    empty) — there is nothing to sync, so the daemon skips the sync loop. The
+    local root is ``settings.data_path`` (the canonical store root used by
+    :func:`build_store`).
+
+    Parameters
+    ----------
+    cfg : AppConfig
+
+    Returns
+    -------
+    RemoteStorage or None
+    """
+    if not cfg.storage.remotes:
+        return None
+
+    from dccd.storage.remote import RemoteStorage
+
+    return RemoteStorage(
+        cfg.settings.data_path,
+        [r.model_dump() for r in cfg.storage.remotes],
+    )

--- a/dccd/application/service_factory.py
+++ b/dccd/application/service_factory.py
@@ -13,11 +13,18 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from dccd.application.config import AppConfig
     from dccd.sources.registry import SourceRegistry
+    from dccd.storage.coverage_sqlite import CoverageStore
     from dccd.storage.parquet import ParquetStore
     from dccd.storage.remote import RemoteStorage
     from dccd.storage.runs_sqlite import RunsStore
 
-__all__ = ["build_registry", "build_store", "build_runs_store", "build_remote"]
+__all__ = [
+    "build_registry",
+    "build_store",
+    "build_runs_store",
+    "build_remote",
+    "build_coverage_store",
+]
 
 
 def build_registry() -> "SourceRegistry":
@@ -79,6 +86,26 @@ def build_runs_store(data_path: str | pathlib.Path) -> "RunsStore":
     from dccd.storage.runs_sqlite import RunsStore
 
     return RunsStore(pathlib.Path(data_path) / ".dccd" / "runs.db")
+
+
+def build_coverage_store(data_path: str | pathlib.Path) -> "CoverageStore":
+    """Return a :class:`~dccd.storage.coverage_sqlite.CoverageStore`.
+
+    The database lives at ``{data_path}/.dccd/coverage.db`` — the manifest that
+    lets local data be dropped without forcing a re-download on the next
+    backfill.
+
+    Parameters
+    ----------
+    data_path : str or Path
+
+    Returns
+    -------
+    CoverageStore
+    """
+    from dccd.storage.coverage_sqlite import CoverageStore
+
+    return CoverageStore(pathlib.Path(data_path) / ".dccd" / "coverage.db")
 
 
 def build_remote(cfg: "AppConfig") -> "RemoteStorage | None":

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -41,10 +41,12 @@ from dccd.application.registry import REGISTRY
 from dccd.application.scheduler import Scheduler
 from dccd.application.service_factory import (
     build_registry,
+    build_remote,
     build_runs_store,
     build_store,
 )
 from dccd.domain.symbol import Symbol
+from dccd.domain.timeutils import NS
 from dccd.domain.types import DataType
 from dccd.storage.runs_sqlite import RunsStore
 
@@ -169,6 +171,10 @@ def create_app(
         app.state.runs_store = build_runs_store(cfg.settings.data_path)
         app.state.event_bus = EventBus()
         app.state.registry = build_registry()
+        # Remote sync target (None when storage.remotes is empty). Resolved from
+        # config — not the scheduler — so "Sync now" works in `dccd ui` mode too,
+        # where the standalone scheduler has no remote wired in.
+        app.state.remote = build_remote(cfg)
 
         if scheduler is not None:
             app.state.scheduler = scheduler
@@ -337,6 +343,58 @@ def create_app(
     async def get_inventory(request: Request) -> dict[str, Any]:
         """Return all stored datasets."""
         return {"datasets": _store(request).inventory()}
+
+    # -----------------------------------------------------------------------
+    # Remote sync
+    # -----------------------------------------------------------------------
+
+    @app.get("/api/storage/sync")
+    async def get_sync_status(request: Request) -> dict[str, Any]:
+        """Remote-sync status for the Storage page.
+
+        Reports whether remotes are configured, the last persisted ``sync`` run
+        (state/time/error), the next scheduled sync ETA, and the on-disk store
+        size (the "synced volume" proxy — after a successful mirror local equals
+        remote).
+        """
+        cfg = _cfg(request)
+        remotes = [r.remote for r in cfg.storage.remotes]
+        configured = bool(remotes)
+        interval = cfg.storage.sync_interval
+        runs = _runs(request).list_runs(spec_id="remote-sync", limit=1)
+        last = None
+        next_eta = None
+        if runs:
+            r = runs[0]
+            last = {
+                "state": r["state"],
+                "ended_at": r["ended_at"],
+                "error": r["error"],
+                "rows_written": r["rows_written"],
+            }
+            if configured and r["ended_at"]:
+                next_eta = r["ended_at"] + interval * NS
+        total_bytes = sum(d.get("bytes", 0) for d in _store(request).inventory())
+        return {
+            "configured": configured,
+            "remotes": remotes,
+            "sync_interval": interval,
+            "last": last,
+            "next_eta": next_eta,
+            "bytes": total_bytes,
+        }
+
+    @app.post("/api/storage/sync")
+    async def trigger_sync(request: Request) -> dict[str, Any]:
+        """Trigger a remote sync now (runs in the background)."""
+        remote = request.app.state.remote
+        if remote is None:
+            raise HTTPException(400, "no remotes configured")
+        from dccd.application.operations import sync_remote
+
+        events = request.app.state.event_bus.for_run("remote-sync")
+        _spawn(request, sync_remote(remote, runs_store=_runs(request), events=events))
+        return {"status": "started"}
 
     # -----------------------------------------------------------------------
     # Backfill

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -648,7 +648,11 @@ def create_app(
             exchange=body.exchange, symbol=sym,
             data_type=DataType(body.data_type), span=body.span,
         )
-        df = read(target, store=_store(request), start_ns=body.start_ns, end_ns=body.end_ns)
+        # Off-thread: read-through restore may shell out to rclone (blocking).
+        df = await asyncio.to_thread(
+            read, target, store=_store(request), start_ns=body.start_ns,
+            end_ns=body.end_ns, remote=request.app.state.remote,
+        )
         rows = df.to_dicts() if hasattr(df, "to_dicts") else []
         return {"rows": len(rows), "data": rows[:1000]}
 

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -40,6 +40,7 @@ from dccd.application.jobs import JobParams, JobSpec, JobTarget, Trigger
 from dccd.application.registry import REGISTRY
 from dccd.application.scheduler import Scheduler
 from dccd.application.service_factory import (
+    build_coverage_store,
     build_registry,
     build_remote,
     build_runs_store,
@@ -169,6 +170,7 @@ def create_app(
         app.state.config_path = config_path
         app.state.store = build_store(cfg.settings.data_path)
         app.state.runs_store = build_runs_store(cfg.settings.data_path)
+        app.state.coverage_store = build_coverage_store(cfg.settings.data_path)
         app.state.event_bus = EventBus()
         app.state.registry = build_registry()
         # Remote sync target (None when storage.remotes is empty). Resolved from
@@ -184,6 +186,7 @@ def create_app(
                 app.state.store,
                 app.state.runs_store,
                 app.state.event_bus,
+                coverage_store=app.state.coverage_store,
             )
 
         # Register stream workers from config so they can be started/stopped
@@ -308,6 +311,7 @@ def create_app(
         reg = _reg(request)
         store = _store(request)
         runs_store = _runs(request)
+        coverage_store = request.app.state.coverage_store
         bus = _bus(request)
         stops = request.app.state.backfill_stops
         stop_event = asyncio.Event()
@@ -317,6 +321,7 @@ def create_app(
             from dccd.application.operations import backfill
             try:
                 await backfill(spec, registry=reg, store=store, runs_store=runs_store,
+                               coverage_store=coverage_store,
                                events=bus.for_run(run_id), run_id=run_id,
                                stop_event=stop_event)
             except Exception as exc:

--- a/dccd/interfaces/cli/main.py
+++ b/dccd/interfaces/cli/main.py
@@ -167,6 +167,7 @@ def cmd_start(
         registry, store, runs_store, bus,
         remote=remote, sync_interval=cfg.storage.sync_interval,
         coverage_store=coverage_store,
+        data_path=cfg.settings.data_path, min_free_gb=cfg.storage.min_free_gb,
     )
     if remote is not None:
         typer.echo(

--- a/dccd/interfaces/cli/main.py
+++ b/dccd/interfaces/cli/main.py
@@ -45,6 +45,7 @@ def cmd_backfill(
     from dccd.application.jobs import JobParams, JobSpec, JobTarget, Trigger
     from dccd.application.operations import backfill as do_backfill
     from dccd.application.service_factory import (
+        build_coverage_store,
         build_registry,
         build_runs_store,
         build_store,
@@ -55,6 +56,7 @@ def cmd_backfill(
     cfg, _ = _load_cfg(config)
     store = build_store(cfg.settings.data_path)
     runs_store = build_runs_store(cfg.settings.data_path)
+    coverage_store = build_coverage_store(cfg.settings.data_path)
     registry = build_registry()
 
     specs: list[JobSpec] = []
@@ -81,7 +83,8 @@ def cmd_backfill(
     async def _run():
         for spec in specs:
             typer.echo(f"Backfilling {spec.id}…")
-            result = await do_backfill(spec, registry=registry, store=store, runs_store=runs_store)
+            result = await do_backfill(spec, registry=registry, store=store,
+                                       runs_store=runs_store, coverage_store=coverage_store)
             if err := result.get("error"):
                 typer.echo(f"  ✗ {err}", err=True)
             else:
@@ -145,6 +148,7 @@ def cmd_start(
     from dccd.application.events import EventBus
     from dccd.application.scheduler import Scheduler
     from dccd.application.service_factory import (
+        build_coverage_store,
         build_registry,
         build_remote,
         build_runs_store,
@@ -155,12 +159,14 @@ def cmd_start(
     cfg, cfg_path = _load_cfg(config)
     store = build_store(cfg.settings.data_path)
     runs_store = build_runs_store(cfg.settings.data_path)
+    coverage_store = build_coverage_store(cfg.settings.data_path)
     registry = build_registry()
     bus = EventBus()
     remote = build_remote(cfg)
     scheduler = Scheduler(
         registry, store, runs_store, bus,
         remote=remote, sync_interval=cfg.storage.sync_interval,
+        coverage_store=coverage_store,
     )
     if remote is not None:
         typer.echo(

--- a/dccd/interfaces/cli/main.py
+++ b/dccd/interfaces/cli/main.py
@@ -146,6 +146,7 @@ def cmd_start(
     from dccd.application.scheduler import Scheduler
     from dccd.application.service_factory import (
         build_registry,
+        build_remote,
         build_runs_store,
         build_store,
     )
@@ -156,7 +157,16 @@ def cmd_start(
     runs_store = build_runs_store(cfg.settings.data_path)
     registry = build_registry()
     bus = EventBus()
-    scheduler = Scheduler(registry, store, runs_store, bus)
+    remote = build_remote(cfg)
+    scheduler = Scheduler(
+        registry, store, runs_store, bus,
+        remote=remote, sync_interval=cfg.storage.sync_interval,
+    )
+    if remote is not None:
+        typer.echo(
+            f"Remote sync every {cfg.storage.sync_interval}s "
+            f"→ {len(cfg.storage.remotes)} remote(s)"
+        )
 
     # Run *all* configured jobs, not just streams: the scheduler routes each by
     # trigger kind (supervised → stream worker; interval/cron → periodic

--- a/dccd/interfaces/ui/templates/storage.html
+++ b/dccd/interfaces/ui/templates/storage.html
@@ -4,12 +4,65 @@
 <h1>Storage</h1>
 
 <div class="card">
+  <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem">
+    <h2 style="margin:0">Remote sync</h2>
+    <button id="sync-now" type="button" onclick="syncNow()" style="display:none">Sync now</button>
+  </div>
+  <div id="sync-content" style="margin-top:.75rem"><span class="muted">Loading…</span></div>
+</div>
+
+<div class="card">
   <h2 style="margin-top:0">Datasets on disk</h2>
   <div id="inv-content"><span class="muted">Loading…</span></div>
 </div>
 {% endblock %}
 {% block scripts %}
 <script>
+const SYNC_DOT = { succeeded: 'fresh', running: 'stale', failed: 'dead' };
+
+async function loadSync() {
+  try {
+    const s = await api('GET', '/api/storage/sync');
+    const btn = document.getElementById('sync-now');
+    if (!s.configured) {
+      btn.style.display = 'none';
+      document.getElementById('sync-content').innerHTML =
+        '<span class="muted">No remote configured — add <code>storage.remotes</code> on the Config page.</span>';
+      return;
+    }
+    btn.style.display = '';
+    const st = s.last ? s.last.state : null;
+    const dot = SYNC_DOT[st] || 'dead';
+    const lastLabel = s.last && s.last.ended_at ? fmtFreshness(s.last.ended_at)
+      : (st === 'running' ? 'running…' : 'never');
+    let html = `<p style="margin:.2rem 0">
+      <span class="live-dot ${dot}"></span>
+      <strong>Last sync:</strong> ${escapeHtml(lastLabel)}${st ? ` <span class="muted">(${escapeHtml(st)})</span>` : ''}
+    </p>`;
+    if (s.next_eta) html += `<p class="muted" style="margin:.2rem 0">Next sync: ${fmtNs(s.next_eta)}</p>`;
+    html += `<p class="muted" style="margin:.2rem 0">Remotes: ${s.remotes.map(escapeHtml).join(', ')} · Synced volume: ${fmtBytes(s.bytes)}</p>`;
+    if (s.last && s.last.state === 'failed' && s.last.error)
+      html += `<p class="err" style="margin:.2rem 0">${escapeHtml(s.last.error)}</p>`;
+    document.getElementById('sync-content').innerHTML = html;
+  } catch (e) {
+    document.getElementById('sync-content').innerHTML = `<span class="err">${escapeHtml(e.message)}</span>`;
+  }
+}
+
+async function syncNow() {
+  const btn = document.getElementById('sync-now');
+  btn.disabled = true;
+  try {
+    await api('POST', '/api/storage/sync');
+    // Poll a few times so the result lands without a manual refresh.
+    for (const ms of [400, 1200, 3000]) setTimeout(loadSync, ms);
+  } catch (e) {
+    document.getElementById('sync-content').innerHTML = `<span class="err">${escapeHtml(e.message)}</span>`;
+  } finally {
+    setTimeout(() => { btn.disabled = false; }, 1000);
+  }
+}
+
 async function loadInventory() {
   try {
     const { datasets } = await api('GET', '/api/inventory');
@@ -48,6 +101,8 @@ async function loadInventory() {
   }
 }
 
+loadSync();
 loadInventory();
+setInterval(loadSync, 10000);
 </script>
 {% endblock %}

--- a/dccd/storage/coverage_sqlite.py
+++ b/dccd/storage/coverage_sqlite.py
@@ -1,0 +1,134 @@
+"""SQLite-backed coverage manifest.
+
+Records, per dataset, the extent of data we have collected — independent of the
+Parquet files themselves. This is what lets local data be **dropped** (to free
+disk) without forcing a re-download: ``backfill(start="last")`` falls back to the
+manifest's ``max_ts`` when no local file is present, so it resumes from where
+collection left off instead of from the bounded default lookback.
+
+Lives at ``{data_path}/.dccd/coverage.db`` — the ``.dccd`` directory is never
+purged, so the manifest survives a local-data drop.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import sqlite3
+import time
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Generator
+
+if TYPE_CHECKING:
+    from dccd.domain.dataset import DatasetId
+
+__all__ = ["CoverageStore"]
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+
+CREATE TABLE IF NOT EXISTS coverage (
+    dataset_id  TEXT PRIMARY KEY,
+    exchange    TEXT NOT NULL,
+    symbol      TEXT NOT NULL,
+    data_type   TEXT NOT NULL,
+    span        INTEGER,
+    min_ts      INTEGER,
+    max_ts      INTEGER,
+    rows        INTEGER DEFAULT 0,
+    updated_at  INTEGER NOT NULL
+);
+"""
+
+
+class CoverageStore:
+    """Per-dataset coverage manifest (min/max ts + row count).
+
+    Parameters
+    ----------
+    db_path : str or Path
+        Path to the SQLite database file. Created if absent.
+    """
+
+    def __init__(self, db_path: str | pathlib.Path) -> None:
+        self._path = pathlib.Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as conn:
+            conn.executescript(_SCHEMA)
+
+    @contextmanager
+    def _conn(self) -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(str(self._path))
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def record(
+        self,
+        ds: "DatasetId",
+        *,
+        min_ts: int | None,
+        max_ts: int | None,
+        rows_added: int = 0,
+    ) -> None:
+        """Upsert coverage for *ds*, widening the [min_ts, max_ts] envelope.
+
+        ``min_ts``/``max_ts`` are merged with any existing row (min of mins, max
+        of maxes), so a later backfill never *narrows* the recorded extent;
+        ``rows_added`` accumulates (an approximate stored-row tally for display).
+        """
+        key = str(ds)
+        now = int(time.time() * 1_000_000_000)
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT min_ts, max_ts, rows FROM coverage WHERE dataset_id=?",
+                (key,),
+            ).fetchone()
+            if row is not None:
+                new_min = _merge(row["min_ts"], min_ts, min)
+                new_max = _merge(row["max_ts"], max_ts, max)
+                new_rows = (row["rows"] or 0) + rows_added
+                conn.execute(
+                    "UPDATE coverage SET min_ts=?, max_ts=?, rows=?, updated_at=? "
+                    "WHERE dataset_id=?",
+                    (new_min, new_max, new_rows, now, key),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO coverage (dataset_id, exchange, symbol, "
+                    "data_type, span, min_ts, max_ts, rows, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (key, ds.exchange, str(ds.symbol), ds.data_type.value,
+                     ds.span, min_ts, max_ts, rows_added, now),
+                )
+
+    def get_max_ts(self, ds: "DatasetId") -> int | None:
+        """Return the recorded ``max_ts`` for *ds*, or ``None`` if unknown."""
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT max_ts FROM coverage WHERE dataset_id=?", (str(ds),)
+            ).fetchone()
+            return row["max_ts"] if row else None
+
+    def list_all(self) -> list[dict[str, Any]]:
+        """Return every coverage row (most recently updated first)."""
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM coverage ORDER BY updated_at DESC"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+
+def _merge(existing: int | None, incoming: int | None, op: Any) -> int | None:
+    """Combine two optional ints with *op* (min/max), ignoring ``None``."""
+    vals = [v for v in (existing, incoming) if v is not None]
+    return op(vals) if vals else None

--- a/dccd/storage/parquet.py
+++ b/dccd/storage/parquet.py
@@ -119,6 +119,11 @@ class ParquetStore:
         self._file_locks: dict[str, threading.Lock] = {}
         self._file_locks_guard = threading.Lock()
 
+    @property
+    def root(self) -> pathlib.Path:
+        """Root directory of the local store."""
+        return self._root
+
     def _lock_for(self, file_path: pathlib.Path) -> threading.Lock:
         key = str(file_path)
         with self._file_locks_guard:

--- a/dccd/storage/purge.py
+++ b/dccd/storage/purge.py
@@ -1,0 +1,105 @@
+"""Free-space purge: drop the oldest already-synced Parquet files under disk
+pressure.
+
+**Safety contract**: this deletes local data that is recoverable only from the
+remote, so it must be called **only when the remote mirror is up to date** — in
+practice, right after a successful :func:`~dccd.application.operations.sync_remote`
+cycle. The coverage manifest (``CoverageStore``) preserves the resume cursor, so a
+later ``backfill(start="last")`` still continues from where collection left off;
+reads of purged ranges return what's local until read-through restore pulls them
+back.
+
+The ``.dccd`` directory (runs DB, coverage manifest) is never touched.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import shutil
+from typing import Any, Callable
+
+__all__ = ["purge_to_free_space", "free_bytes"]
+
+logger = logging.getLogger(__name__)
+
+_GB = 1024 ** 3
+
+
+def free_bytes(path: str | pathlib.Path) -> int:
+    """Return free bytes on the filesystem holding *path*."""
+    return shutil.disk_usage(str(path)).free
+
+
+def purge_to_free_space(
+    data_path: str | pathlib.Path,
+    min_free_gb: float,
+    *,
+    dry_run: bool = False,
+    free_fn: Callable[[], int] | None = None,
+) -> dict[str, Any]:
+    """Delete oldest Parquet files until free space reaches ``min_free_gb``.
+
+    Files are removed oldest-first (by mtime), so recent data stays local while
+    old data — already mirrored off-box — is dropped. The ``.dccd`` directory is
+    excluded. No-op when ``min_free_gb <= 0`` or free space is already above the
+    threshold.
+
+    Parameters
+    ----------
+    data_path : str or Path
+        Root of the local store.
+    min_free_gb : float
+        Target free space in GiB. ``<= 0`` disables purging.
+    dry_run : bool, default False
+        Report what would be removed without deleting.
+    free_fn : callable or None
+        Override for the *initial* free-bytes probe (testing). Defaults to a real
+        ``shutil.disk_usage`` of *data_path*. Freeing is then simulated by adding
+        each removed file's size, so the result is deterministic.
+
+    Returns
+    -------
+    dict
+        ``{'freed_bytes', 'removed', 'free_after'}`` — ``removed`` is the list of
+        deleted file paths (oldest first).
+    """
+    root = pathlib.Path(data_path)
+    start_free = (free_fn or (lambda: free_bytes(root)))()
+    result: dict[str, Any] = {
+        "freed_bytes": 0, "removed": [], "free_after": start_free,
+    }
+    if min_free_gb <= 0:
+        return result
+
+    target = int(min_free_gb * _GB)
+    if start_free >= target:
+        return result
+
+    files = [f for f in root.rglob("*.parquet") if ".dccd" not in f.parts]
+    files.sort(key=lambda f: f.stat().st_mtime)  # oldest first
+
+    freed = 0
+    removed: list[str] = []
+    for f in files:
+        if start_free + freed >= target:
+            break
+        size = f.stat().st_size
+        if not dry_run:
+            try:
+                f.unlink()
+            except OSError as exc:
+                logger.warning("Could not purge %s: %s", f, exc)
+                continue
+        freed += size
+        removed.append(str(f))
+
+    result["freed_bytes"] = freed
+    result["removed"] = removed
+    result["free_after"] = start_free + freed
+    if removed:
+        logger.info(
+            "Purged %d file(s), freed ~%.2f GiB (free now %.2f GiB)",
+            len(removed), freed / _GB, result["free_after"] / _GB,
+        )
+    return result

--- a/dccd/storage/remote.py
+++ b/dccd/storage/remote.py
@@ -52,6 +52,46 @@ class RemoteStorage:
             logger.error("rclone sync to %s timed out", remote)
             return False
 
+    def restore(self, rel_path: str) -> bool:
+        """Pull *rel_path* back from the first configured remote into the store.
+
+        Runs ``rclone copy {remote}/{rel_path} {local}/{rel_path}`` — **copy**,
+        not sync, so nothing is ever deleted. Used for read-through restore when a
+        dataset's local Parquet was purged but still exists off-box. Returns True
+        on success (or no-op when no remote is configured).
+
+        Parameters
+        ----------
+        rel_path : str
+            Dataset directory relative to the local store root.
+        """
+        if not self._remotes:
+            return False
+        remote = self._remotes[0].get("remote", "")
+        if not remote:
+            return False
+        src = remote.rstrip("/") + "/" + rel_path
+        dst = self._local / rel_path
+        try:
+            dst.mkdir(parents=True, exist_ok=True)
+            result = subprocess.run(
+                ["rclone", "copy", src, str(dst), "--quiet"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                logger.error("rclone restore of %s failed: %s", rel_path, result.stderr)
+                return False
+            logger.info("Restored %s from %s", rel_path, remote)
+            return True
+        except FileNotFoundError:
+            logger.error("rclone not found in PATH")
+            return False
+        except subprocess.TimeoutExpired:
+            logger.error("rclone restore of %s timed out", rel_path)
+            return False
+
     async def sync_all(self) -> dict[str, bool]:
         """Sync to all configured remotes concurrently."""
         if not self._remotes:

--- a/dccd/tests/v3/test_api.py
+++ b/dccd/tests/v3/test_api.py
@@ -4,7 +4,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from dccd.application.config import AppConfig
+from dccd.application.config import AppConfig, RemoteConfig
 from dccd.interfaces.api.app import create_app
 
 
@@ -65,6 +65,54 @@ class TestAuth:
 
     def test_no_token_means_open(self, client):
         assert client.get("/api/inventory").status_code == 200
+
+
+class _OkRemote:
+    """In-test remote that reports success without invoking rclone."""
+
+    async def sync_all(self):
+        return {"r:bucket": True}
+
+
+class TestRemoteSync:
+    @pytest.fixture
+    def synced_app(self, tmp_data_path):
+        cfg = AppConfig()
+        cfg.settings.data_path = tmp_data_path
+        cfg.storage.local_path = tmp_data_path
+        cfg.storage.remotes = [RemoteConfig(remote="r:bucket")]
+        cfg.storage.sync_interval = 1800
+        return create_app(config=cfg)
+
+    def test_get_sync_not_configured(self, client):
+        body = client.get("/api/storage/sync").json()
+        assert body["configured"] is False
+        assert body["remotes"] == []
+        assert body["last"] is None
+
+    def test_get_sync_configured_with_last(self, synced_app, tmp_data_path):
+        from dccd.application.service_factory import build_runs_store
+
+        with TestClient(synced_app) as c:
+            runs = build_runs_store(tmp_data_path)
+            runs.create_run("remote-sync@1", "remote-sync", "sync", "-", "all", "-")
+            runs.finish_run("remote-sync@1", "succeeded", rows_written=1)
+            body = c.get("/api/storage/sync").json()
+            assert body["configured"] is True
+            assert body["remotes"] == ["r:bucket"]
+            assert body["sync_interval"] == 1800
+            assert body["last"]["state"] == "succeeded"
+            assert body["next_eta"] is not None
+
+    def test_post_sync_no_remotes_400(self, client):
+        assert client.post("/api/storage/sync").status_code == 400
+
+    def test_post_sync_started(self, synced_app):
+        with TestClient(synced_app) as c:
+            c.app.state.remote = _OkRemote()  # avoid spawning a real rclone call
+            r = c.post("/api/storage/sync")
+            assert r.status_code == 200
+            assert r.json()["status"] == "started"
 
 
 class TestOperationsEndpoint:

--- a/dccd/tests/v3/test_coverage.py
+++ b/dccd/tests/v3/test_coverage.py
@@ -1,0 +1,140 @@
+"""Coverage manifest: remember a dataset's extent so dropped local data isn't
+re-downloaded on the next ``backfill(start="last")``.
+"""
+
+from __future__ import annotations
+
+from dccd.application.jobs import JobParams, JobSpec, JobTarget, Trigger
+from dccd.application.operations import backfill
+from dccd.domain.capability import Capability
+from dccd.domain.dataset import DatasetId
+from dccd.domain.records import OHLCBar
+from dccd.domain.symbol import Symbol
+from dccd.domain.timeutils import NS, ns_now
+from dccd.domain.types import DataType
+from dccd.sources.base import OHLCHistory
+from dccd.storage.coverage_sqlite import CoverageStore
+from dccd.storage.parquet import ParquetStore
+
+_SPAN = 3600
+_SYMBOL = Symbol(base="BTC", quote="USDT")
+
+
+def _ds() -> DatasetId:
+    return DatasetId(exchange="fake", symbol=_SYMBOL, data_type=DataType.OHLC, span=_SPAN)
+
+
+class _FakeOHLC(OHLCHistory):
+    """OHLC adapter that records the start_ns it is asked for and optionally
+    serves a fixed set of bars on the first page."""
+
+    exchange = "fake"
+
+    def __init__(self, bars: list[OHLCBar] | None = None) -> None:
+        self.calls: list[int] = []
+        self._bars = bars or []
+        self._served = False
+
+    def capabilities(self) -> list[Capability]:
+        return [
+            Capability(data_type=DataType.OHLC, transport="rest", mode="historical",
+                       history="full", max_per_request=1000, page_direction="forward"),
+        ]
+
+    async def fetch_ohlc_page(self, symbol, span, start_ns, end_ns, limit):
+        self.calls.append(start_ns)
+        if self._served:
+            return []
+        self._served = True
+        return [b for b in self._bars if start_ns <= b.ts <= end_ns]
+
+
+class _FakeReg:
+    def __init__(self, src): self._s = src
+    def get(self, ex): return self._s
+
+
+# ---------------------------------------------------------------------------
+# CoverageStore unit
+# ---------------------------------------------------------------------------
+
+class TestCoverageStore:
+    def test_record_and_get_max(self, tmp_path):
+        cov = CoverageStore(tmp_path / "coverage.db")
+        ds = _ds()
+        assert cov.get_max_ts(ds) is None
+        cov.record(ds, min_ts=100, max_ts=500, rows_added=5)
+        assert cov.get_max_ts(ds) == 500
+
+    def test_envelope_widens_never_narrows(self, tmp_path):
+        cov = CoverageStore(tmp_path / "coverage.db")
+        ds = _ds()
+        cov.record(ds, min_ts=100, max_ts=500, rows_added=5)
+        # A later run with a narrower window must not shrink the recorded extent.
+        cov.record(ds, min_ts=300, max_ts=400, rows_added=2)
+        rows = cov.list_all()
+        assert len(rows) == 1
+        assert rows[0]["min_ts"] == 100
+        assert rows[0]["max_ts"] == 500
+        assert rows[0]["rows"] == 7  # accumulated
+        # A genuinely later max extends it.
+        cov.record(ds, min_ts=600, max_ts=900, rows_added=1)
+        assert cov.get_max_ts(ds) == 900
+
+    def test_none_timestamps_ignored(self, tmp_path):
+        cov = CoverageStore(tmp_path / "coverage.db")
+        ds = _ds()
+        cov.record(ds, min_ts=None, max_ts=None, rows_added=0)
+        assert cov.get_max_ts(ds) is None
+
+
+# ---------------------------------------------------------------------------
+# backfill integration — resume + record
+# ---------------------------------------------------------------------------
+
+class TestBackfillCoverage:
+    async def test_resumes_from_manifest_when_local_empty(self, tmp_path):
+        """Local files dropped → start='last' resumes from the manifest's max_ts."""
+        cov = CoverageStore(tmp_path / ".dccd" / "coverage.db")
+        ds = _ds()
+        # Span-aligned, ~10 bars ago (OHLC start snaps to the bar boundary).
+        recorded_max = (ns_now() // (_SPAN * NS) - 10) * (_SPAN * NS)
+        cov.record(ds, min_ts=recorded_max - 100 * _SPAN * NS, max_ts=recorded_max)
+
+        src = _FakeOHLC()
+        store = ParquetStore(tmp_path)  # empty → last_timestamp is None
+        target = JobTarget(exchange="fake", symbol=_SYMBOL,
+                           data_type=DataType.OHLC, span=_SPAN)
+        spec = JobSpec(id="x", operation="backfill", target=target,
+                       trigger=Trigger(kind="once"), params=JobParams(start="last"))
+        await backfill(spec, registry=_FakeReg(src), store=store, coverage_store=cov)
+
+        assert src.calls, "adapter never called"
+        # Resumed from the manifest (within a bar of recorded_max), NOT the
+        # 30-day bounded default an empty store would otherwise use.
+        assert abs(src.calls[0] - recorded_max) <= _SPAN * NS
+        default_start = ns_now() - 30 * 86400 * NS
+        assert src.calls[0] > default_start + 86400 * NS
+
+    async def test_records_extent_on_success(self, tmp_path):
+        cov = CoverageStore(tmp_path / ".dccd" / "coverage.db")
+        ds = _ds()
+        base = ns_now() - 5 * _SPAN * NS
+        bars = [
+            OHLCBar(ts=base + i * _SPAN * NS, open=1.0, high=2.0, low=0.5,
+                    close=1.5, volume=10.0)
+            for i in range(3)
+        ]
+        src = _FakeOHLC(bars=bars)
+        store = ParquetStore(tmp_path)
+        target = JobTarget(exchange="fake", symbol=_SYMBOL,
+                           data_type=DataType.OHLC, span=_SPAN)
+        # Explicit ns start just before the bars so they fall in the first page.
+        spec = JobSpec(id="x", operation="backfill", target=target,
+                       trigger=Trigger(kind="once"),
+                       params=JobParams(start=str(base - _SPAN * NS)))
+        await backfill(spec, registry=_FakeReg(src), store=store, coverage_store=cov)
+
+        assert cov.get_max_ts(ds) == bars[-1].ts
+        rows = cov.list_all()
+        assert rows and rows[0]["min_ts"] == bars[0].ts

--- a/dccd/tests/v3/test_purge.py
+++ b/dccd/tests/v3/test_purge.py
@@ -1,0 +1,104 @@
+"""Free-space purge: drop oldest already-synced Parquet files under disk pressure."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+
+from dccd.application.events import EventBus
+from dccd.application.scheduler import Scheduler
+from dccd.application.service_factory import build_registry, build_store
+from dccd.storage.purge import free_bytes, purge_to_free_space
+
+_GB = 1024 ** 3
+
+
+class _OkRemote:
+    async def sync_all(self):
+        return {"r:bucket": True}
+
+
+def _make_store(tmp_path: pathlib.Path) -> dict[str, pathlib.Path]:
+    """Create 4 parquet files (ascending mtime) + a .dccd file to be preserved."""
+    files = {}
+    for i, name in enumerate(["a", "b", "c", "d"]):
+        p = tmp_path / "binance" / "ohlc" / f"{name}.parquet"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"x" * ((i + 1) * 10))  # 10, 20, 30, 40 bytes
+        os.utime(p, (1000 + i, 1000 + i))     # a oldest … d newest
+        files[name] = p
+    dcache = tmp_path / ".dccd" / "coverage.db"
+    dcache.parent.mkdir(parents=True, exist_ok=True)
+    dcache.write_bytes(b"manifest")
+    files["dcache"] = dcache
+    return files
+
+
+class TestPurge:
+    def test_disabled_when_min_free_zero(self, tmp_path):
+        f = _make_store(tmp_path)
+        res = purge_to_free_space(tmp_path, 0.0, free_fn=lambda: 0)
+        assert res["removed"] == []
+        assert f["a"].exists()
+
+    def test_noop_when_already_above_floor(self, tmp_path):
+        _make_store(tmp_path)
+        # Plenty free → nothing removed.
+        res = purge_to_free_space(tmp_path, 1.0, free_fn=lambda: 2 * _GB)
+        assert res["removed"] == []
+
+    def test_drops_oldest_first_until_floor(self, tmp_path):
+        f = _make_store(tmp_path)
+        target = 1 * _GB
+        # Start just short by the two oldest files' sizes (10 + 20 = 30 bytes).
+        start_free = target - 30
+        res = purge_to_free_space(tmp_path, 1.0, free_fn=lambda: start_free)
+        removed = [pathlib.Path(p).name for p in res["removed"]]
+        assert removed == ["a.parquet", "b.parquet"]  # oldest first, stops at floor
+        assert not f["a"].exists() and not f["b"].exists()
+        assert f["c"].exists() and f["d"].exists()
+        assert f["dcache"].exists()  # .dccd never touched
+        assert res["freed_bytes"] == 30
+
+    def test_dry_run_keeps_files(self, tmp_path):
+        f = _make_store(tmp_path)
+        res = purge_to_free_space(
+            tmp_path, 1.0, dry_run=True, free_fn=lambda: 1 * _GB - 30
+        )
+        assert [pathlib.Path(p).name for p in res["removed"]] == ["a.parquet", "b.parquet"]
+        # Nothing actually deleted.
+        assert f["a"].exists() and f["b"].exists()
+
+
+class TestSchedulerPurge:
+    async def test_purges_after_successful_sync(self, tmp_path):
+        """A successful sync cycle triggers the purge when below the floor."""
+        p = tmp_path / "binance" / "ohlc" / "old.parquet"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"x" * 100)
+        # A floor far above real free space → purge must drop the file.
+        huge = free_bytes(tmp_path) / _GB + 1000
+        sched = Scheduler(
+            build_registry(), build_store(tmp_path), None, EventBus(),
+            remote=_OkRemote(), sync_interval=0.02,
+            data_path=str(tmp_path), min_free_gb=huge,
+        )
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        assert not p.exists()  # purged after sync
+
+    async def test_no_purge_without_floor(self, tmp_path):
+        p = tmp_path / "binance" / "ohlc" / "keep.parquet"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"x" * 100)
+        sched = Scheduler(
+            build_registry(), build_store(tmp_path), None, EventBus(),
+            remote=_OkRemote(), sync_interval=0.02,
+            data_path=str(tmp_path), min_free_gb=0.0,
+        )
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        assert p.exists()  # no floor → never purged

--- a/dccd/tests/v3/test_remote_sync.py
+++ b/dccd/tests/v3/test_remote_sync.py
@@ -12,6 +12,7 @@ import asyncio
 
 from dccd.application.config import AppConfig, RemoteConfig, StorageConfig
 from dccd.application.events import EventBus, LogEvent, StatusEvent
+from dccd.application.operations import sync_remote
 from dccd.application.scheduler import Scheduler
 from dccd.application.service_factory import (
     build_registry,
@@ -127,3 +128,45 @@ class TestSyncLoop:
         assert any(
             r["operation"] == "sync" and r["state"] == "succeeded" for r in runs
         )
+
+
+# ---------------------------------------------------------------------------
+# sync_remote — the shared one-cycle primitive (loop + manual endpoint reuse it)
+# ---------------------------------------------------------------------------
+
+class TestSyncRemoteOnce:
+    async def test_success(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        bus = EventBus()
+        queue = bus.add_queue()
+        result = await sync_remote(
+            _FakeRemote(result={"r:bucket": True}),
+            runs_store=runs_store,
+            events=bus.for_run("remote-sync"),
+        )
+        assert result["ok"] is True
+        runs = runs_store.list_runs(spec_id="remote-sync", limit=1)
+        assert runs and runs[0]["state"] == "succeeded"
+        events = []
+        while not queue.empty():
+            events.append(queue.get_nowait())
+        assert any(
+            isinstance(e, StatusEvent) and e.state == "succeeded" for e in events
+        )
+
+    async def test_failure_persists_and_returns_not_ok(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        result = await sync_remote(
+            _FakeRemote(result={"r:bucket": False}),
+            runs_store=runs_store,
+        )
+        assert result["ok"] is False
+        runs = runs_store.list_runs(spec_id="remote-sync", limit=1)
+        assert runs and runs[0]["state"] == "failed"
+
+    async def test_exception_is_caught(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        result = await sync_remote(_FakeRemote(raises=True), runs_store=runs_store)
+        assert result["ok"] is False
+        runs = runs_store.list_runs(spec_id="remote-sync", limit=1)
+        assert runs and runs[0]["state"] == "failed"

--- a/dccd/tests/v3/test_remote_sync.py
+++ b/dccd/tests/v3/test_remote_sync.py
@@ -1,0 +1,129 @@
+"""Tests for daemon-scheduled rclone remote sync.
+
+Covers the wiring added so ``dccd start`` actually drives the existing
+:class:`~dccd.storage.remote.RemoteStorage` on a periodic loop (it was
+implemented but never instantiated outside tests). No rclone is invoked — a fake
+remote stands in for ``sync_all``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from dccd.application.config import AppConfig, RemoteConfig, StorageConfig
+from dccd.application.events import EventBus, LogEvent, StatusEvent
+from dccd.application.scheduler import Scheduler
+from dccd.application.service_factory import (
+    build_registry,
+    build_remote,
+    build_runs_store,
+    build_store,
+)
+from dccd.storage.remote import RemoteStorage
+
+
+class _FakeRemote:
+    """Stand-in for RemoteStorage.sync_all that counts calls (no rclone)."""
+
+    def __init__(self, result: dict[str, bool] | None = None, raises: bool = False):
+        self._result = result if result is not None else {"r:bucket": True}
+        self._raises = raises
+        self.calls = 0
+
+    async def sync_all(self) -> dict[str, bool]:
+        self.calls += 1
+        if self._raises:
+            raise RuntimeError("boom")
+        return self._result
+
+
+def _scheduler(tmp_path, *, remote, sync_interval=0.02, runs_store=None, bus=None):
+    return Scheduler(
+        build_registry(),
+        build_store(tmp_path),
+        runs_store,
+        bus or EventBus(),
+        remote=remote,
+        sync_interval=sync_interval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_remote factory
+# ---------------------------------------------------------------------------
+
+class TestBuildRemote:
+    def test_none_without_remotes(self):
+        assert build_remote(AppConfig()) is None
+
+    def test_remote_rooted_at_data_path(self):
+        cfg = AppConfig(
+            settings={"data_path": "/tmp/dccd-store"},
+            storage=StorageConfig(remotes=[RemoteConfig(remote="myremote:bucket")]),
+        )
+        remote = build_remote(cfg)
+        assert isinstance(remote, RemoteStorage)
+        # Local root is settings.data_path (the canonical store root).
+        assert str(remote._local) == "/tmp/dccd-store"
+
+
+# ---------------------------------------------------------------------------
+# Scheduler sync loop
+# ---------------------------------------------------------------------------
+
+class TestSyncLoop:
+    async def test_daemon_drives_sync(self, tmp_path):
+        """The regression guard: start() must schedule the sync loop."""
+        fake = _FakeRemote()
+        sched = _scheduler(tmp_path, remote=fake)
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        assert fake.calls >= 1
+        assert sched._sync_task is None
+
+    async def test_no_remote_no_task(self, tmp_path):
+        sched = _scheduler(tmp_path, remote=None)
+        await sched.start([])
+        assert sched._sync_task is None
+        await sched.stop()  # clean
+
+    async def test_failure_surfaces_and_loop_survives(self, tmp_path):
+        bus = EventBus()
+        queue = bus.add_queue()
+        runs_store = build_runs_store(tmp_path)
+        fake = _FakeRemote(result={"r:bucket": False})
+        sched = _scheduler(tmp_path, remote=fake, runs_store=runs_store, bus=bus)
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+
+        # Loop kept running despite failures.
+        assert fake.calls >= 1
+        # A failed status + an error log were emitted on the remote-sync channel.
+        events = []
+        while not queue.empty():
+            events.append(queue.get_nowait())
+        assert any(
+            isinstance(e, StatusEvent) and e.run_id == "remote-sync"
+            and e.state == "failed"
+            for e in events
+        )
+        assert any(
+            isinstance(e, LogEvent) and e.level == "error" for e in events
+        )
+        # And the failure was persisted as a `sync` run.
+        runs = runs_store.list_runs(limit=50)
+        assert any(r["operation"] == "sync" and r["state"] == "failed" for r in runs)
+
+    async def test_success_persisted(self, tmp_path):
+        runs_store = build_runs_store(tmp_path)
+        fake = _FakeRemote(result={"r:bucket": True})
+        sched = _scheduler(tmp_path, remote=fake, runs_store=runs_store)
+        await sched.start([])
+        await asyncio.sleep(0.1)
+        await sched.stop()
+        runs = runs_store.list_runs(limit=50)
+        assert any(
+            r["operation"] == "sync" and r["state"] == "succeeded" for r in runs
+        )

--- a/dccd/tests/v3/test_restore.py
+++ b/dccd/tests/v3/test_restore.py
@@ -1,0 +1,79 @@
+"""Read-through restore: a purged dataset is pulled back from the remote on read."""
+
+from __future__ import annotations
+
+from dccd.application.jobs import JobTarget
+from dccd.application.operations import read
+from dccd.domain.dataset import DatasetId, Provenance
+from dccd.domain.records import OHLCBar
+from dccd.domain.symbol import Symbol
+from dccd.domain.types import DataType
+from dccd.storage.parquet import ParquetStore
+from dccd.storage.remote import RemoteStorage
+
+_SYM = Symbol(base="BTC", quote="USDT")
+
+
+def _target() -> JobTarget:
+    return JobTarget(exchange="binance", symbol=_SYM, data_type=DataType.OHLC, span=3600)
+
+
+def _ds() -> DatasetId:
+    return DatasetId(exchange="binance", symbol=_SYM, data_type=DataType.OHLC, span=3600)
+
+
+def _bar(ts: int = 1_700_000_000_000_000_000) -> OHLCBar:
+    return OHLCBar(ts=ts, open=1.0, high=2.0, low=0.5, close=1.5, volume=10.0)
+
+
+class _RestoringRemote:
+    """Fake remote whose restore() re-materialises the dataset (simulates rclone)."""
+
+    def __init__(self, store: ParquetStore, ds: DatasetId, bar: OHLCBar):
+        self._store, self._ds, self._bar = store, ds, bar
+        self.restored = False
+
+    def restore(self, rel_path: str) -> bool:
+        self.restored = True
+        self._store.save(self._ds, [self._bar], Provenance(source="remote"))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# RemoteStorage.restore
+# ---------------------------------------------------------------------------
+
+class TestRemoteRestore:
+    def test_no_remotes_returns_false(self, tmp_path):
+        assert RemoteStorage(tmp_path, []).restore("any/path") is False
+
+    def test_missing_rclone_is_graceful(self, tmp_path):
+        # rclone is not a test dependency → FileNotFoundError handled → False.
+        rs = RemoteStorage(tmp_path, [{"remote": "dummy:bucket"}])
+        assert rs.restore("binance/ohlc/BTC-USDT/3600") is False
+
+
+# ---------------------------------------------------------------------------
+# operations.read read-through
+# ---------------------------------------------------------------------------
+
+class TestReadThrough:
+    def test_restores_when_local_empty(self, tmp_path):
+        store = ParquetStore(tmp_path)
+        remote = _RestoringRemote(store, _ds(), _bar())
+        df = read(_target(), store=store, remote=remote)
+        assert remote.restored is True
+        assert len(df) == 1
+
+    def test_no_restore_when_files_present(self, tmp_path):
+        store = ParquetStore(tmp_path)
+        store.save(_ds(), [_bar()], Provenance(source="local"))
+        remote = _RestoringRemote(store, _ds(), _bar())
+        df = read(_target(), store=store, remote=remote)
+        assert remote.restored is False  # local present → no remote hit
+        assert len(df) == 1
+
+    def test_no_remote_is_unchanged(self, tmp_path):
+        store = ParquetStore(tmp_path)
+        df = read(_target(), store=store, remote=None)
+        assert len(df) == 0  # empty in, empty out, no error

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Read-through restore in operations.read, whole-dir copy (PR #XX) [accepted]
+- **Choice**: when `operations.read` finds no local Parquet for a dataset and a
+  remote is configured, it `rclone copy`s the dataset's **whole directory** back
+  (via `RemoteStorage.restore`, copy not sync — never deletes) before loading.
+  The remote is resolved from config (`build_remote`) and threaded into
+  `Client.read` and `POST /api/read` (off-thread there, since restore shells out).
+- **Why**: the free-space purge (#89) makes a dataset's local files disappear;
+  backfill resume already survives via the coverage manifest (#88), but *reads*
+  would silently return empty. Pulling the dataset back on a read-miss makes the
+  purge transparent. Whole-dir copy keeps it simple and matches the coarse
+  annual/daily file layout — a time-sliced restore would add rclone-filter
+  complexity for little gain.
+- **Rejected alternatives**: restore only the period files overlapping the read
+  window (more rclone plumbing, marginal benefit at this file granularity); teach
+  `ParquetStore` about remotes (breaks the storage/remote separation — the
+  application layer already owns this orchestration, as with sync/purge).
+
 ### 2026-06-09 — Free-space purge runs right after a successful sync (PR #89) [accepted]
 - **Choice**: a `storage.purge.purge_to_free_space` drops the **oldest** Parquet
   files (by mtime, `.dccd/` excluded) until free space is back above

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #XX) [accepted]
+### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #86) [accepted]
 - **Choice**: schedule the existing `RemoteStorage.sync_all` from `dccd start` by
   giving `Scheduler` an optional `remote`/`sync_interval` and a `_sync_loop`
   (mirroring the existing interval-loop pattern), and record each cycle as a

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Read-through restore in operations.read, whole-dir copy (PR #XX) [accepted]
+### 2026-06-09 — Read-through restore in operations.read, whole-dir copy (PR #90) [accepted]
 - **Choice**: when `operations.read` finds no local Parquet for a dataset and a
   remote is configured, it `rclone copy`s the dataset's **whole directory** back
   (via `RemoteStorage.restore`, copy not sync — never deletes) before loading.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,24 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #XX) [accepted]
+- **Choice**: schedule the existing `RemoteStorage.sync_all` from `dccd start` by
+  giving `Scheduler` an optional `remote`/`sync_interval` and a `_sync_loop`
+  (mirroring the existing interval-loop pattern), and record each cycle as a
+  `sync` run in `RunsStore` (zero schema change) while emitting live `remote-sync`
+  EventBus status. Wiring goes through `service_factory.build_remote`.
+- **Why**: `RemoteStorage` was fully implemented but never instantiated outside
+  tests, so a server `dccd start` mirrored nothing off-box. Owning the loop in the
+  Scheduler makes it unit-testable without rclone and gives clean teardown via the
+  existing `stop()`. Persisting a run row makes the sync observable after the fact
+  (the Storage page is a plain GET) — the keystone the upcoming UI (PR2) reads.
+  This is PR 1 of a 4-PR Epic C (tiered storage: sync → UI → coverage manifest →
+  free-space purge).
+- **Rejected alternatives**: firing rclone directly from `cmd_start` (untestable,
+  no reconcile/stop, no status surface); a new always-on service object (more
+  wiring than a scheduler loop for no gain); EventBus-only with no persistence
+  (status vanishes on UI refresh, so the Storage page couldn't show "last sync").
+
 ### 2026-06-07 — v3 docs sweep: drop the v2 migration story, consolidate examples (PR #82) [accepted]
 - **Choice**: removed the README "Migrating from v2" section (and every `dccd
   migrate` mention) outright rather than keeping a slim note; consolidated

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,24 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #XX) [accepted]
+- **Choice**: a `CoverageStore` (SQLite at `.dccd/coverage.db`) records each
+  dataset's `[min_ts, max_ts]` + row count on every successful backfill;
+  `backfill(start="last")` consults it (`get_max_ts`) when `store.last_timestamp`
+  returns `None`, i.e. the local Parquet is gone. Wired through `service_factory`
+  and threaded into backfill by every caller (Client, CLI, API, Scheduler).
+- **Why**: backfill resume reads the cursor from *local Parquet only*, so dropping
+  files to free disk (the point of Epic C) would make the next run re-download
+  from the bounded default lookback. A small manifest that lives outside the data
+  files (and is never purged) is the cheapest durable cursor. Chosen over a
+  remote-aware inventory (rclone listing on every run — network + remote-availability
+  coupling). The envelope only ever *widens* (min of mins, max of maxes) so a
+  narrow re-backfill can't shrink recorded coverage.
+- **Rejected alternatives**: query the remote for what exists (slow, couples
+  resume to remote uptime); store the cursor inside the Parquet footer (lost with
+  the file — the exact failure we're avoiding); reuse `RunsStore` (runs are an
+  event log, coverage is current-state per dataset — different shape and lifecycle).
+
 ### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #87) [accepted]
 - **Choice**: extract the single sync cycle (create run → `sync_all` → finish +
   events) into `operations.sync_remote`, reused by both the scheduler loop and a

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #XX) [accepted]
+### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #88) [accepted]
 - **Choice**: a `CoverageStore` (SQLite at `.dccd/coverage.db`) records each
   dataset's `[min_ts, max_ts]` + row count on every successful backfill;
   `backfill(start="last")` consults it (`get_max_ts`) when `store.last_timestamp`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Free-space purge runs right after a successful sync (PR #XX) [accepted]
+- **Choice**: a `storage.purge.purge_to_free_space` drops the **oldest** Parquet
+  files (by mtime, `.dccd/` excluded) until free space is back above
+  `storage.min_free_gb`. The Scheduler calls it **only after a successful sync
+  cycle**, off-thread. Free accounting is simulated (start probe + summed file
+  sizes) so it's deterministic and unit-testable via a `free_fn` injection.
+- **Why**: dropping local files is only safe once they're mirrored off-box;
+  tying the purge to a just-completed sync gives that guarantee without tracking
+  per-file sync state. Oldest-first keeps recent data local (most likely to be
+  read) and offloads cold data. The coverage manifest (#88) preserves the resume
+  cursor, so a purged dataset still resumes correctly on the next backfill.
+- **Rejected alternatives**: a fixed local-size cap or age-based retention (the
+  user asked specifically for "when I run low on disk" → a free-space floor); a
+  standalone purge daemon/timer (the sync loop is already the natural,
+  safety-gated trigger); deleting during the sync itself (must be strictly after
+  the mirror confirms).
+
 ### 2026-06-09 — Coverage manifest in SQLite so local data can be dropped safely (PR #88) [accepted]
 - **Choice**: a `CoverageStore` (SQLite at `.dccd/coverage.db`) records each
   dataset's `[min_ts, max_ts]` + row count on every successful backfill;

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #XX) [accepted]
+- **Choice**: extract the single sync cycle (create run → `sync_all` → finish +
+  events) into `operations.sync_remote`, reused by both the scheduler loop and a
+  new manual `POST /api/storage/sync`. The Storage page reads `GET
+  /api/storage/sync` (last/next/volume/remotes) and gets a "Sync now" button. The
+  manual endpoint resolves the remote from **config** (`app.state.remote =
+  build_remote(cfg)` in the lifespan), not from the scheduler.
+- **Why**: in `dccd ui` mode the standalone scheduler has no remote wired in, so
+  reading it from the scheduler would make "Sync now" silently dead there;
+  resolving from config works in both `dccd ui` and `dccd start`. Sharing
+  `sync_remote` keeps run-recording in one place so the manual and scheduled
+  paths can't drift. The page persists status (a plain GET) via the existing
+  `sync` runs; no SSE — kept deliberately light per the user's ask.
+- **Rejected alternatives**: duplicate the run-recording in the endpoint (drift
+  risk); drive the sync from `scheduler._remote` (dead in `dccd ui`); push live
+  status over SSE on the Storage page (heavier than asked — a 10s poll suffices).
+
 ### 2026-06-09 — Daemon drives rclone sync; own the loop in the Scheduler (PR #86) [accepted]
 - **Choice**: schedule the existing `RemoteStorage.sync_all` from `dccd start` by
   giving `Scheduler` an optional `remote`/`sync_interval` and a `_sync_loop`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Free-space purge runs right after a successful sync (PR #XX) [accepted]
+### 2026-06-09 — Free-space purge runs right after a successful sync (PR #89) [accepted]
 - **Choice**: a `storage.purge.purge_to_free_space` drops the **oldest** Parquet
   files (by mtime, `.dccd/` excluded) until free space is back above
   `storage.min_free_gb`. The Scheduler calls it **only after a successful sync

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #XX) [accepted]
+### 2026-06-09 — Surface remote sync in the Storage UI; share one sync-cycle primitive (PR #87) [accepted]
 - **Choice**: extract the single sync cycle (create run → `sync_all` → finish +
   events) into `operations.sync_remote`, reused by both the scheduler loop and a
   new manual `POST /api/storage/sync`. The Storage page reads `GET

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -43,8 +43,9 @@ _(nothing release-blocking — see the roadmap for the next epics)_
 - **Remote data sync** (`storage/remote.py`, rclone) is now **scheduled by
   `dccd start`** — a periodic loop mirrors the store off-box every
   `storage.sync_interval` (backoff + persisted `sync` runs + `remote-sync`
-  EventBus status). Still pending in Epic C: UI surfacing, a coverage manifest so
-  local files can be dropped without re-downloading, and free-space purge.
+  EventBus status), and the **Storage page shows last/next sync + volume with a
+  "Sync now" button**. Still pending in Epic C: a coverage manifest so local files
+  can be dropped without re-downloading, and free-space purge.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -21,12 +21,13 @@ an agent doesn't re-investigate settled ground or assume missing things are bugs
   CORS via `ui_allow_origins`.
 - **Quality gates**: ~191 unit tests + 3 network E2E (opt-in); `ruff` + `mypy`
   clean; Sphinx 0 warnings; CI matrix 3.11–3.13.
+- **Released**: `v3.0.0` tagged on `master` (2026-06-07), superseding `v2.4.0` —
+  GitHub Release published. `develop` and `master` are level; the next feature
+  merge into `develop` reopens the rolling release PR (`/release next-cycle`).
 
 ## Pending
 
-- **Release**: v3 is `3.0.0` in `pyproject` but lives on `develop` and is **not
-  tagged**. Last published tag is `v2.4.0`. Releasing = `develop → master` +
-  `v3.0.0` tag (use the `release-gate` skill).
+_(nothing release-blocking — see the roadmap for the next epics)_
 
 ## Known gaps / sharp edges (by design or deferred)
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -48,9 +48,9 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   records each dataset's extent so `start="last"` resumes from it when local files
   are gone — local data can be dropped without a re-download. A **free-space
   purge** (`storage.min_free_gb`) drops the oldest already-synced files after each
-  sync to stay above the floor. Still pending in Epic C: **read-through restore**
-  (pull a purged file back from the remote on read) and the deploy/rclone how-to
-  docs.
+  sync to stay above the floor, and **read-through restore** pulls a purged
+  dataset back from the remote on read. Remaining in Epic C: the rclone
+  provisioning / integrity how-to docs.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -49,8 +49,9 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   are gone — local data can be dropped without a re-download. A **free-space
   purge** (`storage.min_free_gb`) drops the oldest already-synced files after each
   sync to stay above the floor, and **read-through restore** pulls a purged
-  dataset back from the remote on read. Remaining in Epic C: the rclone
-  provisioning / integrity how-to docs.
+  dataset back from the remote on read. **Epic C (tiered storage) is complete** —
+  provisioning, restore and integrity are documented in
+  `doc/source/how-to/sync-remote.rst`.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -44,8 +44,11 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   `dccd start`** — a periodic loop mirrors the store off-box every
   `storage.sync_interval` (backoff + persisted `sync` runs + `remote-sync`
   EventBus status), and the **Storage page shows last/next sync + volume with a
-  "Sync now" button**. Still pending in Epic C: a coverage manifest so local files
-  can be dropped without re-downloading, and free-space purge.
+  "Sync now" button**. A **coverage manifest** (`CoverageStore`, `.dccd/`) now
+  records each dataset's extent so `start="last"` resumes from it when local files
+  are gone — local data can be dropped without a re-download. Still pending in
+  Epic C: the free-space purge that actually drops synced files, and read-through
+  restore.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -40,8 +40,11 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   impractical.
 - **Order-book history** doesn't exist on any exchange for free — you build it by
   recording the live WS over time (snapshot per `snapshot_interval`).
-- **Remote data sync** (`storage/remote.py`, rclone) exists; confirm it's actually
-  scheduled by `dccd start` before relying on it unattended (see roadmap).
+- **Remote data sync** (`storage/remote.py`, rclone) is now **scheduled by
+  `dccd start`** — a periodic loop mirrors the store off-box every
+  `storage.sync_interval` (backoff + persisted `sync` runs + `remote-sync`
+  EventBus status). Still pending in Epic C: UI surfacing, a coverage manifest so
+  local files can be dropped without re-downloading, and free-space purge.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -46,9 +46,11 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   EventBus status), and the **Storage page shows last/next sync + volume with a
   "Sync now" button**. A **coverage manifest** (`CoverageStore`, `.dccd/`) now
   records each dataset's extent so `start="last"` resumes from it when local files
-  are gone — local data can be dropped without a re-download. Still pending in
-  Epic C: the free-space purge that actually drops synced files, and read-through
-  restore.
+  are gone — local data can be dropped without a re-download. A **free-space
+  purge** (`storage.min_free_gb`) drops the oldest already-synced files after each
+  sync to stay above the floor. Still pending in Epic C: **read-through restore**
+  (pull a purged file back from the remote on read) and the deploy/rclone how-to
+  docs.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -16,17 +16,6 @@ shipped; `03-decisions.md` for *why*). Keep it short and true.
 
 ---
 
-## Ship v3.0 (near-term)
-
-The hexagonal rewrite (P0–P8) is done and lives on `develop`; what remains is to
-release it and finish the v3-era docs.
-
-- [ ] **Release v3.0** — `develop → master` + `v3.0.0` tag. `pyproject` already
-  says `3.0.0`; last published tag is `v2.4.0`. Use the `release-gate` skill
-  before, the `release` skill to cut it.
-
----
-
 ## Epic A — Run the app on a remote server
 
 Goal: `dccd start` (scheduler + streams + UI) running 24/7 on a VPS/home server,

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -63,9 +63,6 @@ Goal: open the dashboard securely from a laptop or phone, not just `localhost`.
 Goal: the Parquet store is mirrored to off-box storage (S3/B2/Drive/…) so a server
 loss doesn't lose data.
 
-- [ ] **Surface sync status in the UI** — last successful sync time + errors on
-  the Storage page; manual "Sync now" button (API endpoint). *(Next PR — the
-  daemon already persists `sync` runs + emits a `remote-sync` EventBus status.)*
 - [ ] **rclone provisioning docs** — how to configure a remote (`rclone config`)
   in the container/host; mount or inject `rclone.conf` securely.
 - [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -68,8 +68,6 @@ loss doesn't lose data.
 - [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document
   restore (pull a remote back into `data_path`). Consider a periodic verify
   (counts/sizes) reusing the `data-e2e` skill.
-- [ ] **Optional: read-through restore** — ability to point a fresh instance at a
-  remote and hydrate the local store.
 
 ---
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -63,14 +63,9 @@ Goal: open the dashboard securely from a laptop or phone, not just `localhost`.
 Goal: the Parquet store is mirrored to off-box storage (S3/B2/Drive/…) so a server
 loss doesn't lose data.
 
-- [~] **rclone sync exists** — `storage/remote.py` (`RemoteStorage.sync_one/
-  sync_all`) + `StorageConfig.remotes` + `sync_interval`. **Verify it's actually
-  scheduled** by `dccd start` (a periodic task), not just callable.
-- [ ] **Scheduled sync in the daemon** — if not wired, add a periodic sync task
-  (interval = `sync_interval`) with backoff + failure surfacing via EventBus/UI
-  ("last sync: …", already a v2 concept).
 - [ ] **Surface sync status in the UI** — last successful sync time + errors on
-  the Storage page; manual "Sync now" button (API endpoint).
+  the Storage page; manual "Sync now" button (API endpoint). *(Next PR — the
+  daemon already persists `sync` runs + emits a `remote-sync` EventBus status.)*
 - [ ] **rclone provisioning docs** — how to configure a remote (`rclone config`)
   in the container/host; mount or inject `rclone.conf` securely.
 - [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -58,22 +58,15 @@ Goal: open the dashboard securely from a laptop or phone, not just `localhost`.
 - [ ] **Threat model note** — write down the assumptions (LAN vs internet, tunnel
   vs public) in the deploy how-to.
 
-## Epic C — Sync data to a remote space
-
-Goal: the Parquet store is mirrored to off-box storage (S3/B2/Drive/…) so a server
-loss doesn't lose data.
-
-- [ ] **rclone provisioning docs** — how to configure a remote (`rclone config`)
-  in the container/host; mount or inject `rclone.conf` securely.
-- [ ] **Integrity** — one-way `sync` (mirror) semantics, dedup-safe; document
-  restore (pull a remote back into `data_path`). Consider a periodic verify
-  (counts/sizes) reusing the `data-e2e` skill.
+_Epic C — Sync data to a remote space: **done.** Scheduled rclone sync + UI,
+coverage manifest, free-space purge, read-through restore, and the
+`how-to/sync-remote` guide all shipped. See `06-status.md`._
 
 ---
 
 ## Suggested sequence
 
-1. **C (sync)** first — protect the data before exposing anything.
+1. ~~**C (sync)**~~ — done.
 2. **A (remote run)** — get it running unattended with restart safety.
 3. **B (remote access)** — only then expose the UI, behind TLS + auth.
 

--- a/doc/source/how-to/sync-remote.rst
+++ b/doc/source/how-to/sync-remote.rst
@@ -2,12 +2,81 @@
 Sync data to a remote (S3, GCS, …)
 ==================================
 
-Configure an `rclone <https://rclone.org/>`_ remote and a sync interval; the
-daemon pushes after each cycle:
+dccd can mirror your local Parquet store to off-box storage so a server loss
+doesn't lose data — and, optionally, **drop old local files** once they're safely
+copied, pulling them back on demand. The whole chain is built on
+`rclone <https://rclone.org/>`_.
+
+Provision a remote
+==================
+
+Install rclone and create a remote interactively:
+
+.. code-block:: bash
+
+   rclone config            # follow the prompts; name it e.g. "s3"
+   rclone listremotes       # -> s3:
+
+This writes ``~/.config/rclone/rclone.conf``. In a container, mount or inject
+that file (it holds credentials — keep it out of the image):
+
+.. code-block:: bash
+
+   docker run -v $HOME/.config/rclone:/root/.config/rclone:ro ... dccd start
+
+Configure sync
+==============
 
 .. code-block:: yaml
 
    storage:
      remotes:
        - {provider: rclone, remote: "s3:my-bucket/crypto"}
-     sync_interval: 3600
+     sync_interval: 3600        # seconds between sync cycles
+     min_free_gb: 0             # >0 enables the free-space purge (see below)
+
+With at least one remote configured, ``dccd start`` runs a periodic loop that
+mirrors the store every ``sync_interval`` seconds (one-way ``rclone sync`` —
+remote becomes a mirror of local). Each cycle is recorded as a ``sync`` run, so
+the **Storage** page shows the last/next sync, status and synced volume, with a
+**Sync now** button (``POST /api/storage/sync``). On failure the loop backs off
+exponentially.
+
+Free up disk: purge + restore
+=============================
+
+Set ``min_free_gb`` above ``0`` to let the daemon reclaim space. After **each
+successful sync** (so the data is already off-box), if free space on the store's
+filesystem is below the floor, dccd deletes the **oldest** Parquet files until it
+is back above it. The ``.dccd`` directory (run history + coverage manifest) is
+never touched.
+
+Two mechanisms make this safe:
+
+- **Backfill still resumes correctly.** A coverage manifest under ``.dccd``
+  records each dataset's extent, so ``start="last"`` resumes from where collection
+  left off even when the local files are gone — no accidental re-download.
+- **Reads pull data back.** Reading a dataset whose local files were purged
+  triggers a **read-through restore** (``rclone copy`` of that dataset directory
+  back into the store) before loading — transparent to ``Client.read`` and
+  ``POST /api/read``.
+
+Restore and integrity
+======================
+
+``rclone sync`` is a one-way mirror (local → remote); the remote is a faithful
+copy, deduplicated by dccd before upload. To rehydrate a fresh machine, pull the
+whole tree back:
+
+.. code-block:: bash
+
+   rclone copy s3:my-bucket/crypto /path/to/data/crypto
+
+To spot-check integrity, compare counts/sizes between local and remote:
+
+.. code-block:: bash
+
+   rclone check /path/to/data/crypto s3:my-bucket/crypto
+
+Because the coverage manifest lives under ``.dccd`` (also synced), a restored
+instance keeps its resume cursors and continues collecting without gaps.

--- a/doc/source/reference/storage.rst
+++ b/doc/source/reference/storage.rst
@@ -76,3 +76,9 @@ Run history
 
 .. autoclass:: dccd.storage.runs_sqlite.RunsStore
    :members:
+
+Coverage manifest
+=================
+
+.. autoclass:: dccd.storage.coverage_sqlite.CoverageStore
+   :members:

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -96,6 +96,8 @@ storage:
     # - provider: rclone
     #   remote: "s3:mybucket/crypto/"  # secondary destination (S3 backup)
   sync_interval: 3600          # seconds between sync cycles (0 = disable)
+  min_free_gb: 0               # free-space floor (GiB); >0 drops oldest synced
+                               # files after each sync to stay above it (0 = off)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.0.0"
+version = "3.1.0"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Rolling release PR. **Merge after `chore: release v3.1.0` (#92) lands in `develop`**, then tag `v3.1.0` on `master`.

## v3.1.0 — Epic C: tiered storage

### Added
- Scheduled rclone remote sync driven by `dccd start` (backoff, persisted `sync` runs, `remote-sync` status). (#86)
- Storage page sync status + **Sync now** (`GET`/`POST /api/storage/sync`). (#87)
- Coverage manifest (`CoverageStore`) — resume `start="last"` from the manifest when local files are dropped. (#88)
- Free-space purge (`storage.min_free_gb`), oldest-first, after each successful sync. (#89)
- Read-through restore on read-miss (`rclone copy`). (#90)
- `how-to/sync-remote` guide. (#91)

Supersedes `v3.0.0`.