### PR TITLE
docs: plan perf-robustness (Epic D — production audit fixes)

### DIFF
--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -47,6 +47,37 @@ a pass of the `data-e2e` skill.
 
 ---
 
+## Epic D — Performance & robustness (from the 2026-06-10 production audit)
+
+A py-spy profile of the live collector (arthurserver, 3.3.1, 50 jobs) found the
+daemon pinned at ~98 % CPU: `kraken.stream_orderbook` rebuilds the full book as
+pydantic objects on **every** WS delta while `operations.stream` discards all but
+one frame per `snapshot_interval`. The starved event loop made `/api/inventory`
+take 100 s for 10 KB (store: 50 files / 32 MB). Full findings: memory
+`project-v33-perf-audit` + ADR journal.
+
+Ordered by impact; each line is one small PR:
+
+- [ ] **D1 — Order-book snapshot construction throttled upstream** — adapters keep
+  raw dict state and only build `OrderBookSnapshot`/`OrderBookLevel` at capture
+  time (`snapshot_interval`), not per delta; Kraken book truncated to the
+  subscribed depth (WS v2 contract). Kills the 98 % CPU burn.
+- [ ] **D2 — `inventory()` from parquet footer metadata + off-thread + cached** —
+  `num_rows` + TS min/max from `pyarrow` footer stats (no column read),
+  `asyncio.to_thread` in the API, process-level cache invalidated on write;
+  `GET /api/storage/sync` reuses it instead of re-scanning.
+- [ ] **D3 — Honest WS subscriptions** — validate `depth` per exchange capability
+  (Kraken v2 accepts only {10,25,100,500,1000}; config had 20/50), surface
+  subscription error/ACK frames instead of silently filtering them (a "live"
+  stream must never sit forever writing nothing).
+- [ ] **D4 — Scheduler/monitor hygiene** — exponential backoff for permanently
+  failing interval jobs, startup jitter (no thundering herd), HealthMonitor alert
+  cooldown (alert on threshold crossing, not every failure).
+- [ ] **D5 — HTTP/UI transport efficiency** — `GZipMiddleware`, dashboard fetches
+  in parallel, SSE-driven refresh instead of 8–10 s inventory polling,
+  `RunsStore` calls off-thread; stream ending on its own reports `failed`/ended,
+  not `cancelled`.
+
 ## Deferred — M3 (post-3.0)
 
 Larger axes intentionally parked until after the 3.0 release. Not started; do not

