### PR TITLE
docs: plan remote-ui-access (Epic B)

### DIFF
--- a/doc/dev/plans/remote-ui-access/00-plan.md
+++ b/doc/dev/plans/remote-ui-access/00-plan.md
@@ -69,7 +69,9 @@ note (05) can describe a true posture.
   token-bearing page; after authenticating, the SPA drives the API via the cookie.
 - `/api/*` is rate-limited (a burst past the limit returns 429); a test proves CORS is
   never wildcard and that mutating routes are 401 without a token; `ui_readonly: true`
-  refuses mutating calls.
+  refuses mutating calls. The session cookie is `HttpOnly`+`SameSite=Lax` (CSRF-safe
+  for mutating POST/DELETE), the login `next` cannot open-redirect off-site, and the
+  rate-limit client key does not trust `X-Forwarded-For` unless `ui_trusted_proxy`.
 - The UI is usable at a 390-px viewport; `ui_smoke.py` passes a mobile-viewport run.
 - The deploy how-to carries a threat-model section consistent with the above.
 - Every leaf shipped as its own small PR; roadmap line removed on the last leaf.

--- a/doc/dev/plans/remote-ui-access/00-plan.md
+++ b/doc/dev/plans/remote-ui-access/00-plan.md
@@ -1,0 +1,75 @@
+---
+plan: remote-ui-access
+kind: global
+status: planning
+roadmap: "## Epic B — View the UI remotely (PC + mobile)"
+release_on_done: true
+---
+
+# Epic B — View the UI remotely (PC + mobile)
+
+## Goal
+
+Open the dashboard securely from a laptop or phone — not just `localhost` — without
+ever exposing the API plaintext off-box. "Done" means: a documented TLS-fronted
+deploy; a browser that can authenticate **without editing config** (so the token is
+no longer leaked into the page on an ungated route); the API hardened for a hostile
+network (rate-limited, no wildcard CORS, mutating routes provably token-gated, an
+opt-in read-only mode); a UI usable on a narrow viewport; and a written threat model.
+The bind/auth building blocks (`ui_host=0.0.0.0`, `ui_auth_token` Bearer,
+`ui_allow_origins` CORS) already exist — this epic is wiring, hardening, and UX on
+top of them.
+
+## Security framing (drives the leaf order)
+
+Today page routes (`/`, `/data`, …) are **not** gated and the server **injects the
+auth token into the template** (`api/app.py` `_tpl_ctx` → `base.html` `DCCD_TOKEN`).
+On a trusted `127.0.0.1` bind that's fine; the moment the UI is reachable remotely,
+**anyone who loads a page receives the token**. So leaf **02 (browser auth/session)
+is the linchpin** and must land before "harden" (03) and before the threat-model
+note (05) can describe a true posture.
+
+## Decomposition
+
+1. **deploy-tls-proxy** — how-to: front the UI with HTTPS (Caddy primary; nginx and
+   Cloudflare Tunnel as alternatives); the API never travels plaintext off-box.
+   Docs-only, independent of the code leaves.
+2. **ui-auth-session** — gate the **page** routes too: a token-prompt/login page that
+   sets an HttpOnly cookie session; page routes redirect to it when unauthenticated;
+   the `/api/*` guard accepts the cookie as well as Bearer/`?token=`. Stop injecting
+   the raw token into the template. *The security linchpin.*
+3. **harden-api-exposure** — rate-limit `/api/*`; a regression test asserting CORS is
+   never wildcard; prove every mutating route is refused without a token; an opt-in
+   `ui_readonly` mode that blocks mutating methods (read-only vs control).
+4. **mobile-responsive** — narrow-viewport pass over Dashboard/Data/Historical/Live
+   (tables → stacked/cards, tap targets, nav dropdowns); extend `ui_smoke.py` with a
+   mobile-viewport run.
+5. **threat-model-note** — write the assumptions (LAN vs internet, tunnel vs public,
+   what the token does and doesn't protect) into the deploy how-to, reflecting the
+   final posture from 01–03.
+
+## Leaf checklist
+- [ ] 01 deploy-tls-proxy — docs/tls-reverse-proxy — medium
+- [ ] 02 ui-auth-session — feat/ui-auth-session — high
+- [ ] 03 harden-api-exposure — feat/harden-api-exposure — high (depends on 02)
+- [ ] 04 mobile-responsive — feat/ui-mobile-responsive — medium
+- [ ] 05 threat-model-note — docs/threat-model — low (depends on 01, 02, 03)
+
+## Dependencies
+- 03 depends on 02 (roles/hardening build on the session auth).
+- 05 depends on 01, 02, 03 (it documents the posture they establish).
+- 01 and 04 are independent of the code-auth chain. 04 is logically parallelisable
+  but is kept **serial** because it edits `base.html`, which 02 also touches — running
+  them concurrently would collide. Execute 04 either before 02 or after it merges.
+
+## Done criteria
+- A real Ubuntu testbox serves the UI over **HTTPS** through the documented proxy;
+  `curl` to the plaintext API port from off-box is refused/closed, the TLS front works.
+- Loading any page **without** authenticating yields the login/token prompt, **not** a
+  token-bearing page; after authenticating, the SPA drives the API via the cookie.
+- `/api/*` is rate-limited (a burst past the limit returns 429); a test proves CORS is
+  never wildcard and that mutating routes are 401 without a token; `ui_readonly: true`
+  refuses mutating calls.
+- The UI is usable at a 390-px viewport; `ui_smoke.py` passes a mobile-viewport run.
+- The deploy how-to carries a threat-model section consistent with the above.
+- Every leaf shipped as its own small PR; roadmap line removed on the last leaf.

--- a/doc/dev/plans/remote-ui-access/01-deploy-tls-proxy.md
+++ b/doc/dev/plans/remote-ui-access/01-deploy-tls-proxy.md
@@ -1,0 +1,84 @@
+---
+plan: remote-ui-access/01-deploy-tls-proxy
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: docs/tls-reverse-proxy
+pr: ""
+---
+
+# TLS + reverse proxy — document a secure remote front
+
+## Goal
+
+Document how to put the UI behind HTTPS so it can be reached from a laptop/phone
+without ever exposing the plaintext API off-box. Caddy is the blessed/simple path;
+nginx and Cloudflare Tunnel are alternatives. Docs-only — no code changes.
+
+## Files to change
+- `doc/source/how-to/expose-remote.rst` (new) — the guide. Sections:
+  - *When you need this* — default bind is `127.0.0.1`; remote access is a conscious
+    opt-in. Two safe shapes: (a) private overlay network (Tailscale) where the tailnet
+    already gives transport encryption + identity, and (b) public exposure behind a
+    TLS reverse proxy. Never bind `0.0.0.0` on a public IP without (a) or (b).
+  - *Caddy (recommended)* — minimal `Caddyfile` reverse-proxying `your.host` →
+    `127.0.0.1:8080`, automatic Let's Encrypt TLS. Keep `ui_host: 127.0.0.1` so only
+    Caddy talks to dccd; set `ui_auth_token`. Note the SSE `?token=` only travels over
+    TLS now.
+  - *nginx (alternative)* — equivalent `server {}` block with `proxy_pass`,
+    `proxy_set_header` for SSE (`proxy_buffering off;` + `Connection ''` so
+    `text/event-stream` streams), TLS via certbot.
+  - *Cloudflare Tunnel (no public port)* — `cloudflared` tunnel to
+    `http://127.0.0.1:8080`; no inbound port opened; TLS terminated at the edge.
+  - *Tailscale (private, no public TLS needed)* — bind `ui_host: 0.0.0.0`, reach via
+    the 100.x tailnet address; transport is already encrypted+authenticated. Combine
+    with `ui_auth_token` as defence-in-depth. Cross-reference the testbox setup.
+  - *Checklist* — token set; plaintext port not published publicly; SSE verified
+    through the proxy (the `/api/events` stream must not be buffered).
+- `doc/source/index.rst` — add `how-to/expose-remote` to the how-to toctree (after
+  `how-to/deploy`).
+- `doc/source/how-to/deploy.rst` — replace the short "Reaching the UI from another
+  machine" section's body with a one-line pointer to the new `:doc:expose-remote`
+  (keep the heading; avoid duplicating content).
+
+## Steps
+1. Write `expose-remote.rst`. Reuse the exact title-overline rule from `deploy.rst`
+   (overline `=` line must be ≥ the title length, or Sphinx warns "Title overline too
+   short").
+2. Add the toctree entry and the deploy.rst pointer.
+3. Use `.. code-block:: caddy` / `nginx` / `bash` fenced blocks; `sphinx-copybutton`
+   is already enabled so commands get a copy button.
+4. Cross-link `:doc:protect-ui` (token) and `:doc:sync-remote` (backups) where
+   relevant, mirroring deploy.rst's "Operate it" cross-refs.
+
+## Tests
+- None (docs-only). The gate is the zero-warning docs build.
+
+## Verification on real data
+This is a deploy-doc leaf — verify the **documented procedure on the real testbox**,
+not just that prose renders:
+1. `cd doc && make clean && make html 2>&1 | grep -ciE 'warning:'` → must be `0`.
+2. On `ssh dccd-testbox` (Tailscale): install Caddy, drop the documented `Caddyfile`
+   pointing at the running `dccd start` (127.0.0.1:8080), reload Caddy.
+3. From **this** machine over the tailnet: `curl -fsS https://<testbox>/health` →
+   `{"status":"ok"}` over TLS; confirm the cert chain (`curl -v`, no `-k`).
+4. Open `/api/events` through the proxy (`curl -N https://<testbox>/api/events?token=…`)
+   and confirm SSE frames **stream** (not buffered until close) — this is the nginx/
+   Caddy footgun the doc must prevent.
+5. Confirm the plaintext `:8080` is **not** reachable off the testbox loopback
+   (`curl --max-time 3 http://<testbox-tailnet-ip>:8080/health` should fail/refuse
+   when `ui_host=127.0.0.1`). Record the commands+outputs in the PR.
+
+## Closeout
+- CHANGELOG (`Added`): "How-to guide for exposing the UI remotely behind TLS
+  (Caddy/nginx/Cloudflare Tunnel/Tailscale), verified end-to-end on a real server
+  (#NN)".
+- ADR: append an entry — *Choice*: front remote exposure with a TLS reverse proxy
+  (Caddy blessed) or a private overlay (Tailscale); keep `ui_host=127.0.0.1` behind a
+  proxy. *Why*: never ship the API plaintext off-box; the existing token is
+  defence-in-depth, not transport security. *Rejected*: binding `0.0.0.0` on a public
+  IP with only the token; baking TLS into the app (proxies do it better).
+- Status/roadmap: in `06-status.md` note the remote-exposure guide exists; **roadmap
+  removal deferred to the last leaf (05)**.

--- a/doc/dev/plans/remote-ui-access/01-deploy-tls-proxy.md
+++ b/doc/dev/plans/remote-ui-access/01-deploy-tls-proxy.md
@@ -26,10 +26,16 @@ nginx and Cloudflare Tunnel are alternatives. Docs-only — no code changes.
   - *Caddy (recommended)* — minimal `Caddyfile` reverse-proxying `your.host` →
     `127.0.0.1:8080`, automatic Let's Encrypt TLS. Keep `ui_host: 127.0.0.1` so only
     Caddy talks to dccd; set `ui_auth_token`. Note the SSE `?token=` only travels over
-    TLS now.
+    TLS now. **Forwarding headers**: Caddy sets `X-Forwarded-Proto` and overwrites
+    `X-Forwarded-For` by default — leaves 02/03 rely on these (Secure-cookie
+    derivation + the rate-limit client key). When trusting XFF for rate-limiting, set
+    `ui_trusted_proxy: true` (leaf 03) **only** because the proxy overwrites XFF.
   - *nginx (alternative)* — equivalent `server {}` block with `proxy_pass`,
     `proxy_set_header` for SSE (`proxy_buffering off;` + `Connection ''` so
-    `text/event-stream` streams), TLS via certbot.
+    `text/event-stream` streams), TLS via certbot. **Must explicitly set**
+    `proxy_set_header X-Forwarded-Proto $scheme;` and
+    `proxy_set_header X-Forwarded-For $remote_addr;` (overwrite, not append, so a
+    client can't inject a forged hop) — 02/03 depend on these.
   - *Cloudflare Tunnel (no public port)* — `cloudflared` tunnel to
     `http://127.0.0.1:8080`; no inbound port opened; TLS terminated at the edge.
   - *Tailscale (private, no public TLS needed)* — bind `ui_host: 0.0.0.0`, reach via

--- a/doc/dev/plans/remote-ui-access/02-ui-auth-session.md
+++ b/doc/dev/plans/remote-ui-access/02-ui-auth-session.md
@@ -29,17 +29,29 @@ session cookie instead.
 ## Files to change
 - `dccd/interfaces/api/app.py`
   - Add a small session layer. On successful token submit, mint a random opaque
-    session id (`secrets.token_urlsafe(32)`), store it in an in-process set/dict
-    `app.state.sessions` (value = creation ns; optional TTL), and set it as cookie
-    `dccd_session` with `HttpOnly`, `SameSite=Lax`, `Secure` **derived from the
-    request scheme** (`request.url.scheme == "https"` or `X-Forwarded-Proto: https`
-    so it works behind the leaf-01 proxy), `Path=/`.
+    session id (`secrets.token_urlsafe(32)`), store it in an in-process dict
+    `app.state.sessions` (value = creation-ns) with an **absolute TTL** (default 7
+    days; prune expired ids on each check so the dict can't grow unbounded), and set
+    it as cookie `dccd_session` with `HttpOnly`, `SameSite=Lax`, `Secure` **derived
+    from the request scheme** (`request.url.scheme == "https"` or
+    `X-Forwarded-Proto: https` so it works behind the leaf-01 proxy), `Path=/`,
+    and `Max-Age` matching the TTL.
+  - **CSRF** — because the API guard will accept the cookie, mutating calls become
+    CSRF-reachable. `SameSite=Lax` is the mitigation: it withholds the cookie on
+    **cross-site POST/DELETE** (all mutating routes are POST/DELETE), while still
+    allowing top-level GET navigation. Do **not** use `SameSite=None`. Document this
+    in a code comment and assert it in tests (below). (`Strict` would also work but
+    breaks following an external link into an authed page; `Lax` is the right balance.)
   - Routes:
     - `GET /login` → render `login.html` (a tiny token-prompt form posting to
       `/login`). If already authed, redirect to `/`.
     - `POST /login` → compare submitted token to `ui_auth_token` with
-      `secrets.compare_digest`; on match set cookie + redirect to `next` (sanitised to
-      a local path) or `/`; on mismatch re-render with an error (HTTP 401).
+      `secrets.compare_digest` (timing-safe); on match set cookie + redirect to `next`
+      or `/`; on mismatch re-render with an error (HTTP 401).
+      **Open-redirect guard**: only accept `next` if it is a **local path** —
+      `next.startswith("/")` **and not** `next.startswith("//")` (and no scheme/`\`);
+      otherwise fall back to `/`. A helper `_safe_next(next)` + a unit test for
+      `//evil.com`, `https://evil`, `/data` cases.
     - `POST /logout` → drop the session, clear the cookie, redirect to `/login`.
   - **Page-route gate**: a helper `_page_authed(request)` (no token configured → always
     True; else cookie present in `app.state.sessions`). Wrap the page routes so an
@@ -90,6 +102,12 @@ session cookie instead.
     the leak): fetch `/` authed and assert the configured token value is absent from
     the HTML body.
   - Bearer header and `?token=` continue to authorise `/api/*` (back-compat).
+  - **CSRF**: a cross-site-style POST (cookie present but `Sec-Fetch-Site`/`Origin`
+    cross-site — or simply: the cookie is `SameSite=Lax` so a real cross-site POST
+    wouldn't carry it) must not succeed on cookie alone. Assert `Set-Cookie` contains
+    `SameSite=Lax` and `HttpOnly`; assert no route sets `SameSite=None`.
+  - **Open redirect**: `_safe_next("//evil.com")` and `_safe_next("https://evil")`
+    fall back to `/`; `_safe_next("/data")` is preserved.
 
 ## Verification on real data
 On the testbox behind the leaf-01 TLS proxy (or Tailscale), with a token set:

--- a/doc/dev/plans/remote-ui-access/02-ui-auth-session.md
+++ b/doc/dev/plans/remote-ui-access/02-ui-auth-session.md
@@ -1,0 +1,115 @@
+---
+plan: remote-ui-access/02-ui-auth-session
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/ui-auth-session
+pr: ""
+---
+
+# Browser auth — login page + cookie session (stop leaking the token into pages)
+
+## Goal
+
+Let a browser (incl. a phone) authenticate **without editing config**, and stop
+serving the raw `ui_auth_token` inside every page. When `ui_auth_token` is set:
+unauthenticated page loads get a **login page**; submitting the token sets an
+**HttpOnly session cookie**; page routes and the `/api/*` guard both accept that
+cookie. When no token is set (default localhost), behaviour is unchanged.
+
+## Security problem being fixed
+`api/app.py` `_tpl_ctx()` injects `ui_auth_token` into the template
+(`base.html` `const DCCD_TOKEN = "{{ auth_token }}"`), and page routes are ungated.
+So any client that can reach a page **receives the token** — unacceptable once the UI
+is remote. After this leaf the browser never sees the token value; it holds an opaque
+session cookie instead.
+
+## Files to change
+- `dccd/interfaces/api/app.py`
+  - Add a small session layer. On successful token submit, mint a random opaque
+    session id (`secrets.token_urlsafe(32)`), store it in an in-process set/dict
+    `app.state.sessions` (value = creation ns; optional TTL), and set it as cookie
+    `dccd_session` with `HttpOnly`, `SameSite=Lax`, `Secure` **derived from the
+    request scheme** (`request.url.scheme == "https"` or `X-Forwarded-Proto: https`
+    so it works behind the leaf-01 proxy), `Path=/`.
+  - Routes:
+    - `GET /login` → render `login.html` (a tiny token-prompt form posting to
+      `/login`). If already authed, redirect to `/`.
+    - `POST /login` → compare submitted token to `ui_auth_token` with
+      `secrets.compare_digest`; on match set cookie + redirect to `next` (sanitised to
+      a local path) or `/`; on mismatch re-render with an error (HTTP 401).
+    - `POST /logout` → drop the session, clear the cookie, redirect to `/login`.
+  - **Page-route gate**: a helper `_page_authed(request)` (no token configured → always
+    True; else cookie present in `app.state.sessions`). Wrap the page routes so an
+    unauthed load returns `RedirectResponse(f"/login?next={path}", 303)` instead of the
+    page. Keep `/login`, `/static/*`, `/health` ungated.
+  - **API guard**: extend `_auth_guard` to also accept a valid `dccd_session` cookie
+    (in addition to `Authorization: Bearer` and `?token=`), so the SPA's `fetch`/SSE
+    calls authorise via the cookie — no token in JS needed.
+  - **Stop injecting the token**: in `_tpl_ctx`, drop `auth_token` from the context
+    (or pass `""`). The front-end no longer needs it (cookie is sent automatically).
+- `dccd/interfaces/ui/templates/login.html` (new) — minimal page extending a bare
+  shell (or standalone): a centered form, password-type input named `token`, submit;
+  shows an error banner when `error` is set. No nav.
+- `dccd/interfaces/ui/templates/base.html`
+  - Remove `const DCCD_TOKEN = "{{ auth_token }}"` and the
+    `opts.headers['Authorization'] = 'Bearer ' + DCCD_TOKEN` line. `fetch` calls go to
+    same-origin `/api/*`; the browser sends the cookie automatically (ensure
+    `credentials:'same-origin'` — it's the default for same-origin, but set it
+    explicitly on the wrapper for clarity).
+  - **SSE**: `EventSource('/api/events')` cannot set headers, but **does** send
+    same-origin cookies automatically, so drop the `?token=` query for the browser
+    case. (The `?token=` path stays supported server-side for `curl`/non-browser.)
+  - Add a small "Logout" affordance in the nav, shown only when a session is active
+    (pass a `bool authed` into the context to conditionally render it).
+- `dccd/interfaces/api/app.py` `_tpl_ctx` — add `"authed": _page_authed(request)` for
+  the logout button.
+
+## Steps
+1. Implement the session store + cookie helpers (mind `Secure` derivation behind a
+   proxy via `X-Forwarded-Proto`).
+2. Add `/login` (GET/POST) and `/logout`; write `login.html`.
+3. Gate page routes via `_page_authed`; keep `/login`,`/static`,`/health` open.
+4. Extend `_auth_guard` to accept the session cookie.
+5. Strip `DCCD_TOKEN`/Bearer-from-JS and the SSE `?token=` from `base.html`; rely on
+   the cookie; add the conditional Logout.
+6. Keep the no-token (localhost default) path a pure pass-through — no login, no gate.
+
+## Tests
+- `dccd/tests/v3/test_api.py` (TestClient):
+  - With `ui_auth_token` set: `GET /` unauthenticated → 303 redirect to `/login`;
+    `GET /login` → 200 with the form.
+  - `POST /login` wrong token → 401; correct token → 303 + `Set-Cookie: dccd_session=…`
+    with `HttpOnly`. Reusing that cookie: `GET /` → 200, and an `/api/*` call with the
+    cookie (no Bearer) → 200; without it → 401.
+  - `POST /logout` clears the cookie; subsequent `GET /` → 303 to `/login`.
+  - **No token configured**: `GET /` → 200 (no redirect); `/api/*` → 200 (unchanged).
+  - Assert the rendered pages **no longer contain the token string** (regression for
+    the leak): fetch `/` authed and assert the configured token value is absent from
+    the HTML body.
+  - Bearer header and `?token=` continue to authorise `/api/*` (back-compat).
+
+## Verification on real data
+On the testbox behind the leaf-01 TLS proxy (or Tailscale), with a token set:
+1. From a **phone browser**, load `https://<testbox>/` → land on the login page;
+   submit the token → reach the dashboard; navigate Data/Historical/Live; confirm SSE
+   liveness updates flow (cookie-authed EventSource) and **view source shows no token**.
+2. `curl -i https://<testbox>/` (no cookie) → 303 `/login`; `curl` the login POST,
+   capture the cookie jar, re-request `/` and `/api/jobs` with the jar → 200.
+3. Confirm `Secure` is set on the cookie when reached over HTTPS (and not set on plain
+   `http://127.0.0.1` so localhost dev still works). Record commands+outputs in the PR.
+
+## Closeout
+- CHANGELOG (`Added`): "Browser login page + HttpOnly cookie session so the UI
+  authenticates without editing config; the auth token is no longer injected into
+  served pages (#NN)". (`Security`/`Fixed`): "page routes are now gated when
+  `ui_auth_token` is set".
+- ADR: *Choice*: opaque in-process cookie session + `/login`; gate page routes; accept
+  the cookie in the API guard; stop templating the token. *Why*: remote exposure made
+  the templated token a leak; cookies are the browser-native, header-less-SSE-friendly
+  auth. *Rejected*: signed-JWT/stateless (overkill for a single shared token); keeping
+  the templated token (leaks); HTTP Basic (worse UX, no logout).
+- Status/roadmap: in `06-status.md` flip the auth-UX gap; roadmap removal deferred to
+  leaf 05.

--- a/doc/dev/plans/remote-ui-access/03-harden-api-exposure.md
+++ b/doc/dev/plans/remote-ui-access/03-harden-api-exposure.md
@@ -18,17 +18,24 @@ that CORS is never wildcard, proof that every mutating route is refused without 
 and an opt-in **read-only** mode that blocks mutating methods (read-only vs control).
 
 ## Files to change
-- `dccd/application/config.py` `SettingsConfig` — add `ui_readonly: bool = False` and
+- `dccd/application/config.py` `SettingsConfig` — add `ui_readonly: bool = False`,
   `ui_rate_limit: int = 0` (requests/sec per client IP on `/api/*`; `0` = disabled,
-  the localhost default). Document both in the model docstring.
+  the localhost default), and `ui_trusted_proxy: bool = False` (whether to trust
+  `X-Forwarded-For` for the client key — see the spoofing note below). Validate
+  `ui_rate_limit >= 0`. Document all three in the model docstring.
 - `dccd/interfaces/api/app.py`
   - **Rate limiter**: a tiny in-process token-bucket per client key, applied in a
     middleware ordered **before** `_auth_guard`, only when `ui_rate_limit > 0` and the
-    path starts with `/api/`. Client key = `X-Forwarded-For` first hop (behind the
-    leaf-01 proxy) else `request.client.host`. Over-limit → `429` JSON
-    `{"detail":"rate limited"}` with a `Retry-After` header. Reuse the existing
-    `transport/ratelimit.py` token-bucket if it's import-safe here; otherwise a
-    minimal local bucket (keep it dependency-free).
+    path starts with `/api/`. Over-limit → `429` JSON `{"detail":"rate limited"}` with
+    a `Retry-After` header. Reuse the existing `transport/ratelimit.py` token-bucket if
+    it's import-safe here; otherwise a minimal local bucket (keep it dependency-free).
+  - **Client key / XFF spoofing guard** (important): `X-Forwarded-For` is
+    attacker-controlled when the app is reachable directly, so trusting it blindly lets
+    a single client forge unlimited keys and bypass the limit. Therefore: use
+    `request.client.host` **by default**; honour `X-Forwarded-For` (first hop) **only
+    when `ui_trusted_proxy=True`** — i.e. the operator asserts the app is reachable
+    *only* through the leaf-01 reverse proxy. Document that `ui_trusted_proxy` must be
+    set **only** behind a proxy that overwrites XFF.
   - **Read-only mode**: when `settings.ui_readonly` is True, refuse mutating requests
     to `/api/*` — block `POST/PUT/PATCH/DELETE` (the mutating verbs; all job CRUD,
     backfill run/cancel, stream start/stop are POST/DELETE) with `403`
@@ -52,6 +59,10 @@ and an opt-in **read-only** mode that blocks mutating methods (read-only vs cont
   - **Rate limit**: app with `ui_rate_limit=2`; a burst of N>bucket GET `/api/jobs`
     from the same client returns at least one `429` with `Retry-After`; a different
     client key is unaffected; with `ui_rate_limit=0` no 429 ever.
+  - **XFF trust**: with `ui_trusted_proxy=False` (default), a forged `X-Forwarded-For`
+    header does **not** create a fresh bucket (keying ignores XFF → same
+    `request.client.host` still rate-limited). With `ui_trusted_proxy=True`, distinct
+    XFF values get distinct buckets.
   - **Read-only**: app with `ui_readonly=True` + valid auth → `POST /api/jobs/create`
     → 403 `read-only`; `GET /api/jobs` → 200. With `ui_readonly=False` the POST works
     (existing behaviour). Confirm read-only is enforced **after** auth (a 401 still

--- a/doc/dev/plans/remote-ui-access/03-harden-api-exposure.md
+++ b/doc/dev/plans/remote-ui-access/03-harden-api-exposure.md
@@ -1,0 +1,84 @@
+---
+plan: remote-ui-access/03-harden-api-exposure
+kind: leaf
+status: planned
+complexity: high
+depends: [02]
+parallel: false
+branch: feat/harden-api-exposure
+pr: ""
+---
+
+# Harden /api for a hostile network — rate limit, CORS proof, read-only role
+
+## Goal
+
+Make the API safe(r) to expose: bound request rate on `/api/*`, a regression test
+that CORS is never wildcard, proof that every mutating route is refused without auth,
+and an opt-in **read-only** mode that blocks mutating methods (read-only vs control).
+
+## Files to change
+- `dccd/application/config.py` `SettingsConfig` — add `ui_readonly: bool = False` and
+  `ui_rate_limit: int = 0` (requests/sec per client IP on `/api/*`; `0` = disabled,
+  the localhost default). Document both in the model docstring.
+- `dccd/interfaces/api/app.py`
+  - **Rate limiter**: a tiny in-process token-bucket per client key, applied in a
+    middleware ordered **before** `_auth_guard`, only when `ui_rate_limit > 0` and the
+    path starts with `/api/`. Client key = `X-Forwarded-For` first hop (behind the
+    leaf-01 proxy) else `request.client.host`. Over-limit → `429` JSON
+    `{"detail":"rate limited"}` with a `Retry-After` header. Reuse the existing
+    `transport/ratelimit.py` token-bucket if it's import-safe here; otherwise a
+    minimal local bucket (keep it dependency-free).
+  - **Read-only mode**: when `settings.ui_readonly` is True, refuse mutating requests
+    to `/api/*` — block `POST/PUT/PATCH/DELETE` (the mutating verbs; all job CRUD,
+    backfill run/cancel, stream start/stop are POST/DELETE) with `403`
+    `{"detail":"read-only"}`. `GET`/`HEAD`/`OPTIONS` pass. Apply in the guard.
+  - **CORS**: no code change expected (already opt-in, non-wildcard at app.py:226) —
+    but add an assertion path the test can exercise.
+- `doc/source/how-to/expose-remote.rst` (created in leaf 01) — add a short
+  "Hardening" subsection documenting `ui_rate_limit` and `ui_readonly`.
+
+## Steps
+1. Add the two settings + validation (non-negative int; bool).
+2. Implement the rate-limit middleware (before auth) gated on `ui_rate_limit>0`.
+3. Add the read-only check in `_auth_guard` (after auth succeeds, before dispatch).
+4. Document both in the expose-remote how-to.
+
+## Tests
+- `dccd/tests/v3/test_api.py`:
+  - **CORS regression**: build an app with `ui_allow_origins=[]` → no
+    `access-control-allow-origin: *` ever returned; with a specific origin set → that
+    origin echoed, never `*`. (Assert wildcard is impossible.)
+  - **Rate limit**: app with `ui_rate_limit=2`; a burst of N>bucket GET `/api/jobs`
+    from the same client returns at least one `429` with `Retry-After`; a different
+    client key is unaffected; with `ui_rate_limit=0` no 429 ever.
+  - **Read-only**: app with `ui_readonly=True` + valid auth → `POST /api/jobs/create`
+    → 403 `read-only`; `GET /api/jobs` → 200. With `ui_readonly=False` the POST works
+    (existing behaviour). Confirm read-only is enforced **after** auth (a 401 still
+    wins for unauthenticated mutating calls).
+  - **Mutating-routes-need-auth sweep**: parametrise over the mutating endpoints
+    (`/api/jobs/{create,delete,update}`, `/api/jobs/{run,run-all}`,
+    `/api/backfill/{id}` DELETE, stream start/stop) and assert each is `401` without a
+    token when `ui_auth_token` is set.
+
+## Verification on real data
+On the testbox behind the proxy, token set:
+1. Set `ui_rate_limit: 5`; hammer `/api/jobs` (`for i in $(seq 50); do curl -s -o
+   /dev/null -w '%{http_code}\n' …; done`) → observe `429`s appear; confirm normal
+   browsing still works under the limit.
+2. Set `ui_readonly: true`, reload; from the browser the Run/Start/Delete buttons get
+   `403`; `GET` views still render. Flip back to control; mutations work again.
+3. Confirm the proxy's `X-Forwarded-For` is the key (rate limit is per real client,
+   not per-proxy) — two devices get independent buckets. Record outputs in the PR.
+
+## Closeout
+- CHANGELOG (`Added`): "`ui_rate_limit` (token-bucket on `/api/*`) and `ui_readonly`
+  (block mutating methods) settings for hardened remote exposure (#NN)".
+  (`Security`): "regression test proving CORS is never wildcard and every mutating
+  route requires the token".
+- ADR: *Choice*: in-process per-IP token-bucket + read-only verb gate, both opt-in
+  (off on localhost). *Why*: exposure needs abuse-resistance and a safe view-only
+  share without standing up Redis/an external WAF. *Rejected*: external rate-limiter
+  dependency; per-route role decorators (heavier than a verb gate for a single shared
+  token).
+- Status/roadmap: note hardening in `06-status.md`; roadmap removal deferred to leaf 05.

--- a/doc/dev/plans/remote-ui-access/04-mobile-responsive.md
+++ b/doc/dev/plans/remote-ui-access/04-mobile-responsive.md
@@ -1,0 +1,75 @@
+---
+plan: remote-ui-access/04-mobile-responsive
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/ui-mobile-responsive
+pr: ""
+---
+
+# Mobile responsiveness pass + ui_smoke mobile-viewport run
+
+## Goal
+
+Make Dashboard/Data/Historical/Live usable on a phone (≈390-px viewport): wide tables
+stack into cards, tap targets are finger-sized, the nav and its dropdowns work on a
+narrow screen. Add a mobile-viewport pass to `ui_smoke.py`.
+
+## Files to change
+- `dccd/interfaces/ui/templates/base.html`
+  - The `<meta name="viewport">` already exists (line 5) — good. Add a `@media
+    (max-width: 640px)` block to the inline `<style>`:
+    - `nav` already `flex-wrap`s; ensure brand + menu buttons stay tappable
+      (≥44px height), reduce horizontal padding, let the nav wrap cleanly.
+    - Make `.nav-menu-items` dropdowns full-width / properly positioned on narrow
+      screens (they're `position:absolute` — verify they don't overflow the viewport).
+    - Generic table rule: under the breakpoint, allow horizontal scroll
+      (`overflow-x:auto` wrappers) **or** stacked rows; pick the approach per table
+      below.
+  - **Coordinate with leaf 02**: 02 edits `base.html` nav (Logout button). This leaf
+    is kept serial (not `parallel`) so the two don't collide — execute it before 02 or
+    after 02 merges, rebasing onto the latest `base.html`.
+- `dccd/interfaces/ui/templates/{dashboard,data,historical,live}.html`
+  - Wrap their wide tables in a responsive container and add per-page `@media` tweaks
+    (KPI cards stack to one column; accordion rows reflow; the Historical/Live
+    action buttons — Run/Delete/Start/Stop — get adequate spacing/size on touch).
+  - Keep desktop layout byte-identical above the breakpoint (only add `@media`
+    rules; do not restructure the default styles).
+- `doc/dev/ui_smoke.py`
+  - Add a mobile-viewport pass: after the existing desktop checks, set
+    `await page.set_viewport_size({"width": 390, "height": 844})` (iPhone-ish) and
+    re-run the core navigation checks (Dashboard loads, nav dropdowns open and route,
+    Data/Historical/Live render). Add a check that no element overflows the viewport
+    width (e.g. evaluate `document.documentElement.scrollWidth <=
+    window.innerWidth + 1` on each page) and `step(...)` it.
+
+## Steps
+1. Add the `@media (max-width:640px)` rules to `base.html` and per-page templates.
+2. Pick a consistent table strategy (recommend: horizontal-scroll wrappers for dense
+   data tables on Data/Historical/Live; card-stack for the Dashboard KPIs).
+3. Extend `ui_smoke.py` with the 390-px pass + the no-horizontal-overflow assertion.
+4. Keep all changes additive (media queries) — desktop unchanged.
+
+## Tests
+- No unit test (pure templates/CSS). The gate is `ui_smoke.py` (now including the
+  mobile pass) plus the manual real-device check below. (`pytest` must still pass —
+  no Python behaviour changed.)
+
+## Verification on real data
+- Start an isolated `dccd ui` on a temp config/data; run
+  `python doc/dev/ui_smoke.py http://127.0.0.1:<port>` → all steps PASS, **including
+  the new mobile-viewport pass and the no-horizontal-overflow check**.
+- On a **real phone** (over Tailscale/the leaf-01 proxy): load each page, confirm no
+  horizontal scrolling of the whole page, dropdowns open and route, the
+  Run/Start/Stop/Delete buttons are tappable, tables are readable (scroll or stacked).
+  Capture a screenshot or note per page in the PR.
+
+## Closeout
+- CHANGELOG (`Changed`): "Responsive layout for Dashboard/Data/Historical/Live on
+  narrow (mobile) viewports; `ui_smoke.py` gains a mobile-viewport pass (#NN)".
+- ADR: none — UI/CSS pass, no architectural decision (state "none — presentation
+  only" at finish).
+- Status/roadmap: note mobile pass in `06-status.md`; roadmap removal deferred to leaf
+  05.

--- a/doc/dev/plans/remote-ui-access/05-threat-model-note.md
+++ b/doc/dev/plans/remote-ui-access/05-threat-model-note.md
@@ -32,7 +32,10 @@ is and isn't protected. Docs-only; depends on 01–03 because it must describe t
   - *Residual risks & mitigations*: `?token=` in SSE URLs can appear in proxy logs —
     prefer the cookie path for browsers (default after 02); set `ui_readonly` for
     view-only shares; bound `ui_rate_limit`; keep `data_path` under the service's
-    `StateDirectory`.
+    `StateDirectory`. **CSRF**: mutating routes are protected by the `SameSite=Lax`
+    cookie (cross-site POST/DELETE don't carry it) — state this explicitly. **XFF
+    spoofing**: `ui_trusted_proxy` must be enabled *only* behind a proxy that
+    overwrites `X-Forwarded-For`, else the rate-limit key is forgeable.
   - *Recommended postures table*: LAN-only / Tailnet / Public — for each: bind, TLS,
     token, read-only suggestion.
 - `doc/source/how-to/deploy.rst` — ensure its "Reaching the UI remotely" pointer (set

--- a/doc/dev/plans/remote-ui-access/05-threat-model-note.md
+++ b/doc/dev/plans/remote-ui-access/05-threat-model-note.md
@@ -1,0 +1,64 @@
+---
+plan: remote-ui-access/05-threat-model-note
+kind: leaf
+status: planned
+complexity: low
+depends: [01, 02, 03]
+parallel: false
+branch: docs/threat-model
+pr: ""
+---
+
+# Threat-model note in the deploy how-to
+
+## Goal
+
+Write down the security assumptions for remote exposure so a reader knows exactly what
+is and isn't protected. Docs-only; depends on 01–03 because it must describe the
+**final** posture (TLS front, cookie session + gated pages, rate-limit/read-only).
+
+## Files to change
+- `doc/source/how-to/expose-remote.rst` (created in leaf 01) — add a **Threat model**
+  section near the end. Cover:
+  - *Trust boundaries*: localhost-only (default, no auth needed) vs private overlay
+    (Tailscale: transport already encrypted+authenticated) vs public internet (must be
+    behind a TLS reverse proxy; never plaintext).
+  - *What the token/session protects*: API authZ for a **single shared secret** — not
+    per-user identity, not multi-tenant. The cookie session is opaque and HttpOnly; the
+    token is never templated into pages (post leaf 02).
+  - *What it does NOT protect*: it is not a substitute for TLS (use a proxy or the
+    overlay); a shared token has no per-user revocation beyond rotating it; in-process
+    rate-limit/session state resets on restart (acceptable for a single-node daemon).
+  - *Residual risks & mitigations*: `?token=` in SSE URLs can appear in proxy logs —
+    prefer the cookie path for browsers (default after 02); set `ui_readonly` for
+    view-only shares; bound `ui_rate_limit`; keep `data_path` under the service's
+    `StateDirectory`.
+  - *Recommended postures table*: LAN-only / Tailnet / Public — for each: bind, TLS,
+    token, read-only suggestion.
+- `doc/source/how-to/deploy.rst` — ensure its "Reaching the UI remotely" pointer (set
+  in leaf 01) also references the threat-model section anchor.
+
+## Steps
+1. Write the Threat model section, consistent with what 01–03 actually shipped (read
+   the merged leaves, don't restate the plan).
+2. Add the postures table (`.. list-table::` or a simple grid).
+3. Re-check cross-references resolve.
+
+## Tests
+- None (docs-only). Gate: zero-warning docs build.
+
+## Verification on real data
+- `cd doc && make clean && make html 2>&1 | grep -ciE 'warning:'` → `0`.
+- Read the rendered page top-to-bottom and confirm every claim matches the **shipped**
+  behaviour of leaves 01–03 (e.g. "token not in page source" is true; `ui_readonly`
+  exists; rate-limit header is `Retry-After`). No aspirational statements.
+
+## Closeout
+- CHANGELOG (`Added`): "Threat-model section in the remote-exposure how-to (trust
+  boundaries, what the token/session protects, recommended postures) (#NN)".
+- ADR: none — documents decisions already recorded by leaves 01–03 (state "none —
+  documents prior ADRs" at finish).
+- Status/roadmap: **this is the last leaf** — set `00-plan.md` `status: done`, **remove
+  the Epic B block from `doc/dev/07-roadmap.md`** and update the "Suggested sequence"
+  (mark B done), update `06-status.md` to reflect Epic B complete, archive the whole
+  `doc/dev/plans/remote-ui-access/` tree to `_archive/`, and **suggest `/release`**.


### PR DESCRIPTION
## Goal

Plan tree for **Epic B — View the UI remotely (PC + mobile)**: open the dashboard
securely from a laptop or phone, never exposing the API plaintext off-box. Lands the
durable plan on `develop` so every leaf branch inherits it.

**Security framing:** today page routes are ungated and the server injects
`ui_auth_token` into every page (`api/app.py` `_tpl_ctx` → `base.html` `DCCD_TOKEN`).
On localhost that's fine; remotely it leaks the token to anyone who loads a page — so
leaf **02 (browser auth/session) is the linchpin** and must land before hardening and
the threat-model note.

## Leaf checklist
- [ ] 01 deploy-tls-proxy — `docs/tls-reverse-proxy` — medium — TLS front (Caddy/nginx/Cloudflare Tunnel/Tailscale), verified on the real testbox
- [ ] 02 ui-auth-session — `feat/ui-auth-session` — high — login page + HttpOnly cookie session; gate page routes; stop templating the token *(linchpin)*
- [ ] 03 harden-api-exposure — `feat/harden-api-exposure` — high — rate-limit `/api/*`, CORS-never-wildcard test, `ui_readonly` mode *(depends 02)*
- [ ] 04 mobile-responsive — `feat/ui-mobile-responsive` — medium — narrow-viewport pass + `ui_smoke.py` mobile run
- [ ] 05 threat-model-note — `docs/threat-model` — low — trust boundaries + postures in the deploy how-to *(depends 01,02,03; last leaf → removes roadmap line, suggests /release)*

## Dependencies
- 03 depends on 02; 05 depends on 01,02,03.
- 04 is independent but kept **serial** (it edits `base.html`, which 02 also touches).

## Why plan-PR-first
Lands `doc/dev/plans/remote-ui-access/` on `develop` before any code, so each leaf
branch already contains the spec and the plan is reviewable up front.

## Test plan
- [x] Docs-only on this branch; plan tree follows `doc/dev/plans/README.md` schema
- [ ] CI green