### PR TITLE
docs: plan epic-a-remote-server

### DIFF
--- a/doc/dev/plans/epic-a-remote-server/00-plan.md
+++ b/doc/dev/plans/epic-a-remote-server/00-plan.md
@@ -1,0 +1,68 @@
+---
+plan: epic-a-remote-server
+kind: global
+status: planning
+roadmap: "Epic A — Run the app on a remote server"
+release_on_done: true
+---
+
+# Epic A — Run the app on a remote server
+
+## Goal
+
+`dccd start` (scheduler + streams + web UI) runs **24/7 on a VPS/home server**,
+surviving reboots and crashes. The scaffolding already exists — `Dockerfile`
+(python:3.12-slim, `dccd start --host 0.0.0.0 --port 8080`, `/data` volume,
+`XDG_CONFIG_HOME=/etc`) and `deploy/dccd.service` (systemd, `Restart=on-failure`,
+`User=dccd`, hardening). Epic A is **verify, harden, and document one blessed
+path**, not greenfield: prove both deploy targets actually run, confirm the app
+resumes after a restart, wire ops (healthcheck/limits/log rotation/alerting), nail
+the secrets story, then write the deploy how-to that records the chosen path.
+
+"Done" = a reader can follow `doc/source/how-to/deploy.rst` to stand up a
+self-restarting dccd on a server, with `/health` watched, secrets injected (not
+baked), and alerts on repeated failures.
+
+## Decomposition
+
+1. **verify-container** — clean `docker build` + `docker run` (mounted config +
+   `/data` volume, UI reachable on `0.0.0.0`); pin/refresh the base image.
+2. **verify-systemd** — `deploy/dccd.service`: install path, `Restart=on-failure`,
+   `User=dccd`, `ReadWritePaths`, `XDG_CONFIG_HOME`, `/etc/dccd/config.yml`, data
+   dir perms; confirm start + auto-restart.
+3. **restart-safety** — after a restart, streams resume and the scheduler re-arms;
+   `RunsStore` (SQLite WAL) survives; the data volume is durable. Fix if not.
+4. **resource-ops** — `/health` wired into the orchestrator (systemd/Docker
+   healthcheck), log rotation, basic resource limits, alerting via the existing
+   `HealthMonitor` webhook.
+5. **secrets-config** — keep `config.yml` out of the image (verify) and document
+   env/volume injection of `ui_auth_token` (and `rclone.conf`).
+6. **deploy-howto** — `doc/source/how-to/deploy.rst`: one blessed end-to-end path
+   (decision: systemd vs Docker recorded as an ADR), referencing the above.
+
+## Leaf checklist
+
+- [ ] 01 verify-container — chore/verify-container — medium
+- [ ] 02 verify-systemd — chore/verify-systemd — medium
+- [ ] 03 restart-safety — feat/restart-safety — high (depends on 01, 02)
+- [ ] 04 resource-ops — feat/resource-ops — medium (depends on 01, 02)
+- [ ] 05 secrets-config — docs/secrets-injection — low (depends on 01)
+- [ ] 06 deploy-howto — docs/deploy-howto — medium (depends on 01–05)
+
+## Dependencies
+
+- 01 and 02 are independent → **`parallel: true`** (run concurrently).
+- 03, 04 depend on 01+02 (need a runnable target); 05 depends on 01.
+- 03, 04, 05 are logically independent of each other but run serially (they touch
+  overlapping deploy/config docs — keep it simple, no parallel worktrees).
+- 06 is the synthesis doc — depends on all of 01–05.
+
+## Done criteria
+
+- Both deploy targets verified to build/run (or the blocker documented if the
+  sandbox can't, e.g. no Docker/root — same honesty as the rclone stand-in).
+- A real kill→restart cycle shows streams + scheduler resume with no data gap.
+- `/health` is consumed by the orchestrator; failures alert via webhook.
+- No secret is baked into the image; injection is documented.
+- `doc/source/how-to/deploy.rst` builds (0 Sphinx warnings) and records the chosen
+  path; the roadmap's Epic A items are all removed by the last leaf's `/finish-task`.

--- a/doc/dev/plans/epic-a-remote-server/01-verify-container.md
+++ b/doc/dev/plans/epic-a-remote-server/01-verify-container.md
@@ -1,0 +1,55 @@
+---
+plan: epic-a-remote-server/01-verify-container
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: chore/verify-container
+pr: ""
+---
+
+# Verify the container image (build + run) and pin the base
+
+## Goal
+Prove the existing `Dockerfile` produces a working image: a clean build, then a
+run with a mounted config + `/data` volume where the web UI is reachable on
+`0.0.0.0`. Pin/refresh the base image so builds are reproducible.
+
+## Files to change
+- `Dockerfile` — pin the base image to a digest (`FROM python:3.12-slim@sha256:…`)
+  or, if a digest is undesirable, document why and keep the tag; add a
+  `HEALTHCHECK` only if leaf 04 hasn't claimed it (coordinate — leave healthcheck
+  to 04, just confirm `/health` responds here).
+- `doc/source/how-to/deploy.rst` — **do not create here** (leaf 06 owns it); if a
+  build caveat surfaces, jot it in the leaf Closeout for 06 to fold in.
+
+## Steps
+1. `docker build -t dccd:verify .` from the repo root — must succeed.
+2. Create a throwaway config (`data_path: /data`, `ui_host: 0.0.0.0`, a test
+   `ui_auth_token`), run:
+   `docker run --rm -p 8137:8080 -v "$PWD/config.yml:/etc/dccd/config.yml:ro" -v dccd-data:/data dccd:verify`.
+3. Confirm `GET http://127.0.0.1:8137/health` returns ok and the UI index loads
+   (with the Bearer token).
+4. Pin the base image digest in `Dockerfile`; rebuild to confirm it still works.
+
+## Tests
+- No unit test (infra). The verification *is* the real build+run below.
+- If the digest pin is added, ensure `docker build` still passes — record the
+  digest used in the commit message.
+
+## Verification on real data
+- Real build + run (above). Hit `/health` and the UI on the published port; confirm
+  the mounted `/data` volume is written (trigger a tiny backfill via the UI or
+  `docker exec … dccd backfill …` and see a Parquet file appear under the volume).
+- **If Docker is unavailable in this environment**, say so explicitly (like the
+  rclone stand-in precedent), do the static review of the `Dockerfile` (paths,
+  `XDG_CONFIG_HOME=/etc` → `/etc/dccd/config.yml`, `EXPOSE`/`CMD` port match), and
+  flag that a real build must be run on a Docker host before Epic A closes.
+
+## Closeout
+- CHANGELOG (`Changed`): "Pin the Docker base image to a digest for reproducible
+  builds; verified `docker build`+`run` with mounted config and `/data` volume
+  (#NN)" — adjust to what was actually done.
+- ADR: only if a non-trivial choice (e.g. digest-pin vs tag) — else "none".
+- Status/roadmap: deferred to last leaf (06).

--- a/doc/dev/plans/epic-a-remote-server/02-verify-systemd.md
+++ b/doc/dev/plans/epic-a-remote-server/02-verify-systemd.md
@@ -1,0 +1,60 @@
+---
+plan: epic-a-remote-server/02-verify-systemd
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: chore/verify-systemd
+pr: ""
+---
+
+# Verify the systemd unit
+
+## Goal
+Prove `deploy/dccd.service` installs and runs the daemon as a hardened,
+auto-restarting service: correct paths, `User=dccd`, `Restart=on-failure`,
+`XDG_CONFIG_HOME=/etc` → `/etc/dccd/config.yml`, writable data dir under the
+sandbox of `ProtectSystem=strict` + `ReadWritePaths`.
+
+## Files to change
+- `deploy/dccd.service` — fix anything the verification surfaces: ensure
+  `ReadWritePaths` covers the actual `data_path` (the install header uses
+  `/var/lib/dccd/data`, the unit lists `/var/lib/dccd` — confirm consistent),
+  `ExecStart` path note, and that `WorkingDirectory`/`StateDirectory=dccd` is
+  considered (using `StateDirectory=` auto-creates `/var/lib/dccd` with correct
+  perms — propose it if cleaner than manual `useradd --create-home`).
+- The install header comment — align it with whatever the verification proves
+  (exact `useradd`, config placement, `data_path`).
+
+## Steps
+1. `systemd-analyze verify deploy/dccd.service` — must report no errors.
+2. Install on a test host/VM: copy to `/etc/systemd/system/`, create the `dccd`
+   user (or rely on `DynamicUser=`/`StateDirectory=`), place a config at
+   `/etc/dccd/config.yml` with `data_path: /var/lib/dccd/data`.
+3. `systemctl daemon-reload && systemctl enable --now dccd`; check
+   `systemctl status dccd` is active and the UI/`/health` answers.
+4. Kill the process (`systemctl kill -s SIGKILL dccd` or `kill -9`) and confirm
+   `Restart=on-failure` brings it back within `RestartSec`.
+5. Confirm the data dir is writable under `ProtectSystem=strict` (a backfill writes
+   Parquet under `/var/lib/dccd/data`).
+
+## Tests
+- No unit test (infra). `systemd-analyze verify` is the static gate; the live
+  install is the real check.
+
+## Verification on real data
+- Real `systemctl` install + a kill→auto-restart cycle + a backfill that writes
+  under the hardened data path.
+- **If systemd/root is unavailable here**, run `systemd-analyze verify` (works
+  without root), do the static review (perms, `ReadWritePaths` vs `data_path`,
+  `Environment=XDG_CONFIG_HOME=/etc`), and flag that a live install must be done on
+  a real host before Epic A closes.
+
+## Closeout
+- CHANGELOG (`Changed`/`Fixed`): "Verify + tighten `deploy/dccd.service`
+  (ReadWritePaths/StateDirectory align with `data_path`; auto-restart confirmed)
+  (#NN)".
+- ADR: only if a real choice (e.g. `StateDirectory=`/`DynamicUser=` vs manual
+  `useradd`) — record it then.
+- Status/roadmap: deferred to last leaf (06).

--- a/doc/dev/plans/epic-a-remote-server/03-restart-safety.md
+++ b/doc/dev/plans/epic-a-remote-server/03-restart-safety.md
@@ -1,0 +1,60 @@
+---
+plan: epic-a-remote-server/03-restart-safety
+kind: leaf
+status: planned
+complexity: high
+depends: [01, 02]
+parallel: false
+branch: feat/restart-safety
+pr: ""
+---
+
+# Persistence & restart safety
+
+## Goal
+After a daemon restart (crash or reboot), confirm: configured **streams resume**,
+the **scheduler re-arms** its interval backfills, `RunsStore` (SQLite WAL)
+survives, and no data gap is introduced. Fix whatever doesn't recover.
+
+## Files to change
+- `dccd/application/scheduler.py` — only if `start()` doesn't fully reconstruct
+  state from config on boot (it should `sync_streams` + `sync_intervals` from the
+  loaded `AppConfig`). Verify a fresh `Scheduler.start()` re-arms everything from
+  persisted config alone.
+- `dccd/interfaces/cli/main.py` (`cmd_start`) / `dccd/interfaces/api/app.py`
+  lifespan — only if the boot path doesn't reload config + RunsStore cleanly.
+- Likely **no code change** if it already reconstructs from config — then this leaf
+  is a verification + a regression test.
+
+## Steps
+1. Read `Scheduler.start`/`stop`, `sync_streams`, `sync_intervals` and the
+   `cmd_start` / API lifespan boot path; confirm state is derived from
+   `AppConfig` + `RunsStore` on every start (nothing held only in memory across
+   the process boundary).
+2. Identify any in-memory-only state that wouldn't survive a restart (e.g. an
+   interval cadence or stream cursor not re-derived from config/disk). Fix it.
+3. Confirm `RunsStore` opens the existing SQLite WAL and appends (doesn't
+   truncate) on restart.
+
+## Tests
+- `dccd/tests/v3/test_application.py` (or a new `test_restart.py`): build a
+  `Scheduler` from a config with a stream + an interval backfill, `start()`,
+  `stop()`, then **construct a fresh `Scheduler` from the same config + same
+  RunsStore path** and assert it re-arms the same stream/interval set and the runs
+  history is intact (append, not reset).
+
+## Verification on real data
+- Real cycle on an **isolated store**: `dccd start` with a config that has one
+  stream (e.g. binance trades) + one interval OHLC backfill; let it write a few
+  Parquet rows + a couple of `RunsStore` rows; `kill -9`; `dccd start` again;
+  confirm the stream reconnects, the interval re-arms, the runs DB kept its rows,
+  and collection continues from the last point (no gap, no re-download — coverage
+  manifest from Epic C handles the resume cursor).
+- Back up the store dir before the cycle (per `data-e2e`).
+
+## Closeout
+- CHANGELOG (`Fixed`/`Added`): "Daemon reconstructs streams + interval backfills
+  from config on restart; verified a kill→restart cycle resumes with no gap (#NN)".
+- ADR: if a real persistence gap was found + fixed, record the choice (what state
+  was moved from memory to config/disk and why).
+- Status/roadmap: deferred to last leaf (06).

--- a/doc/dev/plans/epic-a-remote-server/04-resource-ops.md
+++ b/doc/dev/plans/epic-a-remote-server/04-resource-ops.md
@@ -1,0 +1,61 @@
+---
+plan: epic-a-remote-server/04-resource-ops
+kind: leaf
+status: planned
+complexity: medium
+depends: [01, 02]
+parallel: false
+branch: feat/resource-ops
+pr: ""
+---
+
+# Resource/ops: healthcheck, log rotation, limits, alerting
+
+## Goal
+Wire the operational basics for an unattended deploy: `/health` consumed by the
+orchestrator, log rotation, basic resource limits, and failure alerting via the
+existing `HealthMonitor` webhook.
+
+## Files to change
+- `Dockerfile` — add a `HEALTHCHECK` hitting `GET /health` (the endpoint exists at
+  `dccd/interfaces/api/app.py:688`).
+- `deploy/dccd.service` — add `WatchdogSec=` + a systemd-side health note, and
+  basic limits (`MemoryMax=`, `CPUQuota=`, `TasksMax=`) commented with sane
+  defaults; rely on journald for logs (document rotation via
+  `journald`/`logrotate` rather than inventing a file logger).
+- `dccd/application/monitor.py` — confirm `HealthMonitor` subscribes to the
+  EventBus and fires the webhook on repeated failures; wire it into the daemon boot
+  (`cmd_start` / API lifespan) if it isn't already instantiated there.
+- (If log output isn't structured enough for journald) a minimal
+  `logging.basicConfig` in the daemon entry — only if needed; prefer not adding a
+  file handler (journald/docker logging owns rotation).
+
+## Steps
+1. Add the Docker `HEALTHCHECK` and confirm `docker inspect` shows healthy after
+   boot.
+2. Confirm `HealthMonitor` is actually constructed and subscribed in the running
+   daemon (grep the boot path); if not, wire it from `settings` (webhook url).
+3. Add commented resource limits to the systemd unit; document the journald log
+   story (`journalctl -u dccd`, rotation via journald config) — no custom file log.
+4. Trigger a simulated repeated failure (a job that errors) and confirm the webhook
+   fires once past the threshold.
+
+## Tests
+- `dccd/tests/v3/test_application.py`: a `HealthMonitor` test (if missing) — feed
+  it N failing `StatusEvent`s and assert the webhook callback fires once past the
+  threshold (mock the HTTP post). Don't hit a real webhook in tests.
+
+## Verification on real data
+- Run the daemon, post a real (or local stub) webhook URL, drive a failing job,
+  and observe the alert. Confirm `/health` flips/stays per the orchestrator
+  (`docker inspect` health / `systemctl` watchdog).
+- If Docker/systemd unavailable here, verify the `HealthMonitor` path live in a
+  plain `dccd start` and flag the orchestrator-side wiring for a real host.
+
+## Closeout
+- CHANGELOG (`Added`): "Ops hardening for unattended deploy: Docker `HEALTHCHECK`
+  on `/health`, systemd watchdog + resource limits, `HealthMonitor` webhook wired
+  into the daemon, journald log rotation documented (#NN)".
+- ADR: record the choice "journald/docker logging owns rotation (no custom file
+  logger)" and the healthcheck/limits defaults.
+- Status/roadmap: deferred to last leaf (06).

--- a/doc/dev/plans/epic-a-remote-server/05-secrets-config.md
+++ b/doc/dev/plans/epic-a-remote-server/05-secrets-config.md
@@ -1,0 +1,54 @@
+---
+plan: epic-a-remote-server/05-secrets-config
+kind: leaf
+status: planned
+complexity: low
+depends: [01]
+parallel: false
+branch: docs/secrets-injection
+pr: ""
+---
+
+# Secrets/config: keep config.yml out of the image, document injection
+
+## Goal
+Confirm no secret is baked into the image (config.yml is *mounted*, not COPYed —
+the `Dockerfile` already does this) and document how to inject `ui_auth_token` (and
+`rclone.conf` for sync) via env/volume at run time.
+
+## Files to change
+- `doc/source/how-to/deploy.rst` — **owned by leaf 06**; write the secrets section
+  as a self-contained block here and hand it to 06, OR (if 06 not yet merged) add a
+  short `Secrets` subsection to the existing `how-to/protect-ui.rst` and let 06
+  cross-link. Decide at execution based on ordering; do not create `deploy.rst`
+  here.
+- `examples/config.example.yml` — confirm it carries **no real token** (placeholder
+  only) and a comment pointing at env injection.
+
+## Steps
+1. Static check: `grep -i COPY Dockerfile` shows config is **not** copied; the
+   `VOLUME`/mount + `XDG_CONFIG_HOME=/etc` is the only config path. Confirm.
+2. Document injection patterns:
+   - Docker: `-v $HOME/.config/rclone:/root/.config/rclone:ro`,
+     `-v ./config.yml:/etc/dccd/config.yml:ro`, and `ui_auth_token` via the
+     mounted config (kept out of the image/VCS) — note env-substitution isn't
+     parsed by the config loader unless it is (verify `config.py`; if not, say so
+     and recommend the mounted-file pattern).
+   - systemd: config at `/etc/dccd/config.yml` with `0600 root:dccd` perms;
+     `rclone.conf` under the service user's `$XDG_CONFIG_HOME`.
+3. Confirm `examples/config.example.yml` has only placeholders.
+
+## Tests
+- None (docs + static verification). If `config.py` is found to support env
+  substitution, add/confirm a small unit test for it; otherwise note the limitation.
+
+## Verification on real data
+- Build the image (or reuse leaf 01's) and `grep` its layers / `docker history` to
+  confirm no `config.yml`/token is present in the image. Run with an injected
+  token and confirm `/api/*` enforces Bearer (ties to `protect-ui.rst`).
+
+## Closeout
+- CHANGELOG (`Changed`/docs): "Document secret injection for deploy (token +
+  rclone.conf via mounted volume, never baked into the image) (#NN)".
+- ADR: "none" unless `config.py` env-substitution is added (then record it).
+- Status/roadmap: deferred to last leaf (06).

--- a/doc/dev/plans/epic-a-remote-server/06-deploy-howto.md
+++ b/doc/dev/plans/epic-a-remote-server/06-deploy-howto.md
@@ -1,0 +1,53 @@
+---
+plan: epic-a-remote-server/06-deploy-howto
+kind: leaf
+status: planned
+complexity: medium
+depends: [01, 02, 03, 04, 05]
+parallel: false
+branch: docs/deploy-howto
+pr: ""
+---
+
+# Deploy how-to: one blessed end-to-end path
+
+## Goal
+Write `doc/source/how-to/deploy.rst` documenting **one blessed deployment path**
+end-to-end, folding in everything verified/hardened by leaves 01–05. Record the
+systemd-vs-Docker decision as an ADR. This is the leaf that **closes Epic A**:
+remove the roadmap items and suggest `/release`.
+
+## Files to change
+- `doc/source/how-to/deploy.rst` (new) — the blessed path (recommend **systemd**
+  as primary for a long-running home/VPS server, **Docker** as the containerised
+  alternative — or flip, per the decision): provisioning, config placement +
+  secrets injection (from 05), start/enable, `/health` + restart safety (03),
+  ops/limits/alerting (04). Cross-link `protect-ui.rst`, `sync-remote.rst`.
+- the how-to toctree (the index that lists `add-exchange`, `sync-remote`, …) — add
+  `deploy`.
+- `doc/dev/06-status.md` — flip Epic A from pending to done (tooling/deploy).
+- `doc/dev/07-roadmap.md` — **remove all Epic A items** (done by `/finish-task`).
+
+## Steps
+1. Confirm leaves 01–05 are merged (their verified facts are the source material).
+2. Write `deploy.rst` as a single coherent walkthrough; keep both targets but mark
+   one **Recommended** with a one-paragraph rationale (the ADR).
+3. Add `deploy` to the how-to toctree; `cd doc && make html` must be 0 warnings.
+4. At `/finish-task`: this is the **last leaf** → remove the Epic A roadmap block,
+   mark the global `00-plan.md` done, archive the tree, suggest `/release`.
+
+## Tests
+- None (docs). Gate = `cd doc && make html` → 0 warnings; all cross-links resolve.
+
+## Verification on real data
+- Follow the written how-to **literally** on a clean target (VM/host) to stand up a
+  self-restarting dccd; if the sandbox can't, state which steps were executed vs
+  reasoned, consistent with the honesty bar set by leaves 01/02.
+
+## Closeout
+- CHANGELOG (`Added`): "`how-to/deploy` guide — blessed end-to-end path to run dccd
+  unattended on a server (systemd/Docker, healthcheck, restart safety, secrets,
+  alerting), completing Epic A (#NN)".
+- ADR: "Blessed deployment path = <systemd|Docker> primary, the other documented as
+  alternative — why."
+- Status: Epic A done in `06-status.md`. Roadmap: remove the Epic A section.


### PR DESCRIPTION
## Plan tree — Epic A (run the app on a remote server)

First use of the new plan-tree workflow (#94). Lands the durable plan on `develop` **before** any code, so each leaf branch inherits it.

### Goal
`dccd start` (scheduler + streams + UI) runs 24/7 on a server, surviving reboots/crashes. The scaffolding exists (`Dockerfile`, `deploy/dccd.service`, `/health`, `HealthMonitor`) — Epic A is **verify, harden, document one blessed path**, not greenfield.

### Leaves (6 — one disposable PR each)
- [ ] **01 verify-container** — `docker build`+`run`, mounted config + `/data`, pin base — medium · *parallel*
- [ ] **02 verify-systemd** — `dccd.service` install/restart/perms (`systemd-analyze verify`) — medium · *parallel*
- [ ] **03 restart-safety** — streams resume + scheduler re-arms + RunsStore survives a kill→restart — high · deps 01,02
- [ ] **04 resource-ops** — `/health` healthcheck, log rotation, limits, `HealthMonitor` alerting — medium · deps 01,02
- [ ] **05 secrets-config** — config.yml out of the image; document token/rclone injection — low · deps 01
- [ ] **06 deploy-howto** — `how-to/deploy.rst`, blessed path (systemd vs Docker ADR); **closes Epic A** — medium · deps 01–05

01 and 02 are independent (`parallel: true`); the rest follow their deps.

### After merge
`/execute-leaf epic-a-remote-server next` runs the first ready leaf (an agent at the complexity-derived model, verifying on real data), then `/finish-task` per leaf. The last leaf removes the Epic A roadmap block and suggests `/release`.

Full specs: `doc/dev/plans/epic-a-remote-server/`. Format: `doc/dev/plans/README.md`.

## Test plan
- [x] Plan files only (no code); `doc/dev/` is outside the Sphinx tree (build unaffected)
- [ ] CI green