### PR TITLE
chore: hierarchical file-based plan-tree workflow

### DIFF
--- a/.claude/workflow.json
+++ b/.claude/workflow.json
@@ -5,6 +5,8 @@
   "decisions": "doc/dev/03-decisions.md",
   "status": "doc/dev/06-status.md",
   "changelog": "CHANGELOG.md",
+  "plans_dir": "doc/dev/plans",
+  "plans_archive": "doc/dev/_archive/plans",
   "test_cmd": "pytest",
   "lint_cmd": "ruff check dccd/",
   "docs_src": "doc/source"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `high→opus`). New `/plan` (build the tree + open the plan PR first) and
   `/execute-leaf` (spawn an agent per leaf, verify on real data) skills; `/pick-task`,
   `/finish-task`, `/abandon-task`, `/release` and `CLAUDE.md` updated to chain
-  through it. Backward-compatible: no `plans_dir` ⇒ the old plan-mode loop. (#NN)
+  through it. Backward-compatible: no `plans_dir` ⇒ the old plan-mode loop. (#94)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Dev workflow: hierarchical, file-based **plan trees** under `doc/dev/plans/`
+  (committed) with a `<plans_dir>` descriptor key. A roadmap item expands into a
+  global `00-plan.md` + precise leaf specs (adaptive depth); each leaf declares a
+  `complexity` that derives its execution model (`low→haiku`/`medium→sonnet`/
+  `high→opus`). New `/plan` (build the tree + open the plan PR first) and
+  `/execute-leaf` (spawn an agent per leaf, verify on real data) skills; `/pick-task`,
+  `/finish-task`, `/abandon-task`, `/release` and `CLAUDE.md` updated to chain
+  through it. Backward-compatible: no `plans_dir` ⇒ the old plan-mode loop. (#NN)
+
 ### Changed
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,22 +79,38 @@ away without losing unrelated good work is too big: split it. This is what makes
 
 ### Dev loop & docs of record
 
-The iterative loop is tooled by skills, with three tracked docs as the sources of
+The iterative loop is tooled by skills, with four tracked docs as the sources of
 truth:
 
 | Doc | Holds | Updated by |
 |-----|-------|-----------|
-| `doc/dev/07-roadmap.md` | open work (single source) | `/pick-task` reads · `/finish-task`, `/abandon-task` update |
+| `doc/dev/07-roadmap.md` | open work — single source *index* | `/pick-task` reads · `/finish-task`, `/abandon-task` update |
+| `doc/dev/plans/<epic>/` | open work *detail* — durable hierarchical plan trees (global + leaf specs) | `/plan` writes · `/execute-leaf` reads · `/finish-task`/`/abandon-task` archive |
 | `doc/dev/03-decisions.md` | the *why* — ADR journal (+ settled rationale) | `/finish-task` (accepted), `/abandon-task` (rejected/tombstone) |
 | `doc/dev/06-status.md` | where things stand | `/finish-task`, `/groom-docs` |
 
 `CHANGELOG.md` + git log stay authoritative for *what* shipped. The loop:
-`/pick-task` (smallest slice → branch) → plan (split big plans into small PRs) →
-`/finish-task` (tests, ADR entry, status, PR) **or** `/abandon-task` (salvage the
-lesson + close the PR); `/groom-docs` periodically keeps `doc/dev/` lean and true.
 
-**Model per task** (advisory — you set it via `/model`, or a skill spawns a
-subagent with an explicit `model`; subagents otherwise *inherit* the parent):
+`/pick-task` (smallest coherent slice; **no branch yet**) →
+`/plan` (decompose into a `doc/dev/plans/<epic>/` tree — adaptive depth: a single
+leaf for a trivial task, a global `00-plan.md` + leaves otherwise — and open the
+**plan PR** that lands the tree on `develop` first) →
+`/execute-leaf <epic> next` (cut the leaf branch, **spawn an agent at the model
+derived from the leaf's `complexity`**, which implements + tests + **verifies on
+real data**, then reports) →
+`/finish-task` (tests, ADR, CHANGELOG, leaf PR, archive the leaf, tick the global
+checklist) → … per leaf … → last leaf removes the roadmap line → `/release`.
+
+`/abandon-task` salvages the lesson + closes a bad PR (tombstones the leaf);
+`/groom-docs` periodically keeps `doc/dev/` lean and true. The full format lives in
+[`doc/dev/plans/README.md`](doc/dev/plans/README.md). The workflow is
+backward-compatible: a repo whose `.claude/workflow.json` has **no `plans_dir`**
+falls back to the older `/pick-task → plan mode → /finish-task` loop.
+
+**Model per task** (advisory — you set it via `/model`, a skill spawns a subagent
+with an explicit `model`, or a plan **leaf's `complexity` derives it**:
+`low→haiku`, `medium→sonnet`, `high→opus`; subagents otherwise *inherit* the
+parent):
 
 | Model | For |
 |-------|-----|

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -112,7 +112,7 @@ Conventions:
 
 Template:
 ```
-### YYYY-MM-DD — <short title> (PR #NN)  [accepted|rejected|tombstone]
+### YYYY-MM-DD — <short title> (PR #94)  [accepted|rejected|tombstone]
 - **Choice**: …
 - **Why**: …
 - **Rejected alternatives**: …
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-09 — Hierarchical file-based plan trees + complexity-derived agent execution (PR #NN) [accepted]
+### 2026-06-09 — Hierarchical file-based plan trees + complexity-derived agent execution (PR #94) [accepted]
 - **Choice**: plans become durable, hierarchical **files in the repo**
   (`doc/dev/plans/<epic>/`: a global `00-plan.md` + precise leaf specs, adaptive
   depth). Each leaf declares a `complexity` that derives the execution model

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,27 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-09 — Hierarchical file-based plan trees + complexity-derived agent execution (PR #NN) [accepted]
+- **Choice**: plans become durable, hierarchical **files in the repo**
+  (`doc/dev/plans/<epic>/`: a global `00-plan.md` + precise leaf specs, adaptive
+  depth). Each leaf declares a `complexity` that derives the execution model
+  (`low→haiku`/`medium→sonnet`/`high→opus`). The tree lands on `develop` via a
+  **"plan PR" first**, then `/execute-leaf` spawns an agent per leaf that must
+  **verify on real data**; `/finish-task` archives the leaf and ticks the global,
+  the last leaf triggers `/release`. Gated on a `plans_dir` descriptor key (absent
+  ⇒ the legacy plan-mode loop — backward compatible).
+- **Why**: `plan mode` plans live in `~/.claude/plans/` (lost on `/compact`), and
+  the old loop never materialised *whether we were planning one slice or the whole
+  set*. Files in the repo are durable, reviewable, and visible to every leaf
+  branch; an explicit global+leaf hierarchy fixes the granularity ambiguity; the
+  precise leaf level is what makes safe agent handoff possible.
+- **Rejected alternatives**: keep ephemeral plan-mode only (the status quo — fails
+  durability); one flat plan file per epic (doesn't separate the map from the
+  executable detail, and can't express per-leaf model/deps). Note: `~/.claude`
+  isn't a git repo, so the skill bodies themselves are applied directly, not via
+  this PR — only the repo-tracked parts (descriptor, `doc/dev/plans/`, `CLAUDE.md`)
+  ship here.
+
 ### 2026-06-09 — Read-through restore in operations.read, whole-dir copy (PR #90) [accepted]
 - **Choice**: when `operations.read` finds no local Parquet for a dataset and a
   remote is configured, it `rclone copy`s the dataset's **whole directory** back

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -62,7 +62,14 @@ _(nothing release-blocking — see the roadmap for the next epics)_
   `dccd.application` daemon example).
 - **Project skills** (`.claude/skills/`): `data-e2e` (real-data verification),
   `release-gate` (pre-release checks), `ui-audit` (browser audit). Plus the
-  user-level `/finish-task` flow used to open PRs.
+  user-level loop skills used to open PRs.
+- **Dev loop = hierarchical plan trees**: `doc/dev/plans/<epic>/` holds durable
+  global + leaf plans (committed; finished ones archived to `_archive/plans/`).
+  The chain is `/pick-task → /plan` (build tree + plan PR) `→ /execute-leaf`
+  (agent per leaf, model from `complexity`, real-data verify) `→ /finish-task`
+  (per leaf: tests/ADR/PR/archive/tick) `→ … → /release`. Format reference:
+  `doc/dev/plans/README.md`; descriptor key `plans_dir` in `.claude/workflow.json`
+  (absent ⇒ legacy plan-mode loop).
 
 ## Deferred (post-3.0, "M3")
 

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -32,11 +32,17 @@ rules live in the repo-root `CLAUDE.md`.
 
 - [`ui_smoke.py`](ui_smoke.py) — runnable headless-browser UI audit
   (`python doc/dev/ui_smoke.py http://127.0.0.1:8137`). See `05-testing.md`.
+- [`plans/`](plans/) — **active plan trees** (durable, hierarchical task plans;
+  tracked in git). Each roadmap item being worked on expands into a
+  `plans/<epic>/` tree of a global map + precise leaf specs that drive
+  `/plan` → `/execute-leaf` → `/finish-task`. Finished trees move to
+  `_archive/plans/` (gitignored). See [`plans/README.md`](plans/README.md).
 
 ## Conventions for keeping this current
 
 - This is descriptive, not aspirational: write what the repo **is**, not what it
-  should become (put plans in [`07-roadmap.md`](07-roadmap.md) — the single source
-  of open work — and history in git/CHANGELOG).
+  should become. Open work goes in [`07-roadmap.md`](07-roadmap.md) — the single
+  source *index* — and its detailed, executable expansion (while being worked) in
+  [`plans/`](plans/); history stays in git/CHANGELOG.
 - A prior snapshot of these docs (the v3 planning/retrospective set) is archived
   under `doc/dev/_archive/` — **gitignored**, kept locally for reference only.

--- a/doc/dev/plans/README.md
+++ b/doc/dev/plans/README.md
@@ -1,0 +1,180 @@
+# Plan trees — durable, hierarchical task plans
+
+This directory holds **active plan trees**: the durable, file-based expansion of a
+roadmap item into an executable plan. It is **tracked in git** (committed via the
+"plan PR" — see below). Finished trees move to `../_archive/plans/`, which is
+**gitignored** (local reference only; git log + `CHANGELOG.md` stay authoritative
+for what shipped). This file is the canonical reference for the format — the
+`/plan`, `/execute-leaf` and `/finish-task` skills read and write it.
+
+## Why this exists
+
+`plan mode` writes to `~/.claude/plans/*.md` (outside the repo), so a plan is lost
+on `/compact`. And when a task splits into sub-tasks, nothing recorded *whether we
+were planning one slice or the whole set*. Plan trees fix both: plans are
+**committed to the repo** (durable, reviewable, visible to every later branch) and
+**hierarchical** (a global map + precise leaves).
+
+## Layout
+
+```
+doc/dev/plans/<epic-slug>/
+  00-plan.md            # global: goal, decomposition, leaf checklist, deps
+  01-<leaf-slug>.md     # leaf: precise, agent-executable spec
+  02-<leaf-slug>.md
+  ...
+```
+
+**Depth is adaptive — never forced.**
+
+- Trivial task → a *single* leaf file, **no global** `00-plan.md`.
+- Normal task → a global `00-plan.md` + N leaves.
+- A leaf still too big → it gets its own sub-directory with its own `00-plan.md`
+  and sub-leaves (recursion). The **deepest level must be precise enough that an
+  agent executes it without re-deciding anything.**
+
+## Lifecycle
+
+```
+/pick-task → /plan (build tree + open "plan PR" → develop)
+  → merge plan PR
+  → /execute-leaf <epic> next   (model from `complexity`, spawn agent, verify)
+  → /finish-task                (tests, ADR, PR, archive leaf, tick global)
+  → … repeat per leaf (deps respected; `parallel` leaves may run concurrently)
+  → last leaf → roadmap line removed, global done → /release
+```
+
+The **plan PR lands the tree on `develop` first**, so every leaf branch cut later
+already contains `doc/dev/plans/<epic>/`.
+
+## Frontmatter
+
+### Global `00-plan.md`
+```yaml
+---
+plan: <epic-slug>
+kind: global
+status: planning | executing | done
+roadmap: "<verbatim roadmap line this expands>"   # link back to 07-roadmap.md
+release_on_done: true            # completing the global suggests /release
+---
+```
+Body sections: **Goal**, **Decomposition** (numbered leaf list, one-line intent
+each), **Leaf checklist** (`- [ ] 01 <slug> — <branch> — <complexity>`),
+**Dependencies** (`02 depends on 01`), **Done criteria**.
+
+### Leaf `NN-<slug>.md`
+```yaml
+---
+plan: <epic-slug>/NN-<slug>
+kind: leaf
+status: planned | executing | done | abandoned
+complexity: low | medium | high   # → haiku | sonnet | opus
+model: <optional override>
+depends: [01]                     # leaf numbers that must be done first; [] = independent
+parallel: false                   # true = may run in a worktree alongside siblings
+branch: <type>/<topic>
+pr: "#NN"                         # filled in by /finish-task
+---
+```
+Mandatory body sections (this precision is what makes agent handoff safe):
+
+- **Goal** — 1–2 lines.
+- **Files to change** — exact paths + what changes in each.
+- **Steps** — precise enough to execute without re-deciding.
+- **Tests** — what to add or modify.
+- **Verification on real data** — the [`data-e2e`](../../../.claude/skills/data-e2e/)
+  discipline; **mandatory** for any data-path leaf (run the real operation, read
+  what landed on disk, compare it to what was requested — a green unit suite is not
+  enough; see [`05-testing.md`](../05-testing.md)).
+- **Closeout** — the CHANGELOG line text; an ADR note if a non-trivial decision was
+  made; the status/roadmap edits to apply.
+
+## Complexity → execution model
+
+The spawned agent's model is derived from the leaf's `complexity` (overridable via
+`model:`), mirroring the advisory table in [`../../../CLAUDE.md`](../../../CLAUDE.md):
+
+| `complexity` | model | for |
+|--------------|--------|-----|
+| `low` | `haiku` | mechanical fan-out — doc scans, checklists, trivial edits |
+| `medium` | `sonnet` | straightforward implementation against a precise spec |
+| `high` | `opus` | judgement, design, cross-cutting changes |
+
+## Dependencies & parallelism
+
+- `depends:` lists the leaf numbers that must reach `status: done` first.
+- `/execute-leaf <epic> next` picks the lowest-numbered `planned` leaf whose
+  `depends` are all satisfied.
+- Leaves marked `parallel: true` (with deps met) may be spawned **concurrently** in
+  isolated git worktrees; everything else runs **serially in the main worktree** —
+  the safe default.
+
+## Templates
+
+### `00-plan.md`
+```markdown
+---
+plan: <epic-slug>
+kind: global
+status: planning
+roadmap: "<paste the roadmap line>"
+release_on_done: true
+---
+
+# <Epic title>
+
+## Goal
+<one paragraph — what "done" looks like>
+
+## Decomposition
+1. **<leaf-slug>** — <one-line intent>
+2. **<leaf-slug>** — <one-line intent>
+
+## Leaf checklist
+- [ ] 01 <leaf-slug> — feat/<topic> — medium
+- [ ] 02 <leaf-slug> — feat/<topic> — high (depends on 01)
+
+## Dependencies
+- 02 depends on 01
+
+## Done criteria
+- <observable, verifiable conditions>
+```
+
+### `NN-<slug>.md`
+```markdown
+---
+plan: <epic-slug>/NN-<slug>
+kind: leaf
+status: planned
+complexity: medium
+depends: [01]
+parallel: false
+branch: feat/<topic>
+pr: ""
+---
+
+# <Leaf title>
+
+## Goal
+<1–2 lines>
+
+## Files to change
+- `path/to/file.py` — <what>
+
+## Steps
+1. <precise step>
+2. <precise step>
+
+## Tests
+- `dccd/tests/v3/test_<x>.py` — <what to assert>
+
+## Verification on real data
+- <run the real op; read what landed; compare to requested>
+
+## Closeout
+- CHANGELOG (`Added`/`Fixed`/…): "<entry text> (#NN)"
+- ADR: <decision + why, or "none — mechanical">
+- Status/roadmap: <edits, or "deferred to last leaf">
+```


### PR DESCRIPTION
## Summary
Introduces a durable, hierarchical, file-based planning workflow to replace the ephemeral `plan mode` plans and resolve the granularity ambiguity (one slice vs. the whole set).

## Why
- `plan mode` writes to `~/.claude/plans/` (outside the repo) → plans are lost on `/compact` (hit twice this session).
- When a task splits into sub-tasks, nothing recorded *whether we were planning one leaf or all of them*.

Plans now live in `doc/dev/plans/<epic>/` (committed, reviewable), as a global `00-plan.md` + precise leaf specs (adaptive depth). Each leaf declares a `complexity` that derives its execution model. See ADR 2026-06-09 in `doc/dev/03-decisions.md`.

## Changes (repo-tracked — this PR)
- `.claude/workflow.json` — add `plans_dir` / `plans_archive` keys (absent elsewhere ⇒ no-op, backward compatible).
- `doc/dev/plans/README.md` (new) — canonical format reference (frontmatter, templates, complexity→model, deps/parallel).
- `doc/dev/README.md` — point to `plans/`; roadmap = index, plans = detail.
- `CLAUDE.md` — rewrite the dev-loop section to the new chain `/pick-task → /plan → /execute-leaf → /finish-task → … → /release`.
- CHANGELOG / ADR / status updated.

## Skill changes (applied directly — `~/.claude` is NOT a git repo, can't PR)
- **new** `~/.claude/skills/plan/SKILL.md` — `/plan`: build the tree + open the plan PR first.
- **new** `~/.claude/skills/execute-leaf/SKILL.md` — `/execute-leaf`: spawn an agent per leaf at the complexity-derived model, mandatory real-data verification, hand to `/finish-task`.
- **edit** `pick-task` — hand off to `/plan` (no branch) when `plans_dir` set; legacy branch+plan-mode otherwise.
- **edit** `finish-task` — step 11: archive the leaf, tick the global, defer roadmap removal to the last leaf, then suggest `/release`.
- **edit** `abandon-task` — step 4b: tombstone/re-annotate the leaf in the tree.
- **edit** `release` — note it's the plan-tree terminal; archive a leftover completed epic dir.

## Test plan
- [x] `pytest` — 211 passed, 3 network deselected
- [x] `ruff check dccd/` — clean
- [x] `cd doc && make html` — 0 warnings
- [ ] CI green