### PR TITLE
chore: release v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.3.0] - 2026-06-10
+
+### Added
+
 - Threat-model section in `how-to/expose-remote` (trust boundaries: localhost / tailnet
   / public; what the token+cookie session protect and don't; residual risks; a
   recommended-postures table) — completing **Epic B** (view the UI remotely). (#110)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.2.0"
+version = "3.3.0"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v3.3.0 — Epic B (view the UI remotely)

Freezes `[Unreleased]` → `[3.3.0]` and bumps `pyproject.toml` to `3.3.0`.

### Added
- Threat-model section in `how-to/expose-remote` — closes Epic B. (#110)
- API hardening: `ui_rate_limit` (429), `ui_readonly` (403), `ui_trusted_proxy`;
  CORS-never-wildcard + mutating-routes-need-auth tests. (#108)
- Browser `/login` + `HttpOnly` cookie session; API accepts the cookie. (#107)
- `how-to/expose-remote` guide (Caddy/nginx/Cloudflare Tunnel/Tailscale). (#106)

### Changed
- Responsive UI for mobile viewports + `ui_smoke.py` 390px overflow pass. (#109)

### Fixed
- The raw `ui_auth_token` is no longer injected into served pages (token leak). (#107)

All five leaves verified live on a real server over Tailscale / a headless mobile
viewport.

## Test plan
- [x] `pytest` (241) · `ruff` · `mypy` · docs 0 warnings on develop
- [ ] CI green