### PR TITLE
chore: release v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+## [3.3.1] - 2026-06-10
+
+### Fixed
+
 - Kraken crypto/crypto OHLC pairs (e.g. `ETH/BTC`): `_kraken_pair` only mapped the
   *base* `BTC→XBT`, producing `XETHXBTC` which Kraken rejects with "Unknown asset
   pair"; it now maps the *quote* too (`XETHXXBT`). Verified against the live Kraken
   API (721 bars). (#113)
-
-### Deprecated
-
-### Removed
 
 ## [3.3.0] - 2026-06-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.3.0"
+version = "3.3.1"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v3.3.1 — patch

### Fixed
- Kraken crypto/crypto OHLC pairs (`ETH/BTC` → `XETHXXBT`, not the rejected
  `XETHXBTC`). Verified against the live Kraken API. (#113)

## Test plan
- [x] `pytest` (242) · `ruff` · `mypy` green on develop
- [ ] CI green