### PR TITLE
fix: read parquet footer stats instead of the TS column for store metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   back to the old path), and `/api/inventory` + `/api/storage/sync` now run it
   off the event loop. Verified value-identical on real data; 13× faster warm on
   a small store, and the gap grows with file size (production showed 100 s for
-  a 10 KB inventory response under load). (#XX)
+  a 10 KB inventory response under load). (#119)
 - Permanently failing scheduled jobs no longer hammer the exchange at full
   cadence: the interval loop applies exponential backoff (reset on success) and
   starts with a random jitter instead of firing every job at once on daemon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ParquetStore` metadata (inventory, last timestamp, gap detection) no longer
+  reads the full TS column of every file in the store — it reads parquet footer
+  statistics with a per-file mtime cache (legacy files without statistics fall
+  back to the old path), and `/api/inventory` + `/api/storage/sync` now run it
+  off the event loop. Verified value-identical on real data; 13× faster warm on
+  a small store, and the gap grows with file size (production showed 100 s for
+  a 10 KB inventory response under load). (#XX)
 - Permanently failing scheduled jobs no longer hammer the exchange at full
   cadence: the interval loop applies exponential backoff (reset on success) and
   starts with a random jitter instead of firing every job at once on daemon

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -464,7 +464,9 @@ def create_app(
     @app.get("/api/inventory")
     async def get_inventory(request: Request) -> dict[str, Any]:
         """Return all stored datasets."""
-        return {"datasets": _store(request).inventory()}
+        store = _store(request)
+        datasets = await asyncio.to_thread(store.inventory)
+        return {"datasets": datasets}
 
     # -----------------------------------------------------------------------
     # Remote sync
@@ -496,7 +498,9 @@ def create_app(
             }
             if configured and r["ended_at"]:
                 next_eta = r["ended_at"] + interval * NS
-        total_bytes = sum(d.get("bytes", 0) for d in _store(request).inventory())
+        store = _store(request)
+        inventory = await asyncio.to_thread(store.inventory)
+        total_bytes = sum(d.get("bytes", 0) for d in inventory)
         return {
             "configured": configured,
             "remotes": remotes,

--- a/dccd/storage/parquet.py
+++ b/dccd/storage/parquet.py
@@ -118,6 +118,11 @@ class ParquetStore:
         # (datasets/periods) fully parallel.
         self._file_locks: dict[str, threading.Lock] = {}
         self._file_locks_guard = threading.Lock()
+        # Per-file metadata cache: path str → (mtime_ns, size, rows, min_ts, max_ts).
+        # Keyed by (mtime_ns, size) so any write (atomic rename → new inode + mtime)
+        # automatically invalidates. The daemon holds one ParquetStore instance
+        # for its lifetime; CLI processes are short-lived so stale cache is fine.
+        self._stats_cache: dict[str, tuple[int, int, int, int | None, int | None]] = {}
 
     @property
     def root(self) -> pathlib.Path:
@@ -132,6 +137,107 @@ class ParquetStore:
                 lock = threading.Lock()
                 self._file_locks[key] = lock
             return lock
+
+    def _file_stats(
+        self, f: pathlib.Path
+    ) -> tuple[int, int | None, int | None]:
+        """Return ``(rows, min_ts, max_ts)`` for a parquet file.
+
+        Uses pyarrow footer metadata and row-group TS statistics to avoid
+        materialising the TS column.  A per-file mtime/size cache means warm
+        calls cost only one ``stat()`` syscall.  Falls back to
+        ``pl.read_parquet`` when a row group has no TS statistics (legacy
+        writer that didn't record min/max).
+
+        Parameters
+        ----------
+        f:
+            Path to an existing ``.parquet`` file.
+
+        Returns
+        -------
+        tuple[int, int | None, int | None]
+            ``(rows, min_ts, max_ts)`` where *min_ts* / *max_ts* are the
+            nanosecond TS bounds across all row groups, or ``None`` when the
+            file is empty.
+        """
+        try:
+            st = f.stat()
+        except OSError:
+            return 0, None, None
+
+        key = str(f)
+        cached = self._stats_cache.get(key)
+        if cached is not None:
+            c_mtime, c_size, c_rows, c_min, c_max = cached
+            if c_mtime == st.st_mtime_ns and c_size == st.st_size:
+                return c_rows, c_min, c_max
+
+        # Cache miss — read from parquet footer (no column materialisation).
+        try:
+            import pyarrow.parquet as pq  # lazy import, matching existing style
+
+            meta = pq.ParquetFile(f).metadata
+            total_rows: int = meta.num_rows
+            if total_rows == 0:
+                self._stats_cache[key] = (st.st_mtime_ns, st.st_size, 0, None, None)
+                return 0, None, None
+
+            # Find the TS column index (name may differ by file; scan once).
+            ts_col_idx: int | None = None
+            for col_idx in range(meta.row_group(0).num_columns):
+                if meta.row_group(0).column(col_idx).path_in_schema == "TS":
+                    ts_col_idx = col_idx
+                    break
+
+            if ts_col_idx is None:
+                # TS column not found — read full file as fallback.
+                raise ValueError("TS column not found in schema")
+
+            min_ts: int | None = None
+            max_ts: int | None = None
+            needs_fallback = False
+            for rg_idx in range(meta.num_row_groups):
+                rg = meta.row_group(rg_idx)
+                col_meta = rg.column(ts_col_idx)
+                stats = col_meta.statistics
+                if stats is None or not stats.has_min_max:
+                    needs_fallback = True
+                    break
+                rg_min = int(stats.min)
+                rg_max = int(stats.max)
+                if min_ts is None or rg_min < min_ts:
+                    min_ts = rg_min
+                if max_ts is None or rg_max > max_ts:
+                    max_ts = rg_max
+
+            if needs_fallback:
+                # Legacy writer: fall back to reading the TS column.
+                df = pl.read_parquet(f, columns=["TS"])
+                n = len(df)
+                if n == 0:
+                    self._stats_cache[key] = (st.st_mtime_ns, st.st_size, 0, None, None)
+                    return 0, None, None
+                min_ts = int(df["TS"].min())  # type: ignore[arg-type]
+                max_ts = int(df["TS"].max())  # type: ignore[arg-type]
+                total_rows = n
+
+        except Exception:
+            # Any error (corrupt file, missing dep) → try reading the column.
+            try:
+                df = pl.read_parquet(f, columns=["TS"])
+                n = len(df)
+                if n == 0:
+                    self._stats_cache[key] = (st.st_mtime_ns, st.st_size, 0, None, None)
+                    return 0, None, None
+                min_ts = int(df["TS"].min())  # type: ignore[arg-type]
+                max_ts = int(df["TS"].max())  # type: ignore[arg-type]
+                total_rows = n
+            except Exception:
+                return 0, None, None
+
+        self._stats_cache[key] = (st.st_mtime_ns, st.st_size, total_rows, min_ts, max_ts)
+        return total_rows, min_ts, max_ts
 
     def directory(self, ds: DatasetId) -> pathlib.Path:
         """Return the directory for *ds*, creating it if needed."""
@@ -236,12 +342,9 @@ class ParquetStore:
         directory = self.directory(ds)
         files = sorted(directory.glob("*.parquet"), reverse=True)
         for f in files:
-            try:
-                df = pl.read_parquet(f, columns=["TS"])
-                if len(df) > 0:
-                    return int(df["TS"].max())  # type: ignore[arg-type]
-            except Exception:
-                pass
+            _, _, max_ts = self._file_stats(f)
+            if max_ts is not None:
+                return max_ts
         return None
 
     def missing_intervals(
@@ -271,19 +374,14 @@ class ParquetStore:
             if file_path.exists():
                 if year < current_year and self._is_year_complete(ds, year):
                     continue
-                try:
-                    df = pl.read_parquet(file_path, columns=["TS"])
-                    if len(df) > 0:
-                        file_min = int(df["TS"].min())  # type: ignore[arg-type]
-                        file_max = int(df["TS"].max())  # type: ignore[arg-type]
-                        if ivl_start < file_min:
-                            intervals.append((ivl_start, file_min))
-                        trailing = file_max + span_ns
-                        if trailing < ivl_end:
-                            intervals.append((trailing, ivl_end))
-                        continue
-                except Exception:
-                    pass
+                rows, file_min, file_max = self._file_stats(file_path)
+                if rows > 0 and file_min is not None and file_max is not None:
+                    if ivl_start < file_min:
+                        intervals.append((ivl_start, file_min))
+                    trailing = file_max + span_ns
+                    if trailing < ivl_end:
+                        intervals.append((trailing, ivl_end))
+                    continue
 
             intervals.append((ivl_start, ivl_end))
 
@@ -384,20 +482,14 @@ class ParquetStore:
         max_ts: int | None = None
         total_rows = 0
         for f in files:
-            try:
-                df = pl.read_parquet(f, columns=["TS"])
-                n = len(df)
-                if n == 0:
-                    continue
-                total_rows += n
-                fmin = int(df["TS"].min())  # type: ignore[arg-type]
-                fmax = int(df["TS"].max())  # type: ignore[arg-type]
-                if min_ts is None or fmin < min_ts:
-                    min_ts = fmin
-                if max_ts is None or fmax > max_ts:
-                    max_ts = fmax
-            except Exception:
-                pass
+            n, fmin, fmax = self._file_stats(f)
+            if n == 0:
+                continue
+            total_rows += n
+            if fmin is not None and (min_ts is None or fmin < min_ts):
+                min_ts = fmin
+            if fmax is not None and (max_ts is None or fmax > max_ts):
+                max_ts = fmax
         return min_ts, max_ts, total_rows
 
     def _is_year_complete(self, ds: DatasetId, year: int) -> bool:
@@ -407,11 +499,11 @@ class ParquetStore:
         if not file_path.exists():
             return False
         try:
-            df = pl.read_parquet(file_path, columns=["TS"])
+            rows, _, _ = self._file_stats(file_path)
             year_start = datetime(year, 1, 1, tzinfo=timezone.utc)
             year_end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
             expected = int((year_end - year_start).total_seconds()) // ds.span
-            return len(df) >= expected
+            return rows >= expected
         except Exception:
             return False
 

--- a/dccd/tests/v3/test_storage_extended.py
+++ b/dccd/tests/v3/test_storage_extended.py
@@ -2,10 +2,12 @@
 
 import pathlib
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from dccd.domain.dataset import DatasetId
-from dccd.domain.records import OHLCBar
+from dccd.domain.records import OHLCBar, Trade
 from dccd.domain.symbol import Symbol
 from dccd.domain.timeutils import NS
 from dccd.domain.types import DataType
@@ -149,3 +151,257 @@ class TestEventBusQueue:
         assert isinstance(event, ProgressEvent)
         assert event.done == 3
         assert event.total == 10
+
+
+# ---------------------------------------------------------------------------
+# _file_stats: cache behaviour
+# ---------------------------------------------------------------------------
+
+class TestFileStatsCache:
+    """Cache behaviour: mtime/size keyed, invalidates on write."""
+
+    @pytest.fixture
+    def store(self, tmp_path: pathlib.Path) -> ParquetStore:
+        return ParquetStore(tmp_path)
+
+    @pytest.fixture
+    def ohlc_ds(self) -> DatasetId:
+        return DatasetId(
+            exchange="binance",
+            symbol=Symbol(base="BTC", quote="USDT"),
+            data_type=DataType.OHLC,
+            span=3600,
+        )
+
+    def test_cache_hit_avoids_second_parquet_open(
+        self, store: ParquetStore, ohlc_ds: DatasetId, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Second inventory() call succeeds from cache even if pq.ParquetFile is broken."""
+        bars = [
+            OHLCBar(ts=i * 3600 * NS, open=1.0, high=1.0, low=1.0, close=1.0, volume=1.0)
+            for i in range(5)
+        ]
+        store.save(ohlc_ds, bars)
+
+        # First call — populates cache.
+        inv1 = store.inventory()
+        assert len(inv1) == 1
+        entry1 = inv1[0]
+
+        # Break pq.ParquetFile so any real file read would raise.
+        def _explode(*a: object, **kw: object) -> None:
+            raise RuntimeError("should not read file on cache hit")
+
+        monkeypatch.setattr(pq, "ParquetFile", _explode)
+
+        # Second call — must use cache, not call pq.ParquetFile.
+        inv2 = store.inventory()
+        assert len(inv2) == 1
+        entry2 = inv2[0]
+        assert entry2["rows"] == entry1["rows"]
+        assert entry2["min_ts"] == entry1["min_ts"]
+        assert entry2["max_ts"] == entry1["max_ts"]
+
+    def test_cache_invalidates_after_save(
+        self, store: ParquetStore, ohlc_ds: DatasetId, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After save() (mtime changes) the cache is invalidated and new rows appear."""
+        bars_first = [
+            OHLCBar(ts=i * 3600 * NS, open=1.0, high=1.0, low=1.0, close=1.0, volume=1.0)
+            for i in range(5)
+        ]
+        store.save(ohlc_ds, bars_first)
+
+        # Populate cache with 5 rows.
+        inv1 = store.inventory()
+        assert inv1[0]["rows"] == 5
+
+        # Break ParquetFile; verify cache is used.
+        def _explode(*a: object, **kw: object) -> None:
+            raise RuntimeError("should not read on cache hit")
+
+        monkeypatch.setattr(pq, "ParquetFile", _explode)
+        inv_cached = store.inventory()
+        assert inv_cached[0]["rows"] == 5
+
+        # Restore and add more bars (mtime will differ after atomic rename).
+        monkeypatch.undo()
+        bars_second = [
+            OHLCBar(ts=i * 3600 * NS, open=1.0, high=1.0, low=1.0, close=1.0, volume=1.0)
+            for i in range(5, 10)
+        ]
+        store.save(ohlc_ds, bars_second)
+
+        inv2 = store.inventory()
+        assert inv2[0]["rows"] == 10
+
+
+# ---------------------------------------------------------------------------
+# _file_stats: fallback for write_statistics=False
+# ---------------------------------------------------------------------------
+
+class TestFileStatsFallback:
+    """Parquet files written without statistics still produce correct output."""
+
+    @pytest.fixture
+    def store(self, tmp_path: pathlib.Path) -> ParquetStore:
+        return ParquetStore(tmp_path)
+
+    @pytest.fixture
+    def ohlc_ds(self) -> DatasetId:
+        return DatasetId(
+            exchange="testex",
+            symbol=Symbol(base="ETH", quote="USDT"),
+            data_type=DataType.OHLC,
+            span=3600,
+        )
+
+    def test_inventory_no_statistics(
+        self, store: ParquetStore, ohlc_ds: DatasetId, tmp_path: pathlib.Path
+    ) -> None:
+        """inventory() returns correct rows/min_ts/max_ts for no-stats files."""
+        # Write a file without column statistics bypassing the normal save() path.
+        year_dir = store.directory(ohlc_ds)
+        file_path = year_dir / "1970.parquet"
+        ts_values = [i * 3600 * 10**9 for i in range(3)]
+        table = pa.table(
+            {
+                "TS": pa.array(ts_values, type=pa.int64()),
+                "open": pa.array([1.0, 2.0, 3.0], type=pa.float64()),
+                "high": pa.array([1.0, 2.0, 3.0], type=pa.float64()),
+                "low": pa.array([1.0, 2.0, 3.0], type=pa.float64()),
+                "close": pa.array([1.0, 2.0, 3.0], type=pa.float64()),
+                "volume": pa.array([1.0, 2.0, 3.0], type=pa.float64()),
+                "quote_volume": pa.array([1.0, 2.0, 3.0], type=pa.float64()),
+                "trades": pa.array([1, 2, 3], type=pa.int64()),
+            }
+        )
+        pq.write_table(table, file_path, write_statistics=False)
+
+        inv = store.inventory()
+        assert len(inv) == 1
+        entry = inv[0]
+        assert entry["rows"] == 3
+        assert entry["min_ts"] == ts_values[0]
+        assert entry["max_ts"] == ts_values[-1]
+
+    def test_last_timestamp_no_statistics(
+        self, store: ParquetStore, ohlc_ds: DatasetId
+    ) -> None:
+        """last_timestamp() still returns correct max_ts for no-stats files."""
+        year_dir = store.directory(ohlc_ds)
+        file_path = year_dir / "1970.parquet"
+        ts_values = [i * 3600 * 10**9 for i in range(5)]
+        table = pa.table(
+            {
+                "TS": pa.array(ts_values, type=pa.int64()),
+                "open": pa.array([1.0] * 5, type=pa.float64()),
+                "high": pa.array([1.0] * 5, type=pa.float64()),
+                "low": pa.array([1.0] * 5, type=pa.float64()),
+                "close": pa.array([1.0] * 5, type=pa.float64()),
+                "volume": pa.array([1.0] * 5, type=pa.float64()),
+                "quote_volume": pa.array([1.0] * 5, type=pa.float64()),
+                "trades": pa.array([1] * 5, type=pa.int64()),
+            }
+        )
+        pq.write_table(table, file_path, write_statistics=False)
+
+        last_ts = store.last_timestamp(ohlc_ds)
+        assert last_ts == ts_values[-1]
+
+
+# ---------------------------------------------------------------------------
+# Value-identity: inventory/last_timestamp/missing_intervals unchanged
+# ---------------------------------------------------------------------------
+
+class TestFileStatsValueIdentity:
+    """Verify the new _file_stats path produces the same values as column reads."""
+
+    @pytest.fixture
+    def store(self, tmp_path: pathlib.Path) -> ParquetStore:
+        return ParquetStore(tmp_path)
+
+    @pytest.fixture
+    def ohlc_ds(self) -> DatasetId:
+        return DatasetId(
+            exchange="binance",
+            symbol=Symbol(base="BTC", quote="USDT"),
+            data_type=DataType.OHLC,
+            span=3600,
+        )
+
+    @pytest.fixture
+    def trades_ds(self) -> DatasetId:
+        return DatasetId(
+            exchange="binance",
+            symbol=Symbol(base="BTC", quote="USDT"),
+            data_type=DataType.TRADES,
+            span=None,
+        )
+
+    def test_inventory_identity_ohlc(
+        self, store: ParquetStore, ohlc_ds: DatasetId
+    ) -> None:
+        """inventory() rows/min_ts/max_ts/expected_rows/missing_rows match stored data."""
+        # 10 hourly bars with index 5 missing → 9 rows, expected=10, missing=1
+        bars = [
+            OHLCBar(ts=i * 3600 * NS, open=1.0, high=2.0, low=0.5, close=1.5, volume=10.0)
+            for i in range(10) if i != 5
+        ]
+        store.save(ohlc_ds, bars)
+        entry = next(d for d in store.inventory() if d["data_type"] == "ohlc")
+
+        assert entry["rows"] == 9
+        assert entry["min_ts"] == 0
+        assert entry["max_ts"] == 9 * 3600 * NS
+        assert entry["expected_rows"] == 10
+        assert entry["missing_rows"] == 1
+        assert entry["bytes"] > 0
+
+    def test_inventory_identity_trades(
+        self, store: ParquetStore, trades_ds: DatasetId
+    ) -> None:
+        """Trades inventory has no gap fields, correct rows/min_ts/max_ts."""
+        trades = [
+            Trade(ts=i * 1000 * NS, price=50000.0, amount=0.1, side="buy")
+            for i in range(5)
+        ]
+        store.save(trades_ds, trades)
+        entry = next(d for d in store.inventory() if d["data_type"] == "trades")
+
+        assert entry["rows"] == 5
+        assert entry["min_ts"] == 0
+        assert entry["max_ts"] == 4 * 1000 * NS
+        assert entry["missing_rows"] is None
+        assert entry["expected_rows"] is None
+        assert entry["bytes"] > 0
+
+    def test_last_timestamp_identity(
+        self, store: ParquetStore, ohlc_ds: DatasetId
+    ) -> None:
+        """last_timestamp returns the last bar TS."""
+        bars = [
+            OHLCBar(ts=i * 3600 * NS, open=1.0, high=1.0, low=1.0, close=1.0, volume=1.0)
+            for i in range(10)
+        ]
+        store.save(ohlc_ds, bars)
+        assert store.last_timestamp(ohlc_ds) == 9 * 3600 * NS
+
+    def test_missing_intervals_identity(
+        self, store: ParquetStore, ohlc_ds: DatasetId
+    ) -> None:
+        """missing_intervals detects leading and trailing gaps correctly."""
+        bars = [
+            OHLCBar(ts=i * 3600 * NS, open=1.0, high=1.0, low=1.0, close=1.0, volume=1.0)
+            for i in range(5, 10)
+        ]
+        store.save(ohlc_ds, bars)
+
+        start_ns = 0
+        end_ns = 11 * 3600 * NS
+        gaps = store.missing_intervals(ohlc_ds, start_ns, end_ns)
+
+        leading = [g for g in gaps if g[0] == start_ns]
+        assert leading, f"Expected leading gap starting at 0, got: {gaps}"
+        trailing = [g for g in gaps if g[1] == end_ns]
+        assert trailing, f"Expected trailing gap ending at {end_ns}, got: {gaps}"

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-10 — Store metadata = parquet footer statistics + per-file mtime cache (PR #119) [accepted]
+- **Choice**: `ParquetStore` derives rows/min/max TS from parquet **footer
+  metadata** (row-group statistics) instead of reading the TS column, cached per
+  file on `(mtime_ns, size)`; files without TS statistics fall back to the column
+  read. API endpoints call `inventory()` via `asyncio.to_thread`.
+- **Why**: inventory was O(total rows) and ran *in the event loop* — the
+  production collector served `/api/inventory` in 100 s for 10 KB while WS
+  collection shared the same starved loop. Footer stats are O(files), exact for
+  int64, and the atomic-rename write path makes mtime+size a sound invalidation
+  key. No new state to keep consistent.
+- **Rejected alternatives**: a write-through cache updated by `save()` (a second
+  source of truth that desyncs on out-of-band writes — purge, rclone restore);
+  a manifest DB (CoverageStore already exists for *extent*, duplicating rows/
+  bounds there couples two stores for one read path); keeping the column read
+  but only off-thread (still O(rows) per call — 365 daily trades files/year/pair
+  keeps growing).
+
 ### 2026-06-10 — API hardening = in-process rate limit + read-only verb gate, both opt-in (PR #108) [accepted]
 - **Choice**: harden `/api/*` for exposure with an in-process, non-blocking per-client
   token bucket (`ui_rate_limit`, over budget → `429`+`Retry-After`) and a read-only

--- a/doc/dev/plans/perf-robustness/00-plan.md
+++ b/doc/dev/plans/perf-robustness/00-plan.md
@@ -43,7 +43,7 @@ auto-memory `project-v33-perf-audit`.
 ## Leaf checklist
 
 - [ ] 01 orderbook-snapshot-throttle — fix/orderbook-snapshot-throttle — medium
-- [ ] 02 inventory-footer-metadata — fix/inventory-footer-metadata — medium
+- [x] 02 inventory-footer-metadata — fix/inventory-footer-metadata — medium
 - [ ] 03 ws-subscription-honesty — fix/ws-subscription-honesty — medium (depends on 01)
 - [x] 04 scheduler-monitor-hygiene — fix/scheduler-monitor-hygiene — medium
 - [ ] 05 ui-transport-efficiency — feat/ui-transport-efficiency — medium (depends on 02)

--- a/doc/dev/plans/perf-robustness/02-inventory-footer-metadata.md
+++ b/doc/dev/plans/perf-robustness/02-inventory-footer-metadata.md
@@ -1,12 +1,12 @@
 ---
 plan: perf-robustness/02-inventory-footer-metadata
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: true
 branch: fix/inventory-footer-metadata
-pr: ""
+pr: "#XX"
 ---
 
 # `ParquetStore` metadata from parquet footers + cache + off-thread API

--- a/doc/dev/plans/perf-robustness/02-inventory-footer-metadata.md
+++ b/doc/dev/plans/perf-robustness/02-inventory-footer-metadata.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: true
 branch: fix/inventory-footer-metadata
-pr: "#XX"
+pr: "#119"
 ---
 
 # `ParquetStore` metadata from parquet footers + cache + off-thread API


### PR DESCRIPTION
Leaf **02-inventory-footer-metadata** of the `perf-robustness` plan tree (production audit 2026-06-10, see #116).

## Problem
`ParquetStore.inventory()` (+ `last_timestamp`, `missing_intervals`, `_is_year_complete`) materialised the whole TS column of **every parquet file in the store** on every call, synchronously inside async API endpoints — blocking the event loop that also drives WS collection. Production measurement: `/api/inventory` took **100 s** to return 10 KB on a 50-file / 32 MB store (under CPU starvation). The cost grows ~365 daily trades files/year/pair.

## Changes
- New `ParquetStore._file_stats()`: row count + TS min/max from the **parquet footer** (pyarrow metadata across all row groups, no column read), cached per file on `(mtime_ns, size)`; files lacking TS statistics fall back to the old column read.
- `inventory()`, `last_timestamp()`, `missing_intervals()`, `_is_year_complete()` all route through it.
- `GET /api/inventory` and `GET /api/storage/sync` call `inventory()` via `asyncio.to_thread`.
- 8 new tests: cache hit/invalidation, no-statistics fallback, value-identity for inventory/last_timestamp/missing_intervals on OHLC + trades.

## Verification on real data
- Real Binance backfills on an isolated store (733 + 733 OHLC bars, **78 236 real trades**), padded to 63 datasets: old-vs-new `inventory()` output **identical on every field**, `last_timestamp` identical on every dataset.
- Timing: old 14.6 ms → new 1.1 ms warm (**13×**) on 63 small files; the gap scales with file size (production trades files are millions of rows).
- 256 unit tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)