### PR TITLE
chore: add runtime resource gates to data-e2e and release-gate skills

### DIFF
--- a/.claude/skills/data-e2e/SKILL.md
+++ b/.claude/skills/data-e2e/SKILL.md
@@ -71,20 +71,39 @@ the cursor advances and stops (`next_cursor is None`) at the window edge.
 One snapshot has many levels sharing one TS. After `save`, stored rows must equal
 the number of levels (TS-only dedup would collapse them to 1).
 
-## 5. Per-exchange sweep
+## 5. Streams — capture cadence AND resource sanity
+
+The class of bug: per-frame work whose output the consumer throws away. The
+v3.3 production case: order-book snapshots built as pydantic objects on every
+WS delta while `operations.stream` kept one per `snapshot_interval` → 97.7 %
+CPU, starved event loop, remote UI unusable — and every unit test green.
+After touching a WS adapter, `operations.stream` or the scheduler:
+
+```bash
+# drive 2-3 REAL order-book/trade streams on the isolated store for ~2 min:
+ps -o pcpu=,rss= -p <daemon-pid>      # steady-state CPU must be < 10 %
+```
+
+Also challenge the capture cadence on disk: with `snapshot_interval=10`, about
+6 snapshots (±2) per minute must land in Parquet, each truncated to the
+subscribed depth, levels uncrossed (max bid < min ask), ts monotonic. A stream
+that is "live" but writes nothing is a failure, not a wait state (rejected WS
+subscriptions must surface as errors).
+
+## 6. Per-exchange sweep
 
 Smoke each of the 7 adapters for the type it supports (OHLC for all; trades for
 binance/kraken/okx/bitfinex/bitmex; bybit spot has no trade history). Watch for
 **silent 0-row** results (e.g. a wrong symbol mapping like Bitfinex USDT→UST that
 returns HTTP 200 + `[]`).
 
-## 6. Migration (only with a backup)
+## 7. Migration (only with a backup)
 
 Before `dccd migrate --no-dry-run` on real data: `cp -a <data> <data>.backup-…`,
 run `--dry-run`, apply, then verify **row-for-row no loss** vs the backup and that
 `needs_migration` is now False (idempotent).
 
-## 7. Report
+## 8. Report
 
 For each dataset: requested vs stored (count, time range), pagination pages,
 dedup integrity, OHLC sanity, and any silent-zero or coverage gap. Clean up the

--- a/.claude/skills/release-gate/SKILL.md
+++ b/.claude/skills/release-gate/SKILL.md
@@ -45,7 +45,24 @@ the smoke against an isolated instance:
 python doc/dev/ui_smoke.py http://127.0.0.1:<port>
 ```
 
-## 5. Release hygiene checks
+## 5. Runtime resource gate (opt-in — needs network)
+
+A green suite can still ship a daemon that burns a core (v3.3: order-book
+snapshots built per WS delta → 97.7 % CPU on the production collector, remote
+UI unusable). On an isolated config with 2-3 real stream jobs:
+
+```bash
+# after ~2 min of `dccd start` warm-up:
+ps -o pcpu= -p <pid>     # steady-state must be < 10 %
+curl -s -o /dev/null -w '%{time_total}\n' http://127.0.0.1:<port>/api/inventory
+                         # must be < 0.5 s on a populated store
+```
+
+After upgrading a deployed server, also run `pip check` in its venv (a mixed
+`polars`/`polars-lts-cpu` install breaks imports — seen at the 3.3 deploy) and
+the same timed `curl` as a smoke test.
+
+## 6. Release hygiene checks
 
 - `git status` clean; no build artefacts / `pytest-of-*` / `doc/_build` tracked
   (they're gitignored — if any are staged, untrack them).
@@ -54,9 +71,9 @@ python doc/dev/ui_smoke.py http://127.0.0.1:<port>
   feature branch. `feat/refonte-v3` is the v3 integration branch.
 - If tagging: version in `pyproject.toml` matches the intended tag.
 
-## 6. Verdict
+## 7. Verdict
 
 Report a table: layer → PASS/FAIL/SKIPPED(reason). **GO** only if tests, ruff,
-mypy and docs are green and nothing in §5 is violated. Anything red ⇒ **NO-GO**,
+mypy and docs are green and nothing in §6 is violated. Anything red ⇒ **NO-GO**,
 name the blocker and the fix. Releasing (merge to master, tag, push) is the
 user's call — never tag or merge to a protected branch without explicit approval.


### PR DESCRIPTION
From the 2026-06-10 production audit (see plan tree `perf-robustness`): a fully green unit suite shipped a daemon at 97.7 % CPU (order-book snapshots built per WS delta) with the remote UI unusable. The verification skills now gate on runtime behaviour, not just correctness:

- **data-e2e** — new §5 *Streams — capture cadence AND resource sanity*: drive real streams ~2 min on an isolated store, assert steady-state CPU < 10 %, capture cadence on disk matches `snapshot_interval`, levels truncated/uncrossed, and "live but writes nothing" counts as failure.
- **release-gate** — new §5 *Runtime resource gate* (opt-in): CPU < 10 % after warm-up, `/api/inventory` < 0.5 s on a populated store, plus `pip check` + timed curl after a server upgrade (the 3.3 deploy crash-looped on a mixed `polars`/`polars-lts-cpu` venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)