### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.2.0] - 2026-06-10
+
+### Added
+
 - Dev workflow: hierarchical, file-based **plan trees** under `doc/dev/plans/`
   (committed) with a `<plans_dir>` descriptor key. A roadmap item expands into a
   global `00-plan.md` + precise leaf specs (adaptive depth); each leaf declares a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.1.0"
+version = "3.2.0"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v3.2.0

Freezes `[Unreleased]` → `## [3.2.0] - 2026-06-10` and bumps `pyproject.toml` to `3.2.0` (dccd reads `__version__` from package metadata — single source).

### Added
- **Plan-tree dev workflow** (`doc/dev/plans/`): global + leaf plans, complexity-derived agent model, plan-PR-first, per-leaf closeout/archive. New `/plan` + `/execute-leaf`; updated `/pick-task`/`/finish-task`/`/abandon-task`/`/release`/`CLAUDE.md`. (#94)
- **Epic A — run on a remote server** (verified on a real Ubuntu host): restart/reboot safety + `test_restart.py` (#99); `HealthMonitor` wired into the daemon + Docker `HEALTHCHECK` + systemd limits/journald (#100); `how-to/deploy` blessed path (#102).

### Changed
- `Dockerfile`: digest-pinned base + `POLARS_VARIANT` build arg for no-AVX2 CPUs (#97).
- `how-to/protect-ui`: deploy-time secret injection (#101).

### Fixed
- `deploy/dccd.service`: venv `ExecStart` + `StateDirectory`, dropped non-existent `ui` extra (#98).
- `HealthMonitor`: key alerts by job (was per-run, never accumulated for backfills) (#100).

## Test plan
- [x] `pytest` — 215 passed
- [x] `ruff` + `mypy` clean · docs 0 warnings
- [ ] CI green