### PR TITLE
docs: detail epic-a plan tree against the real test server

### DIFF
--- a/doc/dev/plans/epic-a-remote-server/00-plan.md
+++ b/doc/dev/plans/epic-a-remote-server/00-plan.md
@@ -10,59 +10,100 @@ release_on_done: true
 
 ## Goal
 
-`dccd start` (scheduler + streams + web UI) runs **24/7 on a VPS/home server**,
-surviving reboots and crashes. The scaffolding already exists — `Dockerfile`
-(python:3.12-slim, `dccd start --host 0.0.0.0 --port 8080`, `/data` volume,
-`XDG_CONFIG_HOME=/etc`) and `deploy/dccd.service` (systemd, `Restart=on-failure`,
-`User=dccd`, hardening). Epic A is **verify, harden, and document one blessed
-path**, not greenfield: prove both deploy targets actually run, confirm the app
-resumes after a restart, wire ops (healthcheck/limits/log rotation/alerting), nail
-the secrets story, then write the deploy how-to that records the chosen path.
+`dccd start` (scheduler + streams + web UI) runs **24/7 on a server**, surviving
+reboots and crashes. The scaffolding exists — `Dockerfile` (python:3.12-slim,
+`dccd start --host 0.0.0.0 --port 8080`, `/data` volume, `XDG_CONFIG_HOME=/etc`)
+and `deploy/dccd.service` (systemd, `Restart=on-failure`, `User=dccd`, hardening).
+Epic A is **verify, harden, and document one blessed path** — *on a real server*,
+not greenfield.
 
-"Done" = a reader can follow `doc/source/how-to/deploy.rst` to stand up a
+"Done" = a reader follows `doc/source/how-to/deploy.rst` to stand up a
 self-restarting dccd on a server, with `/health` watched, secrets injected (not
-baked), and alerts on repeated failures.
+baked), alerts on repeated failures — and every claim was verified on a live host.
+
+## Test environment (real)
+
+A throwaway Ubuntu box is on the same Tailscale tailnet as the dev machine — see
+the `reference-test-server` memory:
+
+- **`ssh dccd-testbox`** → `arthurserver`, `100.91.149.69`, user `arthur`,
+  Ubuntu 24.04.1 LTS, x86_64, 4 cores / 3.7 Gi RAM / 32 G disk (~27 G free),
+  **passwordless sudo**, key `~/.ssh/dccd_testbox`.
+- This converts every "to run on a real host" hedge in the leaves into an
+  **actual** verification. Each leaf below gives concrete `ssh dccd-testbox …`
+  commands and observable acceptance criteria.
+
+## Execution model (deviation from the default `/execute-leaf`)
+
+These leaves operate a **real, stateful external host**, so they run in the **main
+session** (direct `ssh dccd-testbox`), **not** spawned sub-agents — the orchestrator
+keeps direct oversight of every privileged/remote command, and the user sees them.
+Sub-agents stay appropriate for self-contained, repo-local code work. The real-data
+verification discipline still applies: run it on the server, observe, compare.
+
+## Findings already established (ground truth for the leaves)
+
+- **`HealthMonitor` is dead code in the daemon.** `grep -rn "HealthMonitor(" dccd/`
+  (excluding tests) returns nothing — neither `cli/main.py:cmd_start` nor the API
+  lifespan instantiates it. `AlertConfig` (`webhook_url`, `max_consecutive_errors`,
+  `dccd/application/config.py`) exists but is never consumed. → **leaf 04** wires it
+  (same class of bug Epic C fixed for `RemoteStorage`).
+- **Restart state is reconstructed from config.** `cmd_start` builds everything from
+  `cfg` and calls `scheduler.start(cfg.all_job_specs())` (`cli/main.py:159-197`);
+  `Scheduler.start` re-creates stream workers + interval loops from the specs
+  (`scheduler.py:204-225`). So restart safety is *structurally* present — **leaf 03**
+  proves it on a real reboot and checks the resume cursor (Epic C coverage manifest)
+  leaves no gap.
+- **Ports/paths line up**: `ui_port=8080` (`config.py:44`), Dockerfile `EXPOSE 8080`
+  + `CMD --port 8080`; `/health` exists at `api/app.py` (`@app.get("/health")`).
 
 ## Decomposition
 
-1. **verify-container** — clean `docker build` + `docker run` (mounted config +
-   `/data` volume, UI reachable on `0.0.0.0`); pin/refresh the base image.
-2. **verify-systemd** — `deploy/dccd.service`: install path, `Restart=on-failure`,
-   `User=dccd`, `ReadWritePaths`, `XDG_CONFIG_HOME`, `/etc/dccd/config.yml`, data
-   dir perms; confirm start + auto-restart.
-3. **restart-safety** — after a restart, streams resume and the scheduler re-arms;
-   `RunsStore` (SQLite WAL) survives; the data volume is durable. Fix if not.
-4. **resource-ops** — `/health` wired into the orchestrator (systemd/Docker
-   healthcheck), log rotation, basic resource limits, alerting via the existing
-   `HealthMonitor` webhook.
-5. **secrets-config** — keep `config.yml` out of the image (verify) and document
-   env/volume injection of `ui_auth_token` (and `rclone.conf`).
-6. **deploy-howto** — `doc/source/how-to/deploy.rst`: one blessed end-to-end path
-   (decision: systemd vs Docker recorded as an ADR), referencing the above.
+1. **verify-container** — real `docker build` + `docker run` on the box (mounted
+   config + `/data` volume, UI+`/health` reachable, volume actually written); pin
+   the base image to a digest.
+2. **verify-systemd** — install `dccd.service` system-wide on the box with a `dccd`
+   service user; fix the `ExecStart` path assumption; confirm `Restart=on-failure`
+   and the hardening (`ProtectSystem=strict` + `ReadWritePaths`) allow writes.
+3. **restart-safety** — real `reboot` of the box: streams reconnect, interval
+   backfills re-arm, `RunsStore` (SQLite WAL) survives, no data gap. Fix gaps.
+4. **resource-ops** — **wire `HealthMonitor`** into the daemon (the finding above) +
+   `/health` healthcheck (Docker `HEALTHCHECK` / systemd watchdog), resource limits,
+   journald log rotation, real webhook alert fired.
+5. **secrets-config** — prove no secret is baked in the image (`docker history` +
+   layer grep) and document env/volume injection of `ui_auth_token` / `rclone.conf`.
+6. **deploy-howto** — `doc/source/how-to/deploy.rst`: the blessed path, **followed
+   literally on `dccd-testbox`** to validate it; records the systemd-vs-Docker ADR;
+   **closes Epic A** (removes the roadmap items, suggests `/release`).
 
 ## Leaf checklist
 
 - [ ] 01 verify-container — chore/verify-container — medium
 - [ ] 02 verify-systemd — chore/verify-systemd — medium
-- [ ] 03 restart-safety — feat/restart-safety — high (depends on 01, 02)
-- [ ] 04 resource-ops — feat/resource-ops — medium (depends on 01, 02)
+- [ ] 03 restart-safety — feat/restart-safety — high (depends on 02)
+- [ ] 04 resource-ops — feat/resource-ops — high (depends on 01, 02)
 - [ ] 05 secrets-config — docs/secrets-injection — low (depends on 01)
 - [ ] 06 deploy-howto — docs/deploy-howto — medium (depends on 01–05)
 
 ## Dependencies
 
