### PR TITLE
fix: kraken crypto-quote symbol (ETH/BTC -> XETHXXBT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kraken crypto/crypto OHLC pairs (e.g. `ETH/BTC`): `_kraken_pair` only mapped the
   *base* `BTC→XBT`, producing `XETHXBTC` which Kraken rejects with "Unknown asset
   pair"; it now maps the *quote* too (`XETHXXBT`). Verified against the live Kraken
-  API (721 bars). (#NN)
+  API (721 bars). (#113)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kraken crypto/crypto OHLC pairs (e.g. `ETH/BTC`): `_kraken_pair` only mapped the
+  *base* `BTC→XBT`, producing `XETHXBTC` which Kraken rejects with "Unknown asset
+  pair"; it now maps the *quote* too (`XETHXXBT`). Verified against the live Kraken
+  API (721 bars). (#NN)
+
 ### Deprecated
 
 ### Removed

--- a/dccd/sources/kraken.py
+++ b/dccd/sources/kraken.py
@@ -45,13 +45,19 @@ def _kraken_pair(symbol: Symbol) -> str:
     >>> from dccd.domain.symbol import Symbol
     >>> _kraken_pair(Symbol(base='BTC', quote='USD'))
     'XXBTZUSD'
+    >>> _kraken_pair(Symbol(base='ETH', quote='BTC'))
+    'XETHXXBT'
     """
+    # Kraken names BTC as XBT — for the quote too, not just the base, so a
+    # crypto/crypto pair like ETH/BTC must become XETHXXBT (not XETHXBTC,
+    # which Kraken rejects with "Unknown asset pair").
     base = "XBT" if symbol.base == "BTC" else symbol.base
+    quote = "XBT" if symbol.quote == "BTC" else symbol.quote
     if base in ("BCH", "DASH"):
-        return f"{base}{symbol.quote}"
-    if symbol.quote in ("EUR", "USD", "CAD", "JPY", "GBP"):
-        return f"X{base}Z{symbol.quote}"
-    return f"X{base}X{symbol.quote}"
+        return f"{base}{quote}"
+    if quote in ("EUR", "USD", "CAD", "JPY", "GBP"):
+        return f"X{base}Z{quote}"
+    return f"X{base}X{quote}"
 
 
 def _ws_pair(symbol: Symbol) -> str:

--- a/dccd/tests/v3/test_sources.py
+++ b/dccd/tests/v3/test_sources.py
@@ -115,6 +115,10 @@ class TestKrakenCapabilities:
     def test_render_symbol(self):
         assert self.src.render_symbol(BTC_USD) == "XXBTZUSD"
 
+    def test_render_symbol_crypto_quote_btc(self):
+        # ETH/BTC: BTC→XBT for the *quote* too, else Kraken rejects "XETHXBTC".
+        assert self.src.render_symbol(Symbol(base="ETH", quote="BTC")) == "XETHXXBT"
+
     def test_ohlc_cap_history_recent(self):
         cap = self.src.capability_for(DataType.OHLC, "rest", "historical")
         assert cap is not None


### PR DESCRIPTION
## Summary
`_kraken_pair` mapped only the **base** `BTC→XBT`, so a crypto/crypto pair like
`ETH/BTC` became `XETHXBTC` — which Kraken rejects with *Unknown asset pair*. It now
maps the **quote** too → `XETHXXBT`.

## Why
Found while configuring a real collector: every Kraken `ETH/BTC` OHLC backfill wrote 0
rows. Kraken is the user's priority exchange. Mechanical mapping fix, no design choice.

## Changes
- `dccd/sources/kraken.py`: `_kraken_pair` converts `BTC→XBT` for the quote as well;
  added a doctest example.
- `test_sources.py`: assert `render_symbol(ETH/BTC) == "XETHXXBT"`.

## Verification on real data
Live Kraken API: `pair=XETHXBTC` → `["EQuery:Unknown asset pair"]`; `pair=XETHXXBT` →
**OK, 721 bars**. Full suite 242 passed, ruff + mypy clean.

## Test plan
- [x] `pytest` (242) · `ruff` · `mypy`
- [x] Verified against the live Kraken API
- [ ] CI green