--- a/doc/dev/plans/perf-robustness/00-plan.md
+++ b/doc/dev/plans/perf-robustness/00-plan.md
@@ -1,0 +1,70 @@
+---
+plan: perf-robustness
+kind: global
+status: planning
+roadmap: "## Epic D — Performance & robustness (from the 2026-06-10 production audit)"
+release_on_done: true
+---
+
+# Epic D — Performance & robustness
+
+## Goal
+
+The production audit of 2026-06-10 (arthurserver, 3.3.1, 50 jobs) found the
+daemon pinned at **97.7 % CPU** with the UI unusable remotely (`/api/inventory`:
+100 s for 10 KB over a 50-file / 32 MB store). A py-spy profile attributed ~96 %
+of samples to `kraken.stream_orderbook` building the full book as pydantic
+objects on **every WS delta** while `operations.stream` discards all but one
+frame per `snapshot_interval`. Done = an idle collector daemon sits at < 10 %
+CPU with 20 order-book streams, every `/api/*` endpoint answers in < 500 ms on
+a populated store, WS subscription failures are loud, failing scheduled jobs
+back off, and alerts don't spam.
+
+Measured evidence and full findings: ADR journal entry (closeout of leaf 01) +
+auto-memory `project-v33-perf-audit`.
+
+## Decomposition
+
+1. **orderbook-snapshot-throttle** — build `OrderBookSnapshot` only at capture
+   time (`min_interval` pushed down into adapters); truncate Kraken/Bybit book
+   state to the subscribed depth. Kills the CPU burn.
+2. **inventory-footer-metadata** — `ParquetStore` metadata reads (`inventory`,
+   `last_timestamp`, `missing_intervals`, `_is_year_complete`) from parquet
+   footer stats instead of materialising the TS column; per-file mtime cache;
+   API calls moved off-thread.
+3. **ws-subscription-honesty** — declare valid order-book depths per capability
+   and snap requested depths to them; surface WS subscription error/ACK frames
+   instead of silently filtering them.
+4. **scheduler-monitor-hygiene** — exponential backoff for failing interval
+   jobs, startup jitter, HealthMonitor alert cooldown.
+5. **ui-transport-efficiency** — GZip middleware, parallel dashboard fetches,
+   saner poll intervals, RunsStore calls off-thread, honest stream end-state.
+
+## Leaf checklist
+
+- [ ] 01 orderbook-snapshot-throttle — fix/orderbook-snapshot-throttle — medium
+- [ ] 02 inventory-footer-metadata — fix/inventory-footer-metadata — medium
+- [ ] 03 ws-subscription-honesty — fix/ws-subscription-honesty — medium (depends on 01)
+- [ ] 04 scheduler-monitor-hygiene — fix/scheduler-monitor-hygiene — medium
+- [ ] 05 ui-transport-efficiency — feat/ui-transport-efficiency — medium (depends on 02)
+
+## Dependencies
+
+- 03 depends on 01 (both rewrite the same adapter WS loops; serialise to avoid
+  conflicts).
+- 05 depends on 02 (both touch `interfaces/api/app.py`; 05's poll-interval
+  choices assume inventory is cheap).
+- 01, 02 and 04 are mutually independent (`parallel: true`) — disjoint files.
+
+## Done criteria
+
+- A local `dccd start` with ≥ 2 real Kraken + 1 Bybit order-book streams idles
+  below ~10 % CPU (was: one Kraken stream alone saturated a core).
+- `GET /api/inventory` on a populated store returns in < 500 ms and its JSON is
+  byte-identical (same fields/values) to the pre-change implementation.
+- A Kraken order-book job with `depth: 20` either snaps to a valid depth (and
+  says so) or fails loudly — it never sits "live" writing nothing.
+- A permanently failing interval job backs off (observed gaps grow) and fires
+  exactly one alert at the threshold, then at most one per cooldown window.
+- All five PRs merged into `develop`; roadmap Epic D section removed; suggest
+  `/release`.