-- 01 and 02 are independent → **`parallel: true`** (run concurrently).
-- 03, 04 depend on 01+02 (need a runnable target); 05 depends on 01.
-- 03, 04, 05 are logically independent of each other but run serially (they touch
-  overlapping deploy/config docs — keep it simple, no parallel worktrees).
-- 06 is the synthesis doc — depends on all of 01–05.
+- 01 and 02 are independent → **`parallel: true`** in principle, but both install
+  software on the *same* box; run them **serially** here to keep the box state
+  legible (01 leaves a Docker engine; 02 a system service). No worktree parallelism.
+- 03 depends on 02 (reboot test uses the systemd-managed service — the real
+  "survives a reboot" path). 04 depends on 01+02 (healthcheck wiring for both
+  targets). 05 depends on 01 (image inspection). 06 depends on 01–05.
 
 ## Done criteria
 
-- Both deploy targets verified to build/run (or the blocker documented if the
-  sandbox can't, e.g. no Docker/root — same honesty as the rclone stand-in).
-- A real kill→restart cycle shows streams + scheduler resume with no data gap.
-- `/health` is consumed by the orchestrator; failures alert via webhook.
-- No secret is baked into the image; injection is documented.
-- `doc/source/how-to/deploy.rst` builds (0 Sphinx warnings) and records the chosen
-  path; the roadmap's Epic A items are all removed by the last leaf's `/finish-task`.
+- `docker build`+`run` and a system-wide systemd install both verified on
+  `dccd-testbox` (real output captured in each leaf's PR).
+- A real `sudo reboot` shows the service back up, streams + intervals resumed, the
+  runs DB intact, collection continuing with no gap.
+- `HealthMonitor` instantiated in the daemon; a real webhook alert fires past the
+  threshold; `/health` consumed by the orchestrator.
+- `docker history`/layer grep proves no token/config baked into the image.
+- `doc/source/how-to/deploy.rst` builds (0 Sphinx warnings), was executed verbatim
+  on the box, and the last leaf removes the Epic A roadmap block → `/release`.
+- The throwaway box is left documented; `sudoers.d/99-arthur-nopasswd` noted for
+  later revocation.

--- a/doc/dev/plans/epic-a-remote-server/01-verify-container.md
+++ b/doc/dev/plans/epic-a-remote-server/01-verify-container.md
@@ -4,52 +4,102 @@ kind: leaf
 status: planned
 complexity: medium
 depends: []
-parallel: true
+parallel: false
 branch: chore/verify-container
 pr: ""
 ---
 
-# Verify the container image (build + run) and pin the base
+# Verify the container image (build + run on the real box) and pin the base
 
 ## Goal
-Prove the existing `Dockerfile` produces a working image: a clean build, then a
-run with a mounted config + `/data` volume where the web UI is reachable on
-`0.0.0.0`. Pin/refresh the base image so builds are reproducible.
+On `dccd-testbox`, prove the existing `Dockerfile` produces a working image: a
+clean build, then a run with a mounted config + `/data` volume where `/health` and
+the UI answer on `0.0.0.0`, and where a real backfill writes Parquet into the
+volume. Pin the base image to a digest for reproducible builds.
+
+## Context / ground truth
+- `Dockerfile`: `FROM python:3.12-slim`, `XDG_CONFIG_HOME=/etc` (so config is read
+  from `/etc/dccd/config.yml`), `pip install ".[daemon,ui]"`, `VOLUME ["/data"]`,
+  `EXPOSE 8080`, `CMD ["start","--host","0.0.0.0","--port","8080"]`.
+- `SettingsConfig` defaults: `data_path="./data/crypto"`, `ui_port=8080`,
+  `ui_auth_token=None` (`dccd/application/config.py:41-45`). For the container the
+  config must set `data_path: /data` and `ui_host: 0.0.0.0`.
+- rclone is intentionally **not** installed in the image (only needed if
+  `storage.remotes` is set) — so this leaf does **not** exercise sync.
+
+## Target environment
+`ssh dccd-testbox` (Ubuntu 24.04, passwordless sudo). Docker is **not yet
+installed** — this leaf installs it (`docker.io`).
 
 ## Files to change
-- `Dockerfile` — pin the base image to a digest (`FROM python:3.12-slim@sha256:…`)
-  or, if a digest is undesirable, document why and keep the tag; add a
-  `HEALTHCHECK` only if leaf 04 hasn't claimed it (coordinate — leave healthcheck
-  to 04, just confirm `/health` responds here).
-- `doc/source/how-to/deploy.rst` — **do not create here** (leaf 06 owns it); if a
-  build caveat surfaces, jot it in the leaf Closeout for 06 to fold in.
+- `Dockerfile` — pin the base image: `FROM python:3.12-slim@sha256:<digest>` using
+  the digest resolved on the box (`docker buildx imagetools inspect` or
+  `docker inspect` after pull). Keep the human-readable tag in a trailing comment.
+- (No `deploy.rst` here — leaf 06 owns it. Any build caveat → this leaf's Closeout
+  for 06 to fold in.)
 
-## Steps
-1. `docker build -t dccd:verify .` from the repo root — must succeed.
-2. Create a throwaway config (`data_path: /data`, `ui_host: 0.0.0.0`, a test
-   `ui_auth_token`), run:
-   `docker run --rm -p 8137:8080 -v "$PWD/config.yml:/etc/dccd/config.yml:ro" -v dccd-data:/data dccd:verify`.
-3. Confirm `GET http://127.0.0.1:8137/health` returns ok and the UI index loads
-   (with the Bearer token).
-4. Pin the base image digest in `Dockerfile`; rebuild to confirm it still works.
+## Steps (run from the dev machine, driving the box)
+1. **Install Docker on the box** (once):
+   ```
+   ssh dccd-testbox 'sudo apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive \
+     apt-get install -y -qq docker.io && sudo systemctl enable --now docker && \
+     sudo usermod -aG docker arthur && docker --version'
+   ```
+   (Group change needs a fresh session; until then prefix docker with `sudo`, or
+   reconnect. `ssh dccd-testbox` reuses a ControlMaster — open a new master after
+   the usermod so `docker` works without sudo, or just use `sudo docker`.)
+2. **Ship the build context** to the box (no reliance on repo being public):
+   ```
+   rsync -az --delete \
+     --exclude '.git' --exclude 'data' --exclude 'doc/_build' \
+     --exclude '__pycache__' --exclude '*.pyc' --exclude '.pytest_cache' \
+     ./ dccd-testbox:~/dccd-build/
+   ```
+3. **Build**: `ssh dccd-testbox 'cd ~/dccd-build && sudo docker build -t dccd:verify .'`
+   — must exit 0.
+4. **Write a throwaway config on the box** at `~/dccd-build/config.yml` with
+   `settings.data_path: /data`, `ui_host: 0.0.0.0`, `ui_port: 8080`,
+   `ui_auth_token: <test-token>`, and one tiny OHLC job (e.g. binance BTC/USDT 1h)
+   so a backfill has something to write.
+5. **Run** (detached), mounting config + a named volume:
+   ```
+   ssh dccd-testbox 'sudo docker run -d --name dccd-verify -p 8137:8080 \
+     -v ~/dccd-build/config.yml:/etc/dccd/config.yml:ro \
+     -v dccd-data:/data dccd:verify'
+   ```
+6. **Verify over Tailscale** from the dev machine:
+   - `curl -fsS http://100.91.149.69:8137/health` → returns ok (200).
+   - `curl -fsS -H "Authorization: Bearer <test-token>" http://100.91.149.69:8137/` →
+     UI index HTML.
+7. **Verify the volume is really written**: trigger the job
+   (`curl -X POST .../api/jobs/run-all` with the bearer token, or
+   `sudo docker exec dccd-verify dccd backfill …`), wait, then
+   `ssh dccd-testbox 'sudo docker run --rm -v dccd-data:/data alpine \
+     find /data -name "*.parquet"'` → at least one file.
+8. **Pin the base image**: resolve the current `python:3.12-slim` digest on the box,
+   set `FROM …@sha256:<digest>` in `Dockerfile`, rebuild → still exits 0 and runs.
+9. **Tear down**: `sudo docker rm -f dccd-verify` (keep or remove `dccd-data` as
+   needed). Record the digest in the commit message.
 
-## Tests
-- No unit test (infra). The verification *is* the real build+run below.
-- If the digest pin is added, ensure `docker build` still passes — record the
-  digest used in the commit message.
+## Acceptance criteria
+- `docker build` exits 0 both before and after the digest pin.
+- `/health` returns 200 over the Tailscale IP; UI index loads with the bearer token.
+- ≥1 `*.parquet` exists in the `dccd-data` volume after a backfill.
+- `Dockerfile` `FROM` carries a `@sha256:` digest.
 
 ## Verification on real data
-- Real build + run (above). Hit `/health` and the UI on the published port; confirm
-  the mounted `/data` volume is written (trigger a tiny backfill via the UI or
-  `docker exec … dccd backfill …` and see a Parquet file appear under the volume).
-- **If Docker is unavailable in this environment**, say so explicitly (like the
-  rclone stand-in precedent), do the static review of the `Dockerfile` (paths,
-  `XDG_CONFIG_HOME=/etc` → `/etc/dccd/config.yml`, `EXPOSE`/`CMD` port match), and
-  flag that a real build must be run on a Docker host before Epic A closes.
+Steps 5–7 *are* the real verification (build → run → backfill → read what landed in
+the volume). Back up nothing (throwaway box/volume). Capture the `curl /health`
+output and the `find … *.parquet` listing into the PR.
+
+## Risks / rollback
+- Disk: the image + slim base is ~200–300 MB; the box has ~27 G free — fine.
+- Rollback: `sudo docker rm -f dccd-verify; sudo docker rmi dccd:verify`; the
+  `~/dccd-build` dir and `dccd-data` volume can be deleted.
 
 ## Closeout
-- CHANGELOG (`Changed`): "Pin the Docker base image to a digest for reproducible
-  builds; verified `docker build`+`run` with mounted config and `/data` volume
-  (#NN)" — adjust to what was actually done.
-- ADR: only if a non-trivial choice (e.g. digest-pin vs tag) — else "none".
-- Status/roadmap: deferred to last leaf (06).
+- CHANGELOG (`Changed`): "Pin the Docker base image to a digest; verified
+  `docker build`+`run` on a live host (mounted config + `/data` volume, `/health`
+  + UI reachable, backfill writes to the volume) (#NN)".
+- ADR: only if the digest-pin-vs-tag choice is worth recording — else "none".
+- Status/roadmap: deferred to leaf 06.

--- a/doc/dev/plans/epic-a-remote-server/02-verify-systemd.md
+++ b/doc/dev/plans/epic-a-remote-server/02-verify-systemd.md
@@ -4,57 +4,99 @@ kind: leaf
 status: planned
 complexity: medium
 depends: []
-parallel: true
+parallel: false
 branch: chore/verify-systemd
 pr: ""
 ---
 
-# Verify the systemd unit
+# Verify the systemd unit (real system-wide install on the box)
 
 ## Goal
-Prove `deploy/dccd.service` installs and runs the daemon as a hardened,
-auto-restarting service: correct paths, `User=dccd`, `Restart=on-failure`,
-`XDG_CONFIG_HOME=/etc` → `/etc/dccd/config.yml`, writable data dir under the
-sandbox of `ProtectSystem=strict` + `ReadWritePaths`.
+Install `deploy/dccd.service` system-wide on `dccd-testbox` running as a dedicated
+`dccd` user, prove it starts, auto-restarts (`Restart=on-failure`), and that the
+hardening (`ProtectSystem=strict` + `ReadWritePaths`) still lets it write its data.
+Fix the `ExecStart` path assumption surfaced by the static gate.
+
+## Context / ground truth (already verified)
+- `systemd-analyze verify deploy/dccd.service` **fails** with
+  `Command /usr/local/bin/dccd is not executable: No such file or directory`.
+  The unit hard-codes `ExecStart=/usr/local/bin/dccd start`, which only exists for a
+  system-wide `pip install`. On Ubuntu 24.04 (PEP 668, externally-managed Python) a
+  system pip install needs `--break-system-packages` — **a venv is the blessed
+  path**. The unit header already hints "adjust ExecStart to your venv".
+- Unit today: `User=dccd`, `Group=dccd`, `Environment=XDG_CONFIG_HOME=/etc`
+  (→ `/etc/dccd/config.yml`), `Restart=on-failure`, `RestartSec=5`,
+  `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`,
+  `ReadWritePaths=/var/lib/dccd`. Install header uses `data_path: /var/lib/dccd/data`.
+
+## Target environment
+`ssh dccd-testbox`. systemd 255, passwordless sudo, PID 1 = systemd.
 
 ## Files to change
-- `deploy/dccd.service` — fix anything the verification surfaces: ensure
-  `ReadWritePaths` covers the actual `data_path` (the install header uses
-  `/var/lib/dccd/data`, the unit lists `/var/lib/dccd` — confirm consistent),
-  `ExecStart` path note, and that `WorkingDirectory`/`StateDirectory=dccd` is
-  considered (using `StateDirectory=` auto-creates `/var/lib/dccd` with correct
-  perms — propose it if cleaner than manual `useradd --create-home`).
-- The install header comment — align it with whatever the verification proves
-  (exact `useradd`, config placement, `data_path`).
+- `deploy/dccd.service`:
+  - Set `ExecStart=/opt/dccd/venv/bin/dccd start` (the blessed venv path), and/or
+    add a comment block making the path the one explicit thing to adjust.
+  - Add `StateDirectory=dccd` (systemd auto-creates `/var/lib/dccd` with correct
+    ownership for `User=dccd` — cleaner than a manual `useradd --create-home`),
+    keeping `ReadWritePaths=/var/lib/dccd` consistent with `data_path`.
+  - Consider `WorkingDirectory=/var/lib/dccd`.
+- The install-header comment — align with the venv + `StateDirectory` approach
+  actually verified.
 
-## Steps
-1. `systemd-analyze verify deploy/dccd.service` — must report no errors.
-2. Install on a test host/VM: copy to `/etc/systemd/system/`, create the `dccd`
-   user (or rely on `DynamicUser=`/`StateDirectory=`), place a config at
-   `/etc/dccd/config.yml` with `data_path: /var/lib/dccd/data`.
-3. `systemctl daemon-reload && systemctl enable --now dccd`; check
-   `systemctl status dccd` is active and the UI/`/health` answers.
-4. Kill the process (`systemctl kill -s SIGKILL dccd` or `kill -9`) and confirm
-   `Restart=on-failure` brings it back within `RestartSec`.
-5. Confirm the data dir is writable under `ProtectSystem=strict` (a backfill writes
-   Parquet under `/var/lib/dccd/data`).
+## Steps (driving the box)
+1. **Provision the venv + install dccd** on the box:
+   ```
+   ssh dccd-testbox 'sudo mkdir -p /opt/dccd && sudo python3 -m venv /opt/dccd/venv && \
+     sudo /opt/dccd/venv/bin/pip install -q --upgrade pip'
+   rsync -az --delete --exclude .git --exclude data --exclude doc/_build \
+     --exclude __pycache__ ./ dccd-testbox:~/dccd-src/
+   ssh dccd-testbox 'sudo /opt/dccd/venv/bin/pip install -q "~/dccd-src/[daemon,ui]" || \
+     (cd ~/dccd-src && sudo /opt/dccd/venv/bin/pip install -q ".[daemon,ui]") && \
+     /opt/dccd/venv/bin/dccd --help >/dev/null && echo DCCD_INSTALLED'
+   ```
+2. **Create the service user** (or rely on `StateDirectory`/`DynamicUser`):
+   `ssh dccd-testbox 'sudo useradd --system --no-create-home --shell /usr/sbin/nologin dccd || true'`
+3. **Static gate**: copy the edited unit and
+   `ssh dccd-testbox 'systemd-analyze verify /path/to/dccd.service'` → **no errors**
+   (this is the gate the original failed; it must pass with the venv ExecStart).
+4. **Place config** at `/etc/dccd/config.yml` (`data_path: /var/lib/dccd/data`,
+   `ui_host: 0.0.0.0`, a test token, one tiny OHLC job), perms `0640 root:dccd`.
+5. **Install + start**:
+   ```
+   ssh dccd-testbox 'sudo cp ~/dccd-src/deploy/dccd.service /etc/systemd/system/ && \
+     sudo systemctl daemon-reload && sudo systemctl enable --now dccd && \
+     sleep 3 && systemctl is-active dccd'
+   ```
+6. **Verify running**: `systemctl status dccd` active; `journalctl -u dccd -n 30`
+   shows "Daemon running"; `curl -fsS http://100.91.149.69:8080/health` → 200.
+7. **Auto-restart**: `sudo systemctl kill -s SIGKILL dccd` then after `RestartSec`
+   confirm `systemctl is-active dccd` is `active` again and the PID changed.
+8. **Hardening writes**: trigger the configured backfill; confirm a `*.parquet`
+   lands under `/var/lib/dccd/data` (i.e. `ProtectSystem=strict` +
+   `ReadWritePaths`/`StateDirectory` permit the write) — read it back:
+   `ssh dccd-testbox 'sudo find /var/lib/dccd/data -name "*.parquet" | head'`.
 
-## Tests
-- No unit test (infra). `systemd-analyze verify` is the static gate; the live
-  install is the real check.
+## Acceptance criteria
+- `systemd-analyze verify` of the edited unit → exit 0, no errors.
+- `systemctl is-active dccd` = active; `/health` 200 on `:8080`.
+- After `SIGKILL`, the service is auto-restarted within ~`RestartSec`.
+- A backfill writes ≥1 Parquet under `/var/lib/dccd/data` despite the hardening.
 
 ## Verification on real data
-- Real `systemctl` install + a kill→auto-restart cycle + a backfill that writes
-  under the hardened data path.
-- **If systemd/root is unavailable here**, run `systemd-analyze verify` (works
-  without root), do the static review (perms, `ReadWritePaths` vs `data_path`,
-  `Environment=XDG_CONFIG_HOME=/etc`), and flag that a live install must be done on
-  a real host before Epic A closes.
+Steps 6–8 are the real verification (live service + kill→restart + a backfill that
+writes under the hardened path, read back). Capture `systemctl status`,
+`journalctl`, and the `find … *.parquet` output into the PR.
+
+## Risks / rollback
+- The unit's `ProtectSystem=strict` can block writes if `ReadWritePaths` /
+  `data_path` disagree — that's exactly what step 8 catches; fix by aligning them.
+- Rollback: `sudo systemctl disable --now dccd; sudo rm /etc/systemd/system/dccd.service \
+  /etc/dccd/config.yml; sudo userdel dccd; sudo rm -rf /opt/dccd /var/lib/dccd`.
 
 ## Closeout
-- CHANGELOG (`Changed`/`Fixed`): "Verify + tighten `deploy/dccd.service`
-  (ReadWritePaths/StateDirectory align with `data_path`; auto-restart confirmed)
-  (#NN)".
-- ADR: only if a real choice (e.g. `StateDirectory=`/`DynamicUser=` vs manual
-  `useradd`) — record it then.
-- Status/roadmap: deferred to last leaf (06).
+- CHANGELOG (`Changed`/`Fixed`): "`deploy/dccd.service`: ExecStart→venv path (passes
+  `systemd-analyze verify`), `StateDirectory=dccd` aligned with `data_path`;
+  verified live install + auto-restart + writes under hardening on a real host (#NN)".
+- ADR: record "venv at `/opt/dccd` + `StateDirectory=dccd` over system-wide pip /
+  manual useradd — why" (PEP 668, clean ownership).
+- Status/roadmap: deferred to leaf 06.

--- a/doc/dev/plans/epic-a-remote-server/03-restart-safety.md
+++ b/doc/dev/plans/epic-a-remote-server/03-restart-safety.md
@@ -3,58 +3,96 @@ plan: epic-a-remote-server/03-restart-safety
 kind: leaf
 status: planned
 complexity: high
-depends: [01, 02]
+depends: [02]
 parallel: false
 branch: feat/restart-safety
 pr: ""
 ---
 
-# Persistence & restart safety
+# Persistence & restart safety (real reboot)
 
 ## Goal
-After a daemon restart (crash or reboot), confirm: configured **streams resume**,
-the **scheduler re-arms** its interval backfills, `RunsStore` (SQLite WAL)
-survives, and no data gap is introduced. Fix whatever doesn't recover.
+Prove that after a **real machine reboot** of `dccd-testbox`, the systemd-managed
+daemon: comes back up, **streams reconnect**, **interval backfills re-arm**,
+`RunsStore` (SQLite WAL) **survives intact**, and collection resumes with **no data
+gap** (no re-download, no lost window). Fix anything that doesn't recover; add a
+regression test for the reconstruction logic.
+
+## Context / ground truth (already verified by reading)
+- Boot reconstructs from config: `cmd_start` builds store/runs/coverage/registry
+  from `cfg` and calls `scheduler.start(cfg.all_job_specs())`
+  (`dccd/interfaces/cli/main.py:159-197`).
+- `Scheduler.start(specs)` re-creates a `_StreamWorker` per `supervised` spec and an
+  interval loop per `interval`/`cron` spec from the specs alone
+  (`dccd/application/scheduler.py:204-225`) — **no cross-process in-memory state**.
+- Resume cursor is on disk: backfill resumes from `store.last_timestamp` else the
+  **coverage manifest** `CoverageStore.get_max_ts` (Epic C) — so a restart resumes
+  from the last collected point, not epoch.
+- ⇒ restart safety is *structurally* present; this leaf is **verification +
+  regression test**, with a code fix only if the reboot exposes a real gap (e.g. a
+  cadence or cursor not actually re-derived from config/disk).
 
 ## Files to change
-- `dccd/application/scheduler.py` — only if `start()` doesn't fully reconstruct
-  state from config on boot (it should `sync_streams` + `sync_intervals` from the
-  loaded `AppConfig`). Verify a fresh `Scheduler.start()` re-arms everything from
-  persisted config alone.
-- `dccd/interfaces/cli/main.py` (`cmd_start`) / `dccd/interfaces/api/app.py`
-  lifespan — only if the boot path doesn't reload config + RunsStore cleanly.
-- Likely **no code change** if it already reconstructs from config — then this leaf
-  is a verification + a regression test.
+- Likely **none** in `scheduler.py` / `cli/main.py` if the reboot is clean. If a gap
+  is found, fix the specific reconstruction (e.g. an interval cadence read from
+  memory instead of `spec`, or `RunsStore` opened with a truncating mode).
+- `dccd/tests/v3/test_restart.py` (new) — the regression test (below).
 
-## Steps
-1. Read `Scheduler.start`/`stop`, `sync_streams`, `sync_intervals` and the
-   `cmd_start` / API lifespan boot path; confirm state is derived from
-   `AppConfig` + `RunsStore` on every start (nothing held only in memory across
-   the process boundary).
-2. Identify any in-memory-only state that wouldn't survive a restart (e.g. an
-   interval cadence or stream cursor not re-derived from config/disk). Fix it.
-3. Confirm `RunsStore` opens the existing SQLite WAL and appends (doesn't
-   truncate) on restart.
+## Steps — real reboot on the box (depends on leaf 02's installed service)
+1. **Arm a representative config** on the box: one **stream** (binance trades
+   BTC/USDT, `supervised`) + one **interval** OHLC backfill (binance BTC/USDT 1h,
+   short `every`). Restart the service to load it.
+2. **Let it collect**, then snapshot pre-reboot state:
+   ```
+   ssh dccd-testbox 'sudo find /var/lib/dccd/data -name "*.parquet" -printf "%p %s\n";
+     echo "--- runs ---"; sudo sqlite3 /var/lib/dccd/data/.dccd/runs.db \
+       "select count(*), max(rowid) from runs;";
+     echo "--- coverage ---"; sudo sqlite3 /var/lib/dccd/data/.dccd/coverage.db \
+       "select dataset_id, max_ts from coverage;"'
+   ```
+   Record the max trade ts and the runs count.
+3. **Reboot**: `ssh dccd-testbox 'sudo systemctl reboot'`; wait for the box to come
+   back (`until ssh -o ConnectTimeout=5 dccd-testbox true; do sleep 3; done`).
+4. **Confirm recovery** (service is `enable`d so it must auto-start):
+   - `systemctl is-active dccd` → active; `systemctl show -p NRestarts dccd`.
+   - `journalctl -u dccd --boot` shows a fresh "Daemon running" after the boot.
+   - Stream reconnected: a `StreamSampleEvent`/new trades appear (watch
+     `/api/events` or check new rows), and a new interval backfill run is logged.
+5. **Prove no gap / no loss**:
+   - `RunsStore` row count **≥** the pre-reboot count (append, not reset).
+   - The trades Parquet has rows **after** the pre-reboot max ts, **contiguous** with
+     it (no missing window); the coverage manifest `max_ts` only moved forward.
+   - Re-run the snapshot from step 2 and diff.
 
-## Tests
-- `dccd/tests/v3/test_application.py` (or a new `test_restart.py`): build a
-  `Scheduler` from a config with a stream + an interval backfill, `start()`,
-  `stop()`, then **construct a fresh `Scheduler` from the same config + same
-  RunsStore path** and assert it re-arms the same stream/interval set and the runs
-  history is intact (append, not reset).
+## Tests (`dccd/tests/v3/test_restart.py`)
+- Build a `Scheduler` from a config with one stream spec + one interval spec; `await
+  start()`; `await stop()`. Construct a **fresh** `Scheduler` (new instances) from
+  the **same** config + **same** `RunsStore` path; `await start()`; assert it
+  re-arms the same stream/interval set (`_streams` keys, `_interval_loops` keys) and
+  that `RunsStore` still returns the previously written runs (append, not truncate).
+- Use a fake/in-memory adapter (as in `test_coverage.py`) — no network in unit tests.
+
+## Acceptance criteria
+- Box reboots; `dccd` service auto-active without manual action.
+- Stream reconnects and a new interval backfill runs post-boot.
+- `RunsStore` count ≥ pre-reboot; trades resume contiguous to the last ts (no gap,
+  no re-download from epoch).
+- `test_restart.py` passes; full `pytest` green.
 
 ## Verification on real data
-- Real cycle on an **isolated store**: `dccd start` with a config that has one
-  stream (e.g. binance trades) + one interval OHLC backfill; let it write a few
-  Parquet rows + a couple of `RunsStore` rows; `kill -9`; `dccd start` again;
-  confirm the stream reconnects, the interval re-arms, the runs DB kept its rows,
-  and collection continues from the last point (no gap, no re-download — coverage
-  manifest from Epic C handles the resume cursor).
-- Back up the store dir before the cycle (per `data-e2e`).
+The reboot cycle (steps 2–5) is the real verification — snapshot on-disk state,
+reboot, compare. Back up nothing (throwaway). Capture both snapshots + the
+`journalctl --boot` excerpt into the PR.
+
+## Risks / rollback
+- If the box doesn't come back (rare), it's physical/Tailscale-reachable — the user
+  can power-cycle. Note the dependency on `systemctl enable` (done in leaf 02).
+- A discovered gap means a real code fix — keep it minimal and ADR-document it.
 
 ## Closeout
-- CHANGELOG (`Fixed`/`Added`): "Daemon reconstructs streams + interval backfills
-  from config on restart; verified a kill→restart cycle resumes with no gap (#NN)".
-- ADR: if a real persistence gap was found + fixed, record the choice (what state
-  was moved from memory to config/disk and why).
-- Status/roadmap: deferred to last leaf (06).
+- CHANGELOG (`Fixed`/`Added`): "Verified daemon survives a real reboot — streams +
+  interval backfills re-arm from config, `RunsStore` survives, resume is gap-free;
+  added `test_restart.py` (#NN)".
+- ADR: only if a real persistence gap was found + fixed (what moved from memory to
+  config/disk and why).
+- Status/roadmap: deferred to leaf 06.

--- a/doc/dev/plans/epic-a-remote-server/04-resource-ops.md
+++ b/doc/dev/plans/epic-a-remote-server/04-resource-ops.md
@@ -2,60 +2,99 @@
 plan: epic-a-remote-server/04-resource-ops
 kind: leaf
 status: planned
-complexity: medium
+complexity: high
 depends: [01, 02]
 parallel: false
 branch: feat/resource-ops
 pr: ""
 ---
 
-# Resource/ops: healthcheck, log rotation, limits, alerting
+# Resource/ops: wire HealthMonitor, healthcheck, limits, log rotation
 
 ## Goal
-Wire the operational basics for an unattended deploy: `/health` consumed by the
-orchestrator, log rotation, basic resource limits, and failure alerting via the
-existing `HealthMonitor` webhook.
+Make the unattended deploy operable: **actually wire `HealthMonitor`** into the
+daemon (it is currently dead code), expose `/health` to the orchestrator (Docker
+`HEALTHCHECK` / systemd watchdog), set basic resource limits, document the journald
+log story, and fire a **real webhook alert** past the failure threshold.
+
+## Context / ground truth (verified)
+- **`HealthMonitor` is never instantiated in the daemon.** `grep -rn "HealthMonitor("
+  dccd/` (excluding tests) returns nothing — `cmd_start` (`cli/main.py:159-197`) and
+  the API lifespan (`api/app.py:159-195`) build the scheduler but no monitor. So
+  alerts never fire in production. This is the load-bearing fix of this leaf (same
+  class as `RemoteStorage` being dead before Epic C).
+- The config already carries it: `AlertConfig(webhook_url, max_consecutive_errors=3)`
+  (`config.py:82-85`); `HealthMonitor(runs_store, event_bus, webhook_url,
+  max_consecutive_errors)` subscribes to the bus and POSTs `{"text": …}` on N
+  consecutive `StatusEvent(state="failed")` (`application/monitor.py`).
+- `/health` exists (`api/app.py` `@app.get("/health")`).
 
 ## Files to change
-- `Dockerfile` — add a `HEALTHCHECK` hitting `GET /health` (the endpoint exists at
-  `dccd/interfaces/api/app.py:688`).
-- `deploy/dccd.service` — add `WatchdogSec=` + a systemd-side health note, and
-  basic limits (`MemoryMax=`, `CPUQuota=`, `TasksMax=`) commented with sane
-  defaults; rely on journald for logs (document rotation via
-  `journald`/`logrotate` rather than inventing a file logger).
-- `dccd/application/monitor.py` — confirm `HealthMonitor` subscribes to the
-  EventBus and fires the webhook on repeated failures; wire it into the daemon boot
-  (`cmd_start` / API lifespan) if it isn't already instantiated there.
-- (If log output isn't structured enough for journald) a minimal
-  `logging.basicConfig` in the daemon entry — only if needed; prefer not adding a
-  file handler (journald/docker logging owns rotation).
+- `dccd/interfaces/cli/main.py` (`cmd_start`) — instantiate
+  `HealthMonitor(runs_store, bus, cfg.alerts.webhook_url,
+  cfg.alerts.max_consecutive_errors)` after the bus is built, and **keep a reference**
+  (it subscribes in `__init__`, but bind it to a local/closure so it isn't GC'd for
+  the daemon's lifetime — mirror the stream-worker GC lesson).
+- `dccd/interfaces/api/app.py` (lifespan) — same wiring on `app.state` (so the API
+  server path, used by `dccd ui`, also alerts); store as `app.state.monitor`.
+- `Dockerfile` — add `HEALTHCHECK --interval=30s --timeout=5s --start-period=20s \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health',timeout=3).status==200 else 1)"`
+  (no curl in slim image — use Python, which is present).
+- `deploy/dccd.service` — add commented resource limits (`MemoryMax=`, `CPUQuota=`,
+  `TasksMax=`) with sane defaults for a 4-core/3.7 G box, and a note on journald log
+  rotation (`journalctl -u dccd`, rotation via `journald.conf` — **no custom file
+  logger**). Optionally `WatchdogSec=` only if the daemon can `sd_notify` (it can't
+  today without extra code → document, don't fake it).
+- `dccd/tests/v3/test_application.py` — add a `HealthMonitor` unit test if absent.
 
 ## Steps
-1. Add the Docker `HEALTHCHECK` and confirm `docker inspect` shows healthy after
-   boot.
-2. Confirm `HealthMonitor` is actually constructed and subscribed in the running
-   daemon (grep the boot path); if not, wire it from `settings` (webhook url).
-3. Add commented resource limits to the systemd unit; document the journald log
-   story (`journalctl -u dccd`, rotation via journald config) — no custom file log.
-4. Trigger a simulated repeated failure (a job that errors) and confirm the webhook
-   fires once past the threshold.
+1. Wire the monitor in both daemon entry points; confirm with
+   `grep -n "HealthMonitor(" dccd/interfaces/*/*.py` (now non-empty).
+2. Add the Docker `HEALTHCHECK`; rebuild on the box (reuse leaf 01's flow);
+   `sudo docker inspect --format '{{.State.Health.Status}}' dccd-verify` → `healthy`.
+3. Add commented limits to the unit; reload + restart; `systemctl show dccd \
+   -p MemoryMax,CPUQuotaPerSecUSec,TasksMax` reflects them when uncommented.
+4. **Real alert test on the box**: start a tiny webhook sink
+   (`python3 -m http.server 9999` won't accept POST cleanly — use a 10-line
+   `nc -lk 9999` or a trivial Flask/`http.server` POST handler), set
+   `alerts.webhook_url: http://127.0.0.1:9999` + `max_consecutive_errors: 2` in the
+   config, drive a **failing** job (e.g. a bad symbol / unreachable) so ≥2
+   consecutive `StatusEvent(failed)` fire, and confirm the sink receives the POST
+   with the alert text.
+5. Document the journald rotation knobs in the unit header / leaf-06 hand-off.
 
-## Tests
-- `dccd/tests/v3/test_application.py`: a `HealthMonitor` test (if missing) — feed
-  it N failing `StatusEvent`s and assert the webhook callback fires once past the
-  threshold (mock the HTTP post). Don't hit a real webhook in tests.
+## Tests (`dccd/tests/v3/test_application.py`)
+- Feed a `HealthMonitor` (real `EventBus`, `runs_store=None`, a fake webhook via
+  monkeypatching `urllib.request.urlopen`) N `StatusEvent(state="failed", run_id=r)`
+  and assert the webhook is called exactly once at the threshold, and that a
+  `succeeded` event resets the counter. No real HTTP.
+
+## Acceptance criteria
+- `grep "HealthMonitor(" dccd/interfaces/` is non-empty (wired in CLI **and** API).
+- Docker `HEALTHCHECK` reports `healthy`.
+- On the box, a real failing job past the threshold delivers a POST to the local
+  sink with the alert text.
+- New `HealthMonitor` test + full `pytest` green; `ruff`/`mypy` clean.
 
 ## Verification on real data
-- Run the daemon, post a real (or local stub) webhook URL, drive a failing job,
-  and observe the alert. Confirm `/health` flips/stays per the orchestrator
-  (`docker inspect` health / `systemctl` watchdog).
-- If Docker/systemd unavailable here, verify the `HealthMonitor` path live in a
-  plain `dccd start` and flag the orchestrator-side wiring for a real host.
+The real alert (step 4) is verified on the box end-to-end (failing job →
+EventBus → webhook POST received). Capture the sink's received payload + the
+`docker inspect … Health.Status` into the PR.
+
+## Risks / rollback
+- Don't add `WatchdogSec` without `sd_notify` wiring (systemd would kill a healthy
+  daemon) — document instead, or add `sd_notify` as a small, separately-justified
+  change.
+- Resource limits too low could OOM-kill a busy daemon — ship them **commented**
+  with guidance, not forced.
 
 ## Closeout
-- CHANGELOG (`Added`): "Ops hardening for unattended deploy: Docker `HEALTHCHECK`
-  on `/health`, systemd watchdog + resource limits, `HealthMonitor` webhook wired
-  into the daemon, journald log rotation documented (#NN)".
-- ADR: record the choice "journald/docker logging owns rotation (no custom file
-  logger)" and the healthcheck/limits defaults.
-- Status/roadmap: deferred to last leaf (06).
+- CHANGELOG (`Added`/`Fixed`): "Wire `HealthMonitor` into the daemon (CLI + API) so
+  webhook alerts actually fire; Docker `HEALTHCHECK` on `/health`; commented systemd
+  resource limits + journald log-rotation guidance; real alert verified on a host
+  (#NN)".
+- ADR: "`HealthMonitor` was dead code — wired into both daemon entry points; logging
+  delegated to journald/docker (no custom file logger); watchdog deferred (needs
+  `sd_notify`) — why."
+- Status/roadmap: deferred to leaf 06; also drop the `06-status.md` caveat once the
+  monitor is live if one exists.

--- a/doc/dev/plans/epic-a-remote-server/05-secrets-config.md
+++ b/doc/dev/plans/epic-a-remote-server/05-secrets-config.md
@@ -9,46 +9,67 @@ branch: docs/secrets-injection
 pr: ""
 ---
 
-# Secrets/config: keep config.yml out of the image, document injection
+# Secrets/config: prove nothing is baked into the image, document injection
 
 ## Goal
-Confirm no secret is baked into the image (config.yml is *mounted*, not COPYed —
-the `Dockerfile` already does this) and document how to inject `ui_auth_token` (and
-`rclone.conf` for sync) via env/volume at run time.
+Prove (not assume) that no secret lands inside the image, and document how to
+inject `ui_auth_token` and `rclone.conf` at run time for both deploy targets.
+
+## Context / ground truth
+- `Dockerfile` `COPY`s only `pyproject.toml README.md` + `dccd/` — **never**
+  `config.yml`; config is read from `/etc/dccd/config.yml` via `XDG_CONFIG_HOME=/etc`
+  at run time (mounted), and `VOLUME ["/data"]` holds data. So the design is already
+  correct — this leaf **verifies it on the real image** and writes it down.
+- `SettingsConfig.ui_auth_token` defaults `None` (`config.py:45`); `protect-ui.rst`
+  already documents Bearer auth. Whether the YAML loader does **env substitution**
+  is unverified → check `config.py` `_load_cfg`/loader; if it does *not*, the blessed
+  pattern is a mounted file kept out of VCS (not `${ENV}` in the YAML).
 
 ## Files to change
-- `doc/source/how-to/deploy.rst` — **owned by leaf 06**; write the secrets section
-  as a self-contained block here and hand it to 06, OR (if 06 not yet merged) add a
-  short `Secrets` subsection to the existing `how-to/protect-ui.rst` and let 06
-  cross-link. Decide at execution based on ordering; do not create `deploy.rst`
-  here.
-- `examples/config.example.yml` — confirm it carries **no real token** (placeholder
-  only) and a comment pointing at env injection.
+- Do **not** create `deploy.rst` here (leaf 06 owns it). Write the **Secrets**
+  section as a self-contained block in this leaf's body / a scratch file and hand it
+  to leaf 06; if leaf 06 isn't merged yet and a home is needed sooner, add a short
+  `Secrets` subsection to `doc/source/how-to/protect-ui.rst` and let 06 cross-link.
+- `examples/config.example.yml` — confirm only a **placeholder** token + a comment
+  pointing at injection; fix if a real-looking value is present.
 
-## Steps
-1. Static check: `grep -i COPY Dockerfile` shows config is **not** copied; the
-   `VOLUME`/mount + `XDG_CONFIG_HOME=/etc` is the only config path. Confirm.
-2. Document injection patterns:
-   - Docker: `-v $HOME/.config/rclone:/root/.config/rclone:ro`,
-     `-v ./config.yml:/etc/dccd/config.yml:ro`, and `ui_auth_token` via the
-     mounted config (kept out of the image/VCS) — note env-substitution isn't
-     parsed by the config loader unless it is (verify `config.py`; if not, say so
-     and recommend the mounted-file pattern).
-   - systemd: config at `/etc/dccd/config.yml` with `0600 root:dccd` perms;
-     `rclone.conf` under the service user's `$XDG_CONFIG_HOME`.
-3. Confirm `examples/config.example.yml` has only placeholders.
+## Steps (driving the box, reuse leaf 01's image)
+1. **Static**: `grep -n COPY Dockerfile` → confirms config is not copied.
+2. **Prove on the built image**:
+   ```
+   ssh dccd-testbox 'sudo docker history --no-trunc dccd:verify | grep -i -E "token|config.yml|secret" || echo "no secret in history"'
+   ssh dccd-testbox 'sudo docker run --rm --entrypoint sh dccd:verify -c "ls -la /etc/dccd 2>/dev/null; test -f /etc/dccd/config.yml && echo BAKED || echo CLEAN"'
+   ```
+   Expect `no secret in history` and `CLEAN` (config only appears when mounted).
+3. **Check env substitution** in `dccd/application/config.py` (the loader). If
+   supported, document `${UI_AUTH_TOKEN}`; if not, document the mounted-file pattern
+   and say so explicitly (no hand-waving).
+4. **Document injection** for both targets:
+   - **Docker**: `-v ./config.yml:/etc/dccd/config.yml:ro` (token lives in that file,
+     kept out of git), `-v $HOME/.config/rclone:/root/.config/rclone:ro` for sync.
+   - **systemd**: `/etc/dccd/config.yml` `0640 root:dccd`; `rclone.conf` under the
+     service user's config dir; never commit either.
+5. Confirm `examples/config.example.yml` is placeholder-only.
 
-## Tests
-- None (docs + static verification). If `config.py` is found to support env
-  substitution, add/confirm a small unit test for it; otherwise note the limitation.
+## Acceptance criteria
+- `docker history` shows no token/config; the image has **no** `/etc/dccd/config.yml`
+  unless mounted (`CLEAN`).
+- The injection patterns are documented for Docker **and** systemd, matching the
+  loader's real capabilities (env-subst or mounted-file).
+- `examples/config.example.yml` carries no real secret.
 
 ## Verification on real data
-- Build the image (or reuse leaf 01's) and `grep` its layers / `docker history` to
-  confirm no `config.yml`/token is present in the image. Run with an injected
-  token and confirm `/api/*` enforces Bearer (ties to `protect-ui.rst`).
+Step 2 inspects the **actual built image** on the box (history + filesystem), not a
+claim. Capture both command outputs into the PR.
+
+## Risks / rollback
+- If env substitution is found and documented, add/confirm a tiny unit test for it;
+  otherwise note the limitation so users don't put `${ENV}` in YAML expecting it to
+  expand.
 
 ## Closeout
 - CHANGELOG (`Changed`/docs): "Document secret injection for deploy (token +
-  rclone.conf via mounted volume, never baked into the image) (#NN)".
-- ADR: "none" unless `config.py` env-substitution is added (then record it).
-- Status/roadmap: deferred to last leaf (06).
+  `rclone.conf` via mounted volume, never baked into the image); verified on the
+  built image (#NN)".
+- ADR: "none" unless env-substitution is added to the loader (then record it).
+- Status/roadmap: deferred to leaf 06.

--- a/doc/dev/plans/epic-a-remote-server/06-deploy-howto.md
+++ b/doc/dev/plans/epic-a-remote-server/06-deploy-howto.md
@@ -9,45 +9,77 @@ branch: docs/deploy-howto
 pr: ""
 ---
 
-# Deploy how-to: one blessed end-to-end path
+# Deploy how-to: one blessed end-to-end path (validated on the box)
 
 ## Goal
 Write `doc/source/how-to/deploy.rst` documenting **one blessed deployment path**
-end-to-end, folding in everything verified/hardened by leaves 01–05. Record the
-systemd-vs-Docker decision as an ADR. This is the leaf that **closes Epic A**:
-remove the roadmap items and suggest `/release`.
+end-to-end, **followed literally on `dccd-testbox`** to prove it works, folding in
+everything verified by leaves 01–05. Record the systemd-vs-Docker decision as an
+ADR. This leaf **closes Epic A**.
+
+## Context / ground truth
+- The how-to dir holds `add-exchange · analyse · deep-trades · protect-ui ·
+  schedule-daily · sync-remote` (`doc/source/how-to/`). Find the toctree that lists
+  them (`doc/source/how-to/index.rst` or the parent `index.rst`) and add `deploy`.
+- By the time this leaf runs, leaves 01–05 have established the *verified facts*:
+  venv `/opt/dccd/venv` + `StateDirectory=dccd` (02), digest-pinned image (01),
+  reboot-safe (03), `HealthMonitor` wired + `/health` healthcheck (04), secret
+  injection (05). The how-to is the synthesis, not new claims.
+
+## Decision to record (ADR)
+Pick **one** primary path and mark it *Recommended*, the other as the alternative:
+- **systemd** (recommended for a long-lived home/VPS box): venv at `/opt/dccd`,
+  `dccd` user, `StateDirectory`, journald, auto-restart, reboot-safe.
+- **Docker** (recommended for a containerised/ephemeral host): digest-pinned image,
+  named `/data` volume, `HEALTHCHECK`, restart policy.
+Record the rationale in `doc/dev/03-decisions.md`.
 
 ## Files to change
-- `doc/source/how-to/deploy.rst` (new) — the blessed path (recommend **systemd**
-  as primary for a long-running home/VPS server, **Docker** as the containerised
-  alternative — or flip, per the decision): provisioning, config placement +
-  secrets injection (from 05), start/enable, `/health` + restart safety (03),
-  ops/limits/alerting (04). Cross-link `protect-ui.rst`, `sync-remote.rst`.
-- the how-to toctree (the index that lists `add-exchange`, `sync-remote`, …) — add
-  `deploy`.
-- `doc/dev/06-status.md` — flip Epic A from pending to done (tooling/deploy).
-- `doc/dev/07-roadmap.md` — **remove all Epic A items** (done by `/finish-task`).
+- `doc/source/how-to/deploy.rst` (new) — a single coherent walkthrough:
+  1. Prereqs (a server, Tailscale/SSH or public reachability).
+  2. **Recommended path** end-to-end (provision → install → config + **secret
+     injection** (05) → start/enable → verify `/health` → confirm auto-restart).
+  3. The **alternative path** (the other target), condensed.
+  4. Ops: `/health` + healthcheck/watchdog, resource limits, journald logs, webhook
+     alerts (04).
+  5. Restart/reboot safety note (03). Cross-link `protect-ui`, `sync-remote`.
+- the how-to toctree — add `deploy`.
+- `doc/dev/06-status.md` — flip Epic A from pending → done (deploy section).
+- `doc/dev/07-roadmap.md` — **remove the entire Epic A block** (via `/finish-task`).
 
 ## Steps
-1. Confirm leaves 01–05 are merged (their verified facts are the source material).
-2. Write `deploy.rst` as a single coherent walkthrough; keep both targets but mark
-   one **Recommended** with a one-paragraph rationale (the ADR).
-3. Add `deploy` to the how-to toctree; `cd doc && make html` must be 0 warnings.
-4. At `/finish-task`: this is the **last leaf** → remove the Epic A roadmap block,
-   mark the global `00-plan.md` done, archive the tree, suggest `/release`.
+1. Confirm leaves 01–05 are merged (their PRs closed) — the source material.
+2. Draft `deploy.rst`; then **execute it verbatim** on `dccd-testbox` from a clean
+   state (tear down prior leaf artefacts first: remove the service/venv/containers),
+   following only what the doc says. Any step that doesn't work as written → fix the
+   doc until a clean run stands up a working, self-restarting dccd.
+3. `cd doc && make html` → **0 warnings**; all cross-links resolve.
+4. `/finish-task` (last leaf): remove the Epic A roadmap block, set the global
+   `00-plan.md` `status: done`, archive the tree to `_archive/plans/`, suggest
+   `/release`.
+5. Post-epic hygiene: note in the PR that `sudoers.d/99-arthur-nopasswd` on the box
+   can be revoked, and the box reset, now that Epic A is validated.
 
-## Tests
-- None (docs). Gate = `cd doc && make html` → 0 warnings; all cross-links resolve.
+## Acceptance criteria
+- `deploy.rst` exists, is in the toctree, and `make html` is 0 warnings.
+- The doc was run **verbatim on the box** from a clean state and produced a working,
+  auto-restarting dccd (capture the final `systemctl is-active` / `docker inspect`
+  + `/health` 200 into the PR).
+- ADR recorded; `06-status.md` shows Epic A done; `07-roadmap.md` Epic A block gone.
 
 ## Verification on real data
-- Follow the written how-to **literally** on a clean target (VM/host) to stand up a
-  self-restarting dccd; if the sandbox can't, state which steps were executed vs
-  reasoned, consistent with the honesty bar set by leaves 01/02.
+The "execute the doc verbatim on a clean box" run *is* the verification — it proves
+the how-to is sufficient and correct, not just plausible.
+
+## Risks / rollback
+- A doc that "looks right" but skips a step is the classic failure — the verbatim
+  clean-box run is the guard. Don't shortcut it.
 
 ## Closeout
-- CHANGELOG (`Added`): "`how-to/deploy` guide — blessed end-to-end path to run dccd
-  unattended on a server (systemd/Docker, healthcheck, restart safety, secrets,
-  alerting), completing Epic A (#NN)".
-- ADR: "Blessed deployment path = <systemd|Docker> primary, the other documented as
+- CHANGELOG (`Added`): "`how-to/deploy` — blessed, host-validated path to run dccd
+  unattended (systemd/Docker, `/health` healthcheck, restart/reboot safety, secret
+  injection, webhook alerts), completing Epic A (#NN)".
+- ADR: "Blessed deployment path = <systemd|Docker> primary, the other as
   alternative — why."
-- Status: Epic A done in `06-status.md`. Roadmap: remove the Epic A section.
+- Status: Epic A done in `06-status.md`. Roadmap: remove the Epic A section. Then
+  **suggest `/release`** (global `release_on_done: true`).


### PR DESCRIPTION
## Refine the Epic A plan tree (more detail, real-server-grounded)

The first cut (#95) was written before we had a live target — the leaves were hedged ("if Docker unavailable, flag for a host") and a bit light. We now have a throwaway **Ubuntu 24.04 box on Tailscale** (`ssh dccd-testbox`, passwordless sudo). This rewrites all 6 leaves + the global to be concrete and executable on it.

### What changed
- **Real target everywhere**: concrete `ssh dccd-testbox …` commands, observable acceptance criteria, captured-output expectations — no more "to run on a host" hedging.
- **Grounded in code findings** (added to the global + leaves):
  - `HealthMonitor` is **dead code** in the daemon (`grep HealthMonitor( dccd/` excl. tests = empty) — neither `cmd_start` nor the API lifespan instantiate it. → leaf 04 now *wires* it (same class as `RemoteStorage` pre-Epic-C).
  - Restart state is reconstructed from `cfg.all_job_specs()` (`cli/main.py:159-197`, `scheduler.py:204-225`) → leaf 03 is verify-by-real-reboot + a regression test.
  - `systemd-analyze verify` already fails on `ExecStart=/usr/local/bin/dccd` → leaf 02 fixes it to a venv path + `StateDirectory=dccd`.
- **Per leaf**: Context/ground-truth, Files, detailed Steps, Acceptance criteria, real-data Verification, Risks/rollback, Closeout.
- **Deps tightened**: 03 depends on 02 (reboot uses the installed service); 01/02 run serially (same box). Execution-model note: these run in the **main session** (real external host), not spawned agents.

### After merge
`/execute-leaf epic-a-remote-server next` → leaf 01 (Docker build/run on the box), then 02…06. Last leaf removes the Epic A roadmap block → `/release`.

## Test plan
- [x] `pytest` — 211 passed (plan docs only, no code)
- [ ] CI green