--- a/doc/dev/plans/perf-robustness/01-orderbook-snapshot-throttle.md
+++ b/doc/dev/plans/perf-robustness/01-orderbook-snapshot-throttle.md
@@ -1,0 +1,113 @@
+---
+plan: perf-robustness/01-orderbook-snapshot-throttle
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: fix/orderbook-snapshot-throttle
+pr: ""
+---
+
+# Throttle order-book snapshot construction upstream (kills the 98 % CPU burn)
+
+## Goal
+
+Adapters currently build a full `OrderBookSnapshot` (pydantic: one
+`OrderBookLevel` per price level, sorted) on **every** WS frame; the consumer
+(`operations.stream`) discards all but one per `snapshot_interval` (default
+60 s). Move the throttle *upstream*: apply deltas to cheap dict state on every
+frame, but **construct pydantic objects only when a capture is due**. Measured
+on arthurserver: ~96 % of daemon CPU samples were in `kraken.stream_orderbook`
+lines 343–345 (`pydantic __init__`).
+
+## Files to change
+
+- `dccd/sources/base.py` — `OrderBookLive.stream_orderbook` protocol gains a
+  keyword-only param: `def stream_orderbook(self, symbol, depth, *,
+  min_interval: float = 0.0)`. `0.0` = legacy behaviour (yield every frame).
+- `dccd/sources/kraken.py` — `KrakenSource.stream_orderbook` forwards
+  `min_interval` to `_KrakenWS`; `_KrakenWS.stream_orderbook`:
+  1. keep applying snapshot/delta frames to `state_bids`/`state_asks` dicts
+     exactly as today;
+  2. **before** any `OrderBookLevel`/`OrderBookSnapshot` construction, check
+     `time.monotonic() - last_emit < min_interval` → `continue`;
+  3. at emit time, sort once, **truncate both sides to the subscribed depth**
+     (`self._param`) for the snapshot AND prune `state_bids`/`state_asks` to
+     those same top-`depth` levels (Kraken WS v2 contract says the client
+     truncates after updates; pruning at emit bounds stale-level retention to
+     one interval — note this in a comment);
+  4. emitted snapshots are full state → `is_snapshot=True` always.
+- `dccd/sources/bybit.py` — same treatment in `_BybitWS.stream_orderbook`
+  (lines ~199–235): delta state in dicts, throttle check before construction,
+  truncate/prune to depth at emit.
+- `dccd/sources/binance.py`, `dccd/sources/okx.py`, `dccd/sources/bitmex.py` —
+  these receive push-snapshots (top-5/10/20; OKX `books5` pushes at ~10 Hz).
+  Accept the new `min_interval` kwarg and skip frames (after the cheap
+  `json.loads` + channel check, before building any pydantic object) until the
+  interval has elapsed. For the ones built on `parse_message`/`stream()`
+  (binance, okx, bitmex), the simplest compliant change is a small wrapper
+  generator in the adapter's `stream_orderbook` that tracks `last_emit` and
+  drops early frames *before* parse where possible, else after parse — the
+  invariant to honour is: **no pydantic construction for a frame that will be
+  dropped**. Restructure `parse_message` into a raw-loop generator if needed
+  (kraken/bybit already use `stream_raw`).
+- `dccd/sources/coinbase.py`, `dccd/sources/bitfinex.py` — no live order book
+  (capability not declared); only update signatures if they stub the protocol.
+- `dccd/application/operations.py` — `stream()` order-book branch: pass
+  `min_interval=snapshot_interval` to `adapter.stream_orderbook(...)` and
+  **remove** the local `if time.time() - last_save < snapshot_interval:
+  continue` throttle — save every yielded snapshot (the adapter now owns the
+  cadence). Keep `_emit_sample` on save.
+
+## Steps
+
+1. Change the protocol signature in `base.py` (keyword-only, defaulted — no
+   call-site breakage).
+2. Rework `_KrakenWS.stream_orderbook` per above; verify the truncation uses
+   `self._param` (the subscribed depth).
+3. Rework `_BybitWS.stream_orderbook` identically.
+4. Add the throttle wrapper to binance/okx/bitmex `stream_orderbook`.
+5. Update `operations.stream` (pass-through + remove downstream throttle).
+6. Run `pytest`, `ruff check dccd/`, `mypy dccd/`.
+
+## Tests
+
+- `dccd/tests/v3/test_sources.py` (or a new `test_orderbook_throttle.py`):
+  - feed a scripted sequence of Kraken book frames (1 snapshot + N deltas)
+    through `_KrakenWS.stream_orderbook` with a monkeypatched
+    `time.monotonic`; assert exactly one snapshot is yielded per
+    `min_interval` window, and zero `OrderBookLevel` construction happens for
+    skipped frames (e.g. monkeypatch/spy the class or count via a wrapped
+    constructor).
+  - assert emitted snapshots are truncated to `depth` levels per side and that
+    a delta-removed level (qty 0) is gone.
+  - `min_interval=0.0` keeps legacy per-frame behaviour (regression guard for
+    existing tests).
+  - same scripted-frames test for Bybit.
+- Existing protocol-compliance tests must still pass unmodified.
+
+## Verification on real data
+
+- On an **isolated store** (`data-e2e` discipline): run a real
+  `operations.stream` against live Kraken (BTC/USD order book,
+  `snapshot_interval=10`, depth 25) for ~60 s. Assert: ~6 snapshots landed in
+  Parquet, each with ≤ 25 levels per side, ts monotonic, no crossed book
+  (max bid < min ask).
+- CPU check: run `dccd start` locally with 2 Kraken + 1 Bybit order-book
+  streams for 2 minutes; `ps -o pcpu= -p <pid>` must read **< 10 %**
+  (pre-change: a single Kraken stream saturated a core). Record both numbers
+  in the PR body.
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "Order-book WS adapters built the full book as pydantic
+  objects on every delta (~98 % CPU on a live collector, starving the event
+  loop and the remote UI); snapshots are now constructed only at capture time
+  (`min_interval` pushed down into the adapters) and Kraken/Bybit book state is
+  truncated to the subscribed depth. (#NN)"
+- ADR: throttle lives in the adapter (not the consumer) because the cost to
+  kill is the *construction*, which only the adapter can skip; `min_interval=0`
+  preserves the per-frame contract for any other consumer.
+- Status/roadmap: tick leaf 01 in `00-plan.md`; roadmap line D1 removed by
+  `/finish-task` of the last leaf only.

--- a/doc/dev/plans/perf-robustness/02-inventory-footer-metadata.md
+++ b/doc/dev/plans/perf-robustness/02-inventory-footer-metadata.md
@@ -1,0 +1,102 @@
+---
+plan: perf-robustness/02-inventory-footer-metadata
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: fix/inventory-footer-metadata
+pr: ""
+---
+
+# `ParquetStore` metadata from parquet footers + cache + off-thread API
+
+## Goal
+
+`ParquetStore.inventory()` (and `last_timestamp`, `missing_intervals`,
+`_is_year_complete`) call `pl.read_parquet(f, columns=["TS"])` — materialising
+the whole TS column of **every file in the store** — and run synchronously
+inside async API endpoints, blocking the event loop that also drives WS
+collection. Replace the column reads with parquet **footer metadata**
+(row count + TS min/max statistics), add a per-file cache, and move the API
+calls off-thread. Measured: `/api/inventory` took 100 s for 10 KB on a 50-file
+store (under CPU starvation); cost grows ~365 files/year/pair for trades.
+
+## Files to change
+
+- `dccd/storage/parquet.py` —
+  - new private helper `_file_stats(self, f: pathlib.Path) -> tuple[int, int | None, int | None]`
+    returning `(rows, min_ts, max_ts)`:
+    1. `stat()` the file; cache hit if `(st_mtime_ns, st_size)` unchanged —
+       cache is a plain dict `self._stats_cache: dict[str, tuple[meta..]]` on
+       the instance (the daemon holds one `ParquetStore`; CLI processes are
+       short-lived, no invalidation API needed beyond mtime).
+    2. on miss: `pyarrow.parquet.ParquetFile(f).metadata` → `num_rows`; TS
+       min/max from per-row-group `statistics` of the `TS` column (find the
+       column index by name via `schema_arrow`/`metadata.schema`); aggregate
+       across row groups.
+    3. **fallback**: if any row group lacks TS statistics (legacy writer),
+       fall back to today's `pl.read_parquet(f, columns=["TS"])` for that
+       file — correctness over speed.
+  - `_ts_range(files)` → sums/aggregates via `_file_stats` (no column reads).
+  - `last_timestamp(ds)` (line ~240) → per-file `_file_stats` max.
+  - `missing_intervals(ds, …)` (line ~275) → file min/max via `_file_stats`.
+  - `_is_year_complete(ds, year)` (line ~410) → needs only the row count:
+    `_file_stats(file)[0]`.
+  - `save()` need not touch the cache — mtime invalidation covers it.
+- `dccd/interfaces/api/app.py` —
+  - `GET /api/inventory`: `await asyncio.to_thread(store.inventory)`.
+  - `GET /api/storage/sync`: replace its second full
+    `_store(request).inventory()` scan with the same `to_thread` call (cheap
+    now thanks to the cache; no separate bytes-only path needed).
+
+## Steps
+
+1. Implement `_file_stats` + cache in `ParquetStore` (import
+   `pyarrow.parquet as pq` lazily inside the method, matching the file's
+   existing style).
+2. Convert the four call sites listed above; delete the now-unused direct
+   `pl.read_parquet(..., columns=["TS"])` occurrences in those paths.
+3. Wrap the two API endpoints in `asyncio.to_thread`.
+4. `pytest`, `ruff check dccd/`, `mypy dccd/` (strict on storage? respect
+   current config), `cd doc && make html` if docstrings changed.
+
+## Tests
+
+- `dccd/tests/v3/test_storage.py` / `test_storage_extended.py`:
+  - write OHLC + trades + orderbook datasets via the public `save()` API; assert
+    `inventory()` output (rows/min_ts/max_ts/files/bytes/expected/missing) is
+    **identical** to the values the previous implementation produced (the
+    existing assertions already encode them — they must pass unchanged).
+  - cache behaviour: call `inventory()` twice; monkeypatch
+    `pyarrow.parquet.ParquetFile` after the first call to raise — second call
+    must succeed from cache. Then `save()` more rows into one dataset (mtime
+    changes) and assert the new rows appear (restore the monkeypatch first).
+  - fallback: craft a parquet file without statistics
+    (`pq.write_table(..., write_statistics=False)`) and assert
+    `inventory()`/`last_timestamp` still return correct min/max/rows.
+  - `last_timestamp`, `missing_intervals`, `_is_year_complete` keep their
+    existing tests green.
+
+## Verification on real data
+
+- `data-e2e` discipline on an isolated store: real backfill (e.g. Binance
+  BTC/USDT 1h OHLC, 30 days + one trades hour), then compare `inventory()`
+  JSON before/after the change (run old code via `git stash` or a checkout) —
+  must be byte-identical. Time both: new implementation must be ≥ 10× faster
+  on a store with ≥ 50 files (create extra files by backfilling several pairs
+  if needed) and absolute time < 100 ms warm.
+- `curl -w %{time_total}` on `GET /api/inventory` of a running `dccd ui`
+  against that store: < 500 ms cold, < 50 ms warm.
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "`ParquetStore` metadata (inventory, last timestamp, gap
+  detection) no longer reads the full TS column of every file — it reads
+  parquet footer statistics with a per-file mtime cache, and the API serves it
+  off the event loop. `/api/inventory` on a populated store: seconds → tens of
+  ms. (#NN)"
+- ADR: footer statistics + mtime cache chosen over an explicit write-through
+  cache or a manifest DB — zero new state to keep consistent, legacy files
+  handled by per-file fallback.
+- Status/roadmap: tick leaf 02 in `00-plan.md`.

--- a/doc/dev/plans/perf-robustness/03-ws-subscription-honesty.md
+++ b/doc/dev/plans/perf-robustness/03-ws-subscription-honesty.md
@@ -1,0 +1,96 @@
+---
+plan: perf-robustness/03-ws-subscription-honesty
+kind: leaf
+status: planned
+complexity: medium
+depends: [01]
+parallel: false
+branch: fix/ws-subscription-honesty
+pr: ""
+---
+
+# Honest WS subscriptions: valid depths + loud subscription failures
+
+## Goal
+
+The production config had Kraken order-book jobs with `depth: 20` and
+`depth: 50` — Kraken WS v2 only accepts {10, 25, 100, 500, 1000} — and the
+adapters filter every non-data frame, so a rejected subscription leaves a
+stream "live" that never writes anything, forever and silently. Declare valid
+depths in the capability, snap requested depths to them, and surface
+subscription error frames as failures.
+
+## Files to change
+
+- `dccd/domain/capability.py` — add `depths: list[int] | None = None`
+  (discrete valid order-book depths; `None` = unconstrained; keep the existing
+  `max_depth` untouched). Update docstring attribute list.
+- `dccd/sources/kraken.py` — declare `depths=[10, 25, 100, 500, 1000]` on the
+  ws/live orderbook capability. In `_KrakenWS.stream_raw` consumers (the
+  book/ohlc/trade loops) detect Kraken v2 method-ACK frames:
+  `{"method": "subscribe", "success": false, "error": "..."}` → raise
+  `RuntimeError(f"kraken subscription failed: {error}")`.
+- `dccd/sources/bybit.py` — declare valid depths for the spot book channel
+  (`depths=[1, 50, 200]` — verify against current Bybit v5 spot docs before
+  hardcoding; use what the docs say, not this line). Detect
+  `{"op": "subscribe", "success": false, "ret_msg": ...}` → raise.
+- `dccd/sources/okx.py` — `books5` is fixed top-5: declare `depths=[5]`.
+  Detect `{"event": "error", "msg": ..., "code": ...}` → raise.
+- `dccd/sources/binance.py` — already clamps to {5, 10, 20}; declare
+  `depths=[5, 10, 20]` so the engine knows.
+- `dccd/sources/bitmex.py` — `orderBook10` fixed top-10: `depths=[10]`.
+  Detect `{"status": 4xx, "error": ...}` subscription errors → raise.
+- `dccd/application/operations.py` — in `stream()`'s order-book branch, after
+  fetching `cap = adapter.capability_for(...)`: if `cap.depths` and the
+  requested depth is not in it, **snap to the smallest valid depth ≥
+  requested** (else the largest valid) and emit a warning log event
+  (`_emit_log`-equivalent via `events.log(..., level="warning")`) naming both
+  values — existing configs keep working, loudly.
+
+## Steps
+
+1. Add the `Capability.depths` field + docstring.
+2. Declare `depths` on the five adapters' ws/live orderbook capabilities
+   (check each exchange's current public docs for the true list; adjust the
+   values above if the docs disagree — the **docs win**).
+3. Implement the snap + warning in `operations.stream`.
+4. Add subscription-error detection to each adapter's WS loop. A raised error
+   propagates to `_StreamWorker._run_forever`, which already logs and retries
+   with backoff — no scheduler change needed. Make sure the error message
+   names the exchange, channel and pair.
+5. `pytest`, `ruff check dccd/`, `mypy dccd/`.
+
+## Tests
+
+- `dccd/tests/v3/test_sources.py` — capability declarations: each adapter with
+  a live orderbook capability declares a non-empty `depths`.
+- `test_application.py` (or new file) — `stream()` with a fake adapter whose
+  cap has `depths=[10, 25]`: requesting depth 20 calls
+  `adapter.stream_orderbook` with 25 and logs a warning; requesting 25 passes
+  through silently; requesting 9999 snaps to 25.
+- Per-adapter: feed a scripted subscription-error frame into the WS loop
+  (kraken: `{"method":"subscribe","success":false,"error":"Subscription
+  depth not supported"}`) and assert it raises with the exchange and reason in
+  the message — not silently filtered.
+
+## Verification on real data
+
+- Against **live Kraken**: start a real order-book stream with `depth=20` on
+  an isolated store; assert the warning event fires, the effective
+  subscription is depth 25, and snapshots actually land in Parquet (this
+  exact case wrote nothing on arthurserver).
+- Negative path: subscribe to a nonsense Kraken symbol; assert the stream run
+  is recorded `failed` with the Kraken error text within one reconnect cycle
+  (visible in `/api/runs`), not "live with no data".
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "Order-book stream jobs with a depth the exchange
+  doesn't support (e.g. Kraken `depth: 20`) silently produced no data: valid
+  depths are now declared per capability and requests snap to the nearest
+  valid value with a warning; WS subscription rejections raise (and surface in
+  runs) instead of being filtered out. (#NN)"
+- ADR: snap-with-warning over hard-fail — existing deployed configs (this one
+  included) must keep collecting after upgrade; honesty is preserved by the
+  warning + the declared capability.
+- Status/roadmap: tick leaf 03 in `00-plan.md`.

--- a/doc/dev/plans/perf-robustness/04-scheduler-monitor-hygiene.md
+++ b/doc/dev/plans/perf-robustness/04-scheduler-monitor-hygiene.md
@@ -1,0 +1,84 @@
+---
+plan: perf-robustness/04-scheduler-monitor-hygiene
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: fix/scheduler-monitor-hygiene
+pr: ""
+---
+
+# Scheduler backoff + startup jitter; HealthMonitor alert cooldown
+
+## Goal
+
+A permanently failing interval job (production case: a `FOO/USDT` job) re-runs
+at full cadence forever, and `HealthMonitor` fires a webhook on **every**
+failure past the threshold — the journal showed an alert every ~20 s for hours.
+At daemon start all interval jobs also fire simultaneously (thundering herd on
+exchanges and disk). Add failure backoff, startup jitter, and an alert
+cooldown.
+
+## Files to change
+
+- `dccd/application/scheduler.py` —
+  - `_run_once(spec)` returns `bool` (True = backfill returned without an
+    `error` key / no exception; the `backfill()` result dict already carries
+    `error` on failure — use it, don't re-parse logs).
+  - `_interval_loop(spec)`:
+    - **startup jitter**: before the first run, `await asyncio.sleep(
+      random.uniform(0, min(every, 60)))` so 50 jobs don't fire in the same
+      second at boot;
+    - **failure backoff**: on consecutive failures sleep
+      `min(every * 2**k, max(every, 6 * 3600))` instead of `every`
+      (k = consecutive failures, capped exponent to avoid overflow); reset on
+      success. Log the chosen delay at WARNING on each failed iteration.
+- `dccd/application/monitor.py` —
+  - alert when the consecutive count **crosses** `max_consecutive_errors`
+    (`count == self._max_errors`), then re-alert at most once per cooldown
+    window (`_ALERT_COOLDOWN_S = 3600`, monotonic clock per key) while the
+    failure persists; reset both count and cooldown timestamp on success.
+  - keep one WARNING log per *suppressed* webhook failure? No — log the
+    webhook-send failure itself only once per cooldown window too (the
+    journal had `Webhook alert failed: Connection refused` every 20 s).
+
+## Steps
+
+1. Scheduler changes (import `random` at module top).
+2. Monitor cooldown.
+3. `pytest`, `ruff check dccd/`, `mypy dccd/`.
+
+## Tests
+
+- `dccd/tests/v3/test_application.py` (or a new `test_scheduler_hygiene.py`),
+  using a fake registry/adapter that fails deterministically and
+  `asyncio` time control (wrap sleeps via a monkeypatched `asyncio.sleep`
+  recording requested delays — the existing test style for the scheduler):
+  - failing interval job: recorded sleep delays grow `every, 2*every, 4*every…`
+    capped; a success resets to `every`.
+  - first sleep before any run is within `[0, min(every, 60)]` (jitter).
+  - monitor: with `max_consecutive_errors=3`, 10 consecutive failures fire
+    exactly 1 alert (cooldown not elapsed); advance the monotonic clock past
+    the cooldown → exactly 1 more; a success in between resets the count so
+    the next 3 failures alert again.
+
+## Verification on real data
+
+- Local `dccd start` with one deliberately invalid backfill job
+  (`FOO/USDT` on binance, `every: 30`) and a valid one: journal/log output
+  over ~5 minutes shows growing gaps between FOO attempts, exactly one alert
+  line, and the valid job unaffected. (No isolated-store data assertion needed
+  beyond "valid job still writes" — check its parquet row count grows.)
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "Permanently failing scheduled jobs no longer hammer the
+  exchange at full cadence (exponential backoff, reset on success), interval
+  jobs start with jitter instead of all at once, and HealthMonitor alerts once
+  at the failure threshold then at most hourly — instead of on every failure.
+  (#NN)"
+- ADR: none — mechanical hygiene; thresholds (60 s jitter cap, 6 h backoff cap,
+  1 h alert cooldown) noted as constants, not config, until someone needs them
+  configurable.
+- Status/roadmap: tick leaf 04 in `00-plan.md`.

--- a/doc/dev/plans/perf-robustness/05-ui-transport-efficiency.md
+++ b/doc/dev/plans/perf-robustness/05-ui-transport-efficiency.md
@@ -1,0 +1,90 @@
+---
+plan: perf-robustness/05-ui-transport-efficiency
+kind: leaf
+status: planned
+complexity: medium
+depends: [02]
+parallel: false
+branch: feat/ui-transport-efficiency
+pr: ""
+---
+
+# HTTP/UI transport efficiency: gzip, parallel fetches, saner polling, off-thread SQLite
+
+## Goal
+
+Remote (Tailscale/TLS) UI pages pay uncompressed JSON, serial fetches and
+aggressive polling. Add gzip, parallelise the dashboard's fetches, slow the
+polls that exist only as fallbacks, move RunsStore SQLite calls off the event
+loop, and report an unexpectedly-ended stream as `failed` rather than
+`cancelled`.
+
+## Files to change
+
+- `dccd/interfaces/api/app.py` —
+  - `from fastapi.middleware.gzip import GZipMiddleware` +
+    `app.add_middleware(GZipMiddleware, minimum_size=1024)` (SSE is exempt
+    automatically: streaming responses with unknown length are passed through
+    by Starlette's GZip only when buffering — verify with a test asserting
+    `/api/events` still streams, see Tests).
+  - wrap the synchronous RunsStore calls in `asyncio.to_thread`:
+    `GET /api/runs` (`list_runs`), `GET /api/backfill/{run_id}` (`get_run`),
+    and the `list_runs` call inside `GET /api/storage/sync`.
+- `dccd/interfaces/ui/templates/dashboard.html` — `load()` fetches runs,
+  streams and inventory **in parallel** (`Promise.all`, same pattern as
+  live.html); poll interval 8 s → 15 s.
+- `dccd/interfaces/ui/templates/storage.html` — `setInterval(loadSync, 10000)`
+  → 30 s (the page is a status view; "Sync now" already polls itself).
+- `dccd/interfaces/ui/templates/live.html` — keep the 8 s `loadAll` for
+  jobs/streams state, but fetch `/api/inventory` only on initial load and on
+  SSE `status` events (it seeds liveness; live samples come over SSE) — split
+  the `Promise.all` accordingly and keep `INV` cached between polls.
+- `dccd/application/operations.py` — `stream()`: when the async generator ends
+  **without** `stop_event` set (WS generator exhausted unexpectedly), finish
+  the run as `failed` with error `"stream ended unexpectedly"`; keep
+  `cancelled` only for an actual stop request. (The supervisor restarts it
+  either way; this only fixes the recorded state shown in Logs/Runs.)
+
+## Steps
+
+1. API changes (gzip + to_thread).
+2. Template changes (three files).
+3. `stream()` end-state fix.
+4. `pytest`, `ruff check dccd/`, `mypy dccd/`; run `doc/dev/ui_smoke.py`
+   against a local `dccd ui` (all steps must stay green).
+
+## Tests
+
+- `dccd/tests/v3/test_api.py`:
+  - a `GET /api/inventory` response with `Accept-Encoding: gzip` on a
+    populated-enough store (> 1 KB JSON) carries `content-encoding: gzip`;
+  - `/api/events` SSE still yields the heartbeat within the test timeout with
+    the middleware installed (regression: gzip must not buffer the stream);
+  - existing endpoint tests stay green (to_thread is behaviour-neutral).
+- `test_application.py`: a fake stream adapter whose generator returns after N
+  records (no stop requested) → run recorded `failed` with
+  "stream ended unexpectedly"; with `stop_event` set → still `cancelled`.
+
+## Verification on real data
+
+- Run `dccd ui` against a real populated store; from another machine (or
+  `curl --compressed` locally): `/api/inventory` transfer size shrinks ≥ 5×
+  vs uncompressed (`%{size_download}` with/without `Accept-Encoding`).
+- Load Dashboard, Live, Storage in a headless browser (`ui-audit` discipline,
+  or `doc/dev/ui_smoke.py`): no JS errors, liveness dots still seed and tick,
+  network tab shows inventory fetched once on Live load and not on every 8 s
+  poll.
+
+## Closeout
+
+- CHANGELOG (`Changed`): "Remote-friendly UI transport: gzip on API responses,
+  dashboard fetches parallelised, lighter poll cadences (inventory no longer
+  re-fetched every 8 s by Live), and runs-store reads moved off the event
+  loop." + (`Fixed`): "A live stream that ended unexpectedly was recorded
+  `cancelled`; it is now `failed` with an explicit error. (#NN)"
+- ADR: none — mechanical; note in the PR body that SSE-pushed inventory
+  invalidation was considered and deferred (footer-stats cache made polling
+  cheap enough).
+- Status/roadmap: tick leaf 05 in `00-plan.md`; this is the last leaf — apply
+  the epic closeout: remove the Epic D section from `doc/dev/07-roadmap.md`,
+  update `doc/dev/06-status.md`, archive the tree, suggest `/release`.


### PR DESCRIPTION
## Plan tree for Epic D — Performance & robustness

Expands the new roadmap **Epic D** (added here too) from the 2026-06-10 production audit of the live collector (arthurserver, 3.3.1, 50 jobs): daemon pinned at 97.7 % CPU — a py-spy profile attributed ~96 % of samples to `kraken.stream_orderbook` building the full book as pydantic objects on every WS delta — starving the event loop and making the remote UI unusable (`/api/inventory`: 100 s for 10 KB on a 50-file / 32 MB store).

### Leaf checklist
- [ ] 01 orderbook-snapshot-throttle — `fix/orderbook-snapshot-throttle` — medium — *kills the CPU burn*
- [ ] 02 inventory-footer-metadata — `fix/inventory-footer-metadata` — medium — parquet footer stats + cache + off-thread
- [ ] 03 ws-subscription-honesty — `fix/ws-subscription-honesty` — medium (depends on 01) — valid depths + loud subscription failures
- [ ] 04 scheduler-monitor-hygiene — `fix/scheduler-monitor-hygiene` — medium — backoff, jitter, alert cooldown
- [ ] 05 ui-transport-efficiency — `feat/ui-transport-efficiency` — medium (depends on 02) — gzip, parallel fetches, saner polling

01, 02 and 04 are mutually independent (`parallel: true`).

### Done criteria (from `00-plan.md`)
- Collector with ≥ 3 real order-book streams idles < 10 % CPU.
- `GET /api/inventory` < 500 ms on a populated store, JSON identical to today.
- Invalid order-book depth snaps loudly or fails loudly — never a silent empty "live" stream.
- Failing interval jobs back off; one alert at threshold, then ≤ 1/hour.