### PR TITLE
fix: build order-book snapshots only at capture time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Order-book WS adapters built the full book as pydantic objects on **every**
+  delta while the stream operation kept only one frame per `snapshot_interval` —
+  97.7 % CPU on the production collector, starving the event loop and making
+  the remote UI unusable. Snapshots are now constructed only at capture time
+  (`min_interval` pushed down into the adapters; `0.0` keeps per-frame), and
+  Kraken/Bybit book state is truncated to the subscribed depth (WS truncation
+  contract). Verified live: Kraken 60 s at 10 s interval → exactly 6 snapshots,
+  ≤ 25 levels/side, never crossed; 3 live books for 2 min → **2.0 %** CPU. (#XX)
 - `ParquetStore` metadata (inventory, last timestamp, gap detection) no longer
   reads the full TS column of every file in the store — it reads parquet footer
   statistics with a per-file mtime cache (legacy files without statistics fall

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`min_interval` pushed down into the adapters; `0.0` keeps per-frame), and
   Kraken/Bybit book state is truncated to the subscribed depth (WS truncation
   contract). Verified live: Kraken 60 s at 10 s interval → exactly 6 snapshots,
-  ≤ 25 levels/side, never crossed; 3 live books for 2 min → **2.0 %** CPU. (#XX)
+  ≤ 25 levels/side, never crossed; 3 live books for 2 min → **2.0 %** CPU. (#120)
 - `ParquetStore` metadata (inventory, last timestamp, gap detection) no longer
   reads the full TS column of every file in the store — it reads parquet footer
   statistics with a per-file mtime cache (legacy files without statistics fall

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -449,19 +449,17 @@ async def stream(
         elif target.data_type == DataType.ORDERBOOK:
             if not isinstance(adapter, OrderBookLive):
                 raise NoCapability(target.exchange, "orderbook", "live")
-            # The WS pushes the book continuously, but we only *capture* a
-            # snapshot every ``snapshot_interval`` seconds. Emit the liveness
-            # sample only when we actually save, so the liveness reflects the
-            # real capture cadence (matching the "Δ Ns" shown in the UI) instead
-            # of flickering every second on data we discard. ``last_save = 0``
-            # captures the first frame immediately.
-            last_save = 0.0
-            async for snap in adapter.stream_orderbook(target.symbol, params.depth or 50):
+            # The throttle is now owned by the adapter: pass min_interval so that
+            # pydantic objects are only constructed for frames that will be saved.
+            # The adapter yields one snapshot per interval, so every yielded
+            # snapshot is saved immediately (no downstream throttle needed).
+            # ``last_save = 0`` / first-frame capture is implicit: the adapter
+            # starts with last_emit=0 so the first frame always passes.
+            async for snap in adapter.stream_orderbook(
+                target.symbol, params.depth or 50, min_interval=snapshot_interval
+            ):
                 if stop_event and stop_event.is_set():
                     break
-                if time.time() - last_save < snapshot_interval:
-                    continue
-                last_save = time.time()
                 await asyncio.to_thread(store.save, ds, [snap], Provenance(source=prov_src))
                 # Best bid = highest bid price, best ask = lowest ask price.
                 # Compute rather than trust ordering so a momentarily unsorted

--- a/dccd/sources/base.py
+++ b/dccd/sources/base.py
@@ -130,6 +130,25 @@ class TradesLive(Source):
 class OrderBookLive(Source):
     """Protocol: can stream live order book snapshots/deltas via WebSocket."""
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
-        """Yield live order-book snapshots/deltas over WebSocket."""
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
+        """Yield live order-book snapshots over WebSocket.
+
+        Parameters
+        ----------
+        symbol : Symbol
+        depth : int
+            Maximum number of levels per side to include in each snapshot.
+        min_interval : float, optional
+            Minimum seconds between emitted snapshots.  ``0.0`` (default)
+            preserves the legacy per-frame behaviour — every WS frame yields a
+            snapshot.  Pass ``snapshot_interval`` from the job spec to move the
+            throttle *upstream* so pydantic objects are only constructed for
+            frames that will actually be saved.
+        """
         raise NotImplementedError

--- a/dccd/sources/binance.py
+++ b/dccd/sources/binance.py
@@ -205,7 +205,13 @@ class BinanceSource(
         ws = _BinanceTradeWS(pair)
         return ws.stream()
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream live order-book snapshots over WebSocket.
 
         Uses Binance's *partial book depth* stream, which pushes a fully sorted
@@ -214,7 +220,7 @@ class BinanceSource(
         pair = self.render_symbol(symbol).lower()
         levels = 5 if depth <= 5 else 10 if depth <= 10 else 20
         ws = _BinanceDepthWS(pair, levels)
-        return ws.stream()
+        return ws.stream(min_interval=min_interval)
 
 
 class _BinanceKlineWS(WebSocketBase):
@@ -279,3 +285,22 @@ class _BinanceDepthWS(WebSocketBase):
             asks=asks,
             is_snapshot=True,
         )
+
+    async def stream(self, min_interval: float = 0.0) -> AsyncIterator[OrderBookSnapshot]:
+        """Yield parsed order-book snapshots, throttled to *min_interval* seconds.
+
+        The throttle check is applied on the raw frame **before** calling
+        ``parse_message`` so no pydantic objects are constructed for frames that
+        will be discarded.  ``min_interval=0.0`` preserves the legacy per-frame
+        behaviour.
+        """
+        import time as _time
+        last_emit: float = -float("inf")  # first frame always emits
+        async for raw in self.stream_raw():
+            # Fast path: do a cheap JSON sniff before committing to parse_message.
+            now = _time.monotonic()
+            if now - last_emit < min_interval:
+                continue
+            async for record in self.parse_message(raw):
+                last_emit = _time.monotonic()
+                yield record

--- a/dccd/sources/bitfinex.py
+++ b/dccd/sources/bitfinex.py
@@ -219,7 +219,13 @@ class BitfinexSource(OHLCHistory, TradesHistory, OrderBookSnapshotREST, OHLCLive
         ws = _BitfinexWS(_bfx_symbol(symbol), "trades")
         return ws.stream()
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream live order-book snapshots/deltas over WebSocket."""
         raise NotImplementedError("Bitfinex live order book stream is not implemented")
 

--- a/dccd/sources/bitmex.py
+++ b/dccd/sources/bitmex.py
@@ -211,7 +211,13 @@ class BitMEXSource(OHLCHistory, TradesHistory, OrderBookSnapshotREST, OHLCLive, 
         ws = _BitMEXWS(self.render_symbol(symbol), "trade", "trades")
         return ws.stream()
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream live order-book snapshots over WebSocket.
 
         Uses the ``orderBook10`` topic — a full top-10 snapshot on every update —
@@ -219,7 +225,7 @@ class BitMEXSource(OHLCHistory, TradesHistory, OrderBookSnapshotREST, OHLCLive, 
         carry no price on updates and can't yield a correct best bid-ask.
         """
         ws = _BitMEXWS(self.render_symbol(symbol), "orderBook10", "book")
-        return ws.stream()
+        return ws.stream(min_interval=min_interval)
 
 
 class _BitMEXWS(WebSocketBase):
@@ -281,3 +287,24 @@ class _BitMEXWS(WebSocketBase):
                 asks = [OrderBookLevel(price=float(a[0]), amount=float(a[1])) for a in e.get("asks", [])]
                 if bids or asks:
                     yield OrderBookSnapshot(ts=s_to_ns(time.time()), bids=bids, asks=asks, is_snapshot=True)
+
+    async def stream(self, min_interval: float = 0.0) -> AsyncIterator[Any]:
+        """Yield parsed records, with order-book frames throttled by *min_interval*.
+
+        For order-book mode the throttle is applied on the raw frame **before**
+        ``parse_message`` so no pydantic objects are constructed for frames that
+        will be discarded.  For other modes behaves identically to the base
+        ``stream()`` (min_interval is ignored).
+        """
+        if self._mode != "book" or min_interval == 0.0:
+            async for record in super().stream():
+                yield record
+            return
+        last_emit: float = -float("inf")  # first frame always emits
+        async for raw in self.stream_raw():
+            now = time.monotonic()
+            if now - last_emit < min_interval:
+                continue
+            async for record in self.parse_message(raw):
+                last_emit = time.monotonic()
+                yield record

--- a/dccd/sources/bybit.py
+++ b/dccd/sources/bybit.py
@@ -142,10 +142,16 @@ class BybitSource(OHLCHistory, OHLCLive, TradesLive, OrderBookSnapshotREST, Orde
         ws = _BybitWS(self.render_symbol(symbol), "publicTrade")
         return ws.stream_trades()
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream live order-book snapshots/deltas over WebSocket."""
         ws = _BybitWS(self.render_symbol(symbol), "orderbook", str(depth))
-        return ws.stream_orderbook()
+        return ws.stream_orderbook(depth=depth, min_interval=min_interval)
 
 
 class _BybitWS(WebSocketBase):
@@ -196,16 +202,26 @@ class _BybitWS(WebSocketBase):
                     tid=t.get("i"),
                 )
 
-    async def stream_orderbook(self) -> AsyncIterator[OrderBookSnapshot]:
+    async def stream_orderbook(
+        self, *, depth: int = 50, min_interval: float = 0.0
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream the order book, reconstructing full state from snapshot + deltas.
 
         Bybit sends one ``snapshot`` then ``delta`` frames (a level with size 0
-        is a removal). Yielding the raw delta levels would surface a
-        meaningless/crossed best bid-ask, so we keep the full book and emit it
-        sorted on every frame.
+        is a removal). Delta frames are applied to cheap dict state on every WS
+        frame; pydantic objects are only constructed when a capture is due
+        (controlled by *min_interval*), eliminating per-frame CPU burn.
+
+        At emit time both sides are sorted, truncated to *depth*, and the dicts
+        are pruned to those same top-N levels. Bybit WS says the client truncates
+        after applying updates; pruning at emit bounds stale-level retention to
+        at most one interval.
+
+        All emitted snapshots carry ``is_snapshot=True`` (full reconstructed state).
         """
         state_bids: dict[float, float] = {}
         state_asks: dict[float, float] = {}
+        last_emit: float = -float("inf")  # ensure the first frame always emits
         async for raw in self.stream_raw():
             data = json.loads(raw)
             if "data" not in data:
@@ -228,7 +244,19 @@ class _BybitWS(WebSocketBase):
                         state_asks.pop(price, None)
                     else:
                         state_asks[price] = qty
-            bids = [OrderBookLevel(price=p, amount=q) for p, q in sorted(state_bids.items(), reverse=True)]
-            asks = [OrderBookLevel(price=p, amount=q) for p, q in sorted(state_asks.items())]
+            # Throttle check: skip pydantic construction for frames that
+            # won't be saved (min_interval=0.0 preserves legacy per-frame).
+            now = time.monotonic()
+            if now - last_emit < min_interval:
+                continue
+            last_emit = now
+            # Sort + truncate to subscribed depth; prune dicts to match so
+            # stale levels beyond depth are discarded at most one interval later.
+            sorted_bids = sorted(state_bids.items(), reverse=True)[:depth]
+            sorted_asks = sorted(state_asks.items())[:depth]
+            state_bids = dict(sorted_bids)
+            state_asks = dict(sorted_asks)
+            bids = [OrderBookLevel(price=p, amount=q) for p, q in sorted_bids]
+            asks = [OrderBookLevel(price=p, amount=q) for p, q in sorted_asks]
             ts_ms = d.get("ts", int(time.time() * 1000))
-            yield OrderBookSnapshot(ts=ts_ms * 1_000_000, bids=bids, asks=asks, is_snapshot=is_snap)
+            yield OrderBookSnapshot(ts=ts_ms * 1_000_000, bids=bids, asks=asks, is_snapshot=True)

--- a/dccd/sources/coinbase.py
+++ b/dccd/sources/coinbase.py
@@ -205,7 +205,13 @@ class CoinbaseSource(
         """Stream live OHLC bars over WebSocket."""
         raise NotImplementedError("Coinbase live OHLC stream is not implemented")
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream live order-book snapshots/deltas over WebSocket."""
         raise NotImplementedError("Coinbase live order book stream is not implemented")
 

--- a/dccd/sources/kraken.py
+++ b/dccd/sources/kraken.py
@@ -250,9 +250,15 @@ class KrakenSource(
         """Stream live trades over WebSocket."""
         return _KrakenWS(_ws_pair(symbol), "trade").stream_trades()
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream live order-book snapshots/deltas over WebSocket."""
-        return _KrakenWS(_ws_pair(symbol), "book", depth).stream_orderbook()
+        return _KrakenWS(_ws_pair(symbol), "book", depth).stream_orderbook(min_interval=min_interval)
 
 
 class _KrakenWS(WebSocketBase):
@@ -314,10 +320,26 @@ class _KrakenWS(WebSocketBase):
                     side="buy" if t.get("side") == "buy" else "sell",
                 )
 
-    async def stream_orderbook(self) -> AsyncIterator[OrderBookSnapshot]:
-        """Reconstruct full order-book state from Kraken snapshot + delta frames."""
+    async def stream_orderbook(self, *, min_interval: float = 0.0) -> AsyncIterator[OrderBookSnapshot]:
+        """Reconstruct full order-book state from Kraken snapshot + delta frames.
+
+        Delta frames are applied to cheap dict state on every WS frame.
+        Pydantic ``OrderBookLevel``/``OrderBookSnapshot`` objects are only
+        constructed when a capture is due (controlled by *min_interval*), so
+        the ~96 % CPU burn from per-frame construction is eliminated.
+
+        At emit time both sides are sorted, truncated to the subscribed depth
+        (``self._param``), and the dicts are pruned to those same top-N levels.
+        Kraken WS v2 says the client truncates after applying updates; pruning
+        at emit bounds stale-level retention to at most one interval.
+
+        All emitted snapshots carry ``is_snapshot=True`` because they represent
+        full reconstructed state, not a raw delta.
+        """
         state_bids: dict[float, float] = {}
         state_asks: dict[float, float] = {}
+        last_emit: float = -float("inf")  # ensure the first frame always emits
+        depth = self._param  # subscribed depth
         async for raw in self.stream_raw():
             data = json.loads(raw)
             if data.get("channel") != "book":
@@ -340,8 +362,18 @@ class _KrakenWS(WebSocketBase):
                             state_asks.pop(p, None)
                         else:
                             state_asks[p] = q
-                bids = [OrderBookLevel(price=p, amount=q)
-                        for p, q in sorted(state_bids.items(), reverse=True)]
-                asks = [OrderBookLevel(price=p, amount=q)
-                        for p, q in sorted(state_asks.items())]
-                yield OrderBookSnapshot(ts=s_to_ns(time.time()), bids=bids, asks=asks, is_snapshot=is_snap)
+                # Throttle check: skip pydantic construction for frames that
+                # won't be saved (min_interval=0.0 preserves legacy per-frame).
+                now = time.monotonic()
+                if now - last_emit < min_interval:
+                    continue
+                last_emit = now
+                # Sort + truncate to subscribed depth; prune dicts to match so
+                # stale levels beyond depth are discarded at most one interval later.
+                sorted_bids = sorted(state_bids.items(), reverse=True)[:depth]
+                sorted_asks = sorted(state_asks.items())[:depth]
+                state_bids = dict(sorted_bids)
+                state_asks = dict(sorted_asks)
+                bids = [OrderBookLevel(price=p, amount=q) for p, q in sorted_bids]
+                asks = [OrderBookLevel(price=p, amount=q) for p, q in sorted_asks]
+                yield OrderBookSnapshot(ts=s_to_ns(time.time()), bids=bids, asks=asks, is_snapshot=True)

--- a/dccd/sources/okx.py
+++ b/dccd/sources/okx.py
@@ -190,7 +190,13 @@ class OKXSource(
         ws = _OKXWS(self.render_symbol(symbol), "trades", "trades")
         return ws.stream()
 
-    def stream_orderbook(self, symbol: Symbol, depth: int) -> AsyncIterator[OrderBookSnapshot]:
+    def stream_orderbook(
+        self,
+        symbol: Symbol,
+        depth: int,
+        *,
+        min_interval: float = 0.0,
+    ) -> AsyncIterator[OrderBookSnapshot]:
         """Stream live order-book snapshots over WebSocket.
 
         Uses the ``books5`` channel — a full sorted top-5 snapshot pushed every
@@ -198,7 +204,7 @@ class OKXSource(
         meaningless/crossed best bid-ask.
         """
         ws = _OKXWS(self.render_symbol(symbol), "books5", "books")
-        return ws.stream()
+        return ws.stream(min_interval=min_interval)
 
 
 class _OKXWS(WebSocketBase):
@@ -245,3 +251,25 @@ class _OKXWS(WebSocketBase):
                 asks = [OrderBookLevel(price=float(a[0]), amount=float(a[1])) for a in snap.get("asks", [])]
                 ts_ms = int(snap.get("ts", int(time.time() * 1000)))
                 yield OrderBookSnapshot(ts=ts_ms * 1_000_000, bids=bids, asks=asks)
+
+    async def stream(self, min_interval: float = 0.0) -> AsyncIterator[Any]:
+        """Yield parsed records, with order-book frames throttled by *min_interval*.
+
+        For order-book mode the throttle is applied on the raw frame **before**
+        ``parse_message`` so no pydantic objects are constructed for frames that
+        will be discarded.  For other modes behaves identically to the base
+        ``stream()`` (min_interval is ignored).
+        """
+        if self._mode != "books" or min_interval == 0.0:
+            # Non-books modes and the legacy zero-interval path use the base loop.
+            async for record in super().stream():
+                yield record
+            return
+        last_emit: float = -float("inf")  # first frame always emits
+        async for raw in self.stream_raw():
+            now = time.monotonic()
+            if now - last_emit < min_interval:
+                continue
+            async for record in self.parse_message(raw):
+                last_emit = time.monotonic()
+                yield record

--- a/dccd/tests/v3/test_orderbook_throttle.py
+++ b/dccd/tests/v3/test_orderbook_throttle.py
@@ -1,0 +1,406 @@
+"""Tests for upstream order-book snapshot throttling.
+
+Verifies that the ``min_interval`` knob in ``stream_orderbook`` limits pydantic
+object construction to frames that will actually be saved — the fix for the
+~96 % daemon CPU burn caused by per-frame ``OrderBookLevel``/``OrderBookSnapshot``
+construction in ``_KrakenWS.stream_orderbook`` and ``_BybitWS.stream_orderbook``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _kraken_snapshot_frame(bids: list, asks: list) -> str:
+    """Build a Kraken WS v2 ``book`` snapshot frame."""
+    return json.dumps({
+        "channel": "book",
+        "type": "snapshot",
+        "data": [{
+            "symbol": "BTC/USD",
+            "type": "snapshot",
+            "bids": [{"price": str(p), "qty": str(q)} for p, q in bids],
+            "asks": [{"price": str(p), "qty": str(q)} for p, q in asks],
+        }],
+    })
+
+
+def _kraken_delta_frame(bids: list, asks: list) -> str:
+    """Build a Kraken WS v2 ``book`` delta frame."""
+    return json.dumps({
+        "channel": "book",
+        "type": "update",
+        "data": [{
+            "symbol": "BTC/USD",
+            "type": "update",
+            "bids": [{"price": str(p), "qty": str(q)} for p, q in bids],
+            "asks": [{"price": str(p), "qty": str(q)} for p, q in asks],
+        }],
+    })
+
+
+def _bybit_snapshot_frame(bids: list, asks: list, ts_ms: int = 1_700_000_000_000) -> str:
+    return json.dumps({
+        "type": "snapshot",
+        "data": {
+            "b": [[str(p), str(q)] for p, q in bids],
+            "a": [[str(p), str(q)] for p, q in asks],
+            "ts": ts_ms,
+        },
+    })
+
+
+def _bybit_delta_frame(bids: list, asks: list, ts_ms: int = 1_700_000_001_000) -> str:
+    return json.dumps({
+        "type": "delta",
+        "data": {
+            "b": [[str(p), str(q)] for p, q in bids],
+            "a": [[str(p), str(q)] for p, q in asks],
+            "ts": ts_ms,
+        },
+    })
+
+
+async def _collect(agen) -> list:
+    return [x async for x in agen]
+
+
+# ---------------------------------------------------------------------------
+# Kraken throttle tests
+# ---------------------------------------------------------------------------
+
+class TestKrakenThrottle:
+    """_KrakenWS.stream_orderbook throttles construction to min_interval."""
+
+    @pytest.mark.asyncio
+    async def test_min_interval_zero_yields_every_frame(self):
+        """min_interval=0.0 (legacy) yields a snapshot on every frame."""
+        from dccd.sources.kraken import _KrakenWS
+
+        ws = _KrakenWS("BTC/USD", "book", 10)
+
+        # 1 snapshot + 3 delta frames = 4 frames
+        frames = [
+            _kraken_snapshot_frame([(100.0, 1.0), (99.0, 2.0)], [(101.0, 1.0)]),
+            _kraken_delta_frame([(98.0, 0.5)], []),
+            _kraken_delta_frame([], [(102.0, 0.3)]),
+            _kraken_delta_frame([(100.0, 0)], []),  # removal
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(min_interval=0.0))
+
+        assert len(snaps) == 4
+
+    @pytest.mark.asyncio
+    async def test_min_interval_throttles_to_one_per_window(self):
+        """With min_interval=10, exactly 1 snapshot is emitted per 10-s window."""
+        from dccd.sources.kraken import _KrakenWS
+
+        ws = _KrakenWS("BTC/USD", "book", 10)
+
+        # 1 snapshot + 5 delta frames; monotonic advances: 0, 0.5, 1, 2, 5, 15
+        # Only the first frame (t=0) and the last (t=15) should be emitted
+        # with min_interval=10.
+        mono_values = [0.0, 0.5, 1.0, 2.0, 5.0, 15.0]
+        frames = [
+            _kraken_snapshot_frame([(100.0, 1.0)], [(101.0, 1.0)]),
+            _kraken_delta_frame([(99.0, 0.5)], []),
+            _kraken_delta_frame([], [(102.0, 0.3)]),
+            _kraken_delta_frame([(100.0, 0.8)], []),
+            _kraken_delta_frame([(98.0, 1.0)], []),
+            _kraken_delta_frame([(97.0, 2.0)], []),
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        mono_iter = iter(mono_values)
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw), \
+             patch("dccd.sources.kraken.time.monotonic", side_effect=lambda: next(mono_iter)):
+            snaps = await _collect(ws.stream_orderbook(min_interval=10.0))
+
+        assert len(snaps) == 2, f"Expected 2 snapshots, got {len(snaps)}"
+
+    @pytest.mark.asyncio
+    async def test_truncates_to_depth(self):
+        """Emitted snapshots have at most `depth` levels per side."""
+        from dccd.sources.kraken import _KrakenWS
+
+        depth = 3
+        ws = _KrakenWS("BTC/USD", "book", depth)
+
+        # Snapshot with more levels than depth
+        bids = [(100.0 - i, 1.0) for i in range(10)]  # 10 bid levels
+        asks = [(101.0 + i, 1.0) for i in range(10)]  # 10 ask levels
+        frames = [_kraken_snapshot_frame(bids, asks)]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(min_interval=0.0))
+
+        assert len(snaps) == 1
+        snap = snaps[0]
+        assert len(snap.bids) <= depth
+        assert len(snap.asks) <= depth
+
+    @pytest.mark.asyncio
+    async def test_delta_removal_reflected_in_next_snapshot(self):
+        """A delta removing a level (qty=0) is absent from the next snapshot."""
+        from dccd.sources.kraken import _KrakenWS
+
+        ws = _KrakenWS("BTC/USD", "book", 10)
+
+        frames = [
+            _kraken_snapshot_frame([(100.0, 1.0), (99.0, 2.0)], [(101.0, 1.0)]),
+            _kraken_delta_frame([(100.0, 0)], []),  # remove 100.0 bid
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(min_interval=0.0))
+
+        assert len(snaps) == 2
+        # After removal the last snapshot must not contain price 100.0 on bids
+        last = snaps[-1]
+        assert not any(lvl.price == 100.0 for lvl in last.bids)
+        assert any(lvl.price == 99.0 for lvl in last.bids)
+
+    @pytest.mark.asyncio
+    async def test_is_snapshot_always_true(self):
+        """All emitted snapshots have is_snapshot=True (full state, not raw delta)."""
+        from dccd.sources.kraken import _KrakenWS
+
+        ws = _KrakenWS("BTC/USD", "book", 10)
+
+        frames = [
+            _kraken_snapshot_frame([(100.0, 1.0)], [(101.0, 1.0)]),
+            _kraken_delta_frame([(99.0, 0.5)], []),
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(min_interval=0.0))
+
+        for snap in snaps:
+            assert snap.is_snapshot is True
+
+    @pytest.mark.asyncio
+    async def test_no_pydantic_construction_for_skipped_frames(self):
+        """Pydantic objects are NOT constructed for throttled (skipped) frames."""
+        import dccd.domain.records as records_mod
+        from dccd.sources.kraken import _KrakenWS
+
+        ws = _KrakenWS("BTC/USD", "book", 10)
+
+        # 4 frames but min_interval = 10 so only first frame passes (mono: 0,1,2,3)
+        frames = [
+            _kraken_snapshot_frame([(100.0, 1.0)], [(101.0, 1.0)]),
+            _kraken_delta_frame([(99.0, 0.5)], []),
+            _kraken_delta_frame([], [(102.0, 0.3)]),
+            _kraken_delta_frame([(98.0, 1.0)], []),
+        ]
+        mono_values = [0.0, 1.0, 2.0, 3.0]
+
+        construction_count = [0]
+        original_init = records_mod.OrderBookLevel.__init__
+
+        def counting_init(self, **kwargs):
+            construction_count[0] += 1
+            original_init(self, **kwargs)
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        mono_iter = iter(mono_values)
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw), \
+             patch("dccd.sources.kraken.time.monotonic", side_effect=lambda: next(mono_iter)), \
+             patch.object(records_mod.OrderBookLevel, "__init__", counting_init):
+            snaps = await _collect(ws.stream_orderbook(min_interval=10.0))
+
+        # Only 1 snapshot was emitted (the first frame)
+        assert len(snaps) == 1
+        # Only 2 OrderBookLevel objects were constructed (1 bid + 1 ask for that 1 frame)
+        assert construction_count[0] == 2, (
+            f"Expected 2 OrderBookLevel constructions (1 bid + 1 ask), got {construction_count[0]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bybit throttle tests
+# ---------------------------------------------------------------------------
+
+class TestBybitThrottle:
+    """_BybitWS.stream_orderbook throttles construction to min_interval."""
+
+    @pytest.mark.asyncio
+    async def test_min_interval_zero_yields_every_frame(self):
+        from dccd.sources.bybit import _BybitWS
+
+        ws = _BybitWS("BTCUSDT", "orderbook", "10")
+
+        frames = [
+            _bybit_snapshot_frame([(100.0, 1.0), (99.0, 2.0)], [(101.0, 1.0)]),
+            _bybit_delta_frame([(98.0, 0.5)], []),
+            _bybit_delta_frame([], [(102.0, 0.3)]),
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(depth=10, min_interval=0.0))
+
+        assert len(snaps) == 3
+
+    @pytest.mark.asyncio
+    async def test_min_interval_throttles_to_one_per_window(self):
+        from dccd.sources.bybit import _BybitWS
+
+        ws = _BybitWS("BTCUSDT", "orderbook", "10")
+
+        mono_values = [0.0, 0.5, 1.0, 12.0]
+        frames = [
+            _bybit_snapshot_frame([(100.0, 1.0)], [(101.0, 1.0)]),
+            _bybit_delta_frame([(99.0, 0.5)], []),
+            _bybit_delta_frame([], [(102.0, 0.3)]),
+            _bybit_delta_frame([(98.0, 1.0)], []),
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        mono_iter = iter(mono_values)
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw), \
+             patch("dccd.sources.bybit.time.monotonic", side_effect=lambda: next(mono_iter)):
+            snaps = await _collect(ws.stream_orderbook(depth=10, min_interval=10.0))
+
+        assert len(snaps) == 2, f"Expected 2 snapshots, got {len(snaps)}"
+
+    @pytest.mark.asyncio
+    async def test_truncates_to_depth(self):
+        from dccd.sources.bybit import _BybitWS
+
+        depth = 2
+        ws = _BybitWS("BTCUSDT", "orderbook", str(depth))
+
+        bids = [(100.0 - i, 1.0) for i in range(8)]
+        asks = [(101.0 + i, 1.0) for i in range(8)]
+        frames = [_bybit_snapshot_frame(bids, asks)]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(depth=depth, min_interval=0.0))
+
+        assert len(snaps) == 1
+        assert len(snaps[0].bids) <= depth
+        assert len(snaps[0].asks) <= depth
+
+    @pytest.mark.asyncio
+    async def test_delta_removal_reflected_in_next_snapshot(self):
+        from dccd.sources.bybit import _BybitWS
+
+        ws = _BybitWS("BTCUSDT", "orderbook", "10")
+
+        frames = [
+            _bybit_snapshot_frame([(100.0, 1.0), (99.0, 2.0)], [(101.0, 1.0)]),
+            _bybit_delta_frame([(100.0, 0)], []),  # remove 100.0 bid
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(depth=10, min_interval=0.0))
+
+        assert len(snaps) == 2
+        last = snaps[-1]
+        assert not any(lvl.price == 100.0 for lvl in last.bids)
+        assert any(lvl.price == 99.0 for lvl in last.bids)
+
+    @pytest.mark.asyncio
+    async def test_is_snapshot_always_true(self):
+        from dccd.sources.bybit import _BybitWS
+
+        ws = _BybitWS("BTCUSDT", "orderbook", "10")
+
+        frames = [
+            _bybit_snapshot_frame([(100.0, 1.0)], [(101.0, 1.0)]),
+            _bybit_delta_frame([(99.0, 0.5)], []),
+        ]
+
+        async def _fake_raw():
+            for f in frames:
+                yield f
+
+        with patch.object(ws, "stream_raw", side_effect=_fake_raw):
+            snaps = await _collect(ws.stream_orderbook(depth=10, min_interval=0.0))
+
+        for snap in snaps:
+            assert snap.is_snapshot is True
+
+
+# ---------------------------------------------------------------------------
+# Protocol signature test
+# ---------------------------------------------------------------------------
+
+class TestProtocolSignature:
+    """All OrderBookLive adapters accept min_interval kwarg."""
+
+    @pytest.mark.parametrize("adapter_class,args", [
+        ("dccd.sources.kraken.KrakenSource", ()),
+        ("dccd.sources.bybit.BybitSource", ()),
+        ("dccd.sources.binance.BinanceSource", ()),
+        ("dccd.sources.okx.OKXSource", ()),
+        ("dccd.sources.bitmex.BitMEXSource", ()),
+        ("dccd.sources.coinbase.CoinbaseSource", ()),
+        ("dccd.sources.bitfinex.BitfinexSource", ()),
+    ])
+    def test_accepts_min_interval_kwarg(self, adapter_class, args):
+        """stream_orderbook must accept min_interval as a keyword argument."""
+        import importlib
+        mod_path, cls_name = adapter_class.rsplit(".", 1)
+        mod = importlib.import_module(mod_path)
+        cls = getattr(mod, cls_name)
+        import inspect
+        sig = inspect.signature(cls().stream_orderbook)
+        assert "min_interval" in sig.parameters, (
+            f"{adapter_class}.stream_orderbook missing min_interval parameter"
+        )
+        param = sig.parameters["min_interval"]
+        assert param.default == 0.0, (
+            f"{adapter_class}.stream_orderbook: min_interval default should be 0.0"
+        )
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{adapter_class}.stream_orderbook: min_interval must be keyword-only"
+        )

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-10 — Order-book capture throttle lives in the adapter, not the consumer (PR #XX) [accepted]
+### 2026-06-10 — Order-book capture throttle lives in the adapter, not the consumer (PR #120) [accepted]
 - **Choice**: `OrderBookLive.stream_orderbook` takes a keyword-only
   `min_interval` (default `0.0` = per-frame, the legacy contract).
   Delta-maintained books (Kraken, Bybit) apply frames to plain dicts and only

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,6 +120,25 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-10 — Order-book capture throttle lives in the adapter, not the consumer (PR #XX) [accepted]
+- **Choice**: `OrderBookLive.stream_orderbook` takes a keyword-only
+  `min_interval` (default `0.0` = per-frame, the legacy contract).
+  Delta-maintained books (Kraken, Bybit) apply frames to plain dicts and only
+  sort/construct pydantic objects when a capture is due, truncating snapshot
+  *and* state to the subscribed depth; push-snapshot channels (Binance, OKX,
+  BitMEX) drop frames before parsing. `operations.stream()` passes
+  `snapshot_interval` down and saves every yielded snapshot.
+- **Why**: the cost to kill was the *construction* (pydantic `__init__` was
+  ~96 % of daemon CPU samples in production), and only the adapter can skip
+  it — a downstream throttle (the previous design) pays full price for frames
+  it then discards. Default `0.0` keeps the protocol honest for any consumer
+  that genuinely wants every frame.
+- **Rejected alternatives**: throttle in `operations.stream()` only (where it
+  was — provably insufficient, 97.7 % CPU with 20 book jobs); yielding raw
+  dict state and building snapshots in the consumer (leaks adapter
+  representation across the protocol boundary); plain-dataclass order-book
+  records (still O(levels) per frame, and gives up validation everywhere else).
+
 ### 2026-06-10 — Store metadata = parquet footer statistics + per-file mtime cache (PR #119) [accepted]
 - **Choice**: `ParquetStore` derives rows/min/max TS from parquet **footer
   metadata** (row-group statistics) instead of reading the TS column, cached per

--- a/doc/dev/plans/perf-robustness/00-plan.md
+++ b/doc/dev/plans/perf-robustness/00-plan.md
@@ -42,7 +42,7 @@ auto-memory `project-v33-perf-audit`.
 
 ## Leaf checklist
 
-- [ ] 01 orderbook-snapshot-throttle — fix/orderbook-snapshot-throttle — medium
+- [x] 01 orderbook-snapshot-throttle — fix/orderbook-snapshot-throttle — medium
 - [x] 02 inventory-footer-metadata — fix/inventory-footer-metadata — medium
 - [ ] 03 ws-subscription-honesty — fix/ws-subscription-honesty — medium (depends on 01)
 - [x] 04 scheduler-monitor-hygiene — fix/scheduler-monitor-hygiene — medium

--- a/doc/dev/plans/perf-robustness/01-orderbook-snapshot-throttle.md
+++ b/doc/dev/plans/perf-robustness/01-orderbook-snapshot-throttle.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: true
 branch: fix/orderbook-snapshot-throttle
-pr: "#XX"
+pr: "#120"
 ---
 
 # Throttle order-book snapshot construction upstream (kills the 98 % CPU burn)

--- a/doc/dev/plans/perf-robustness/01-orderbook-snapshot-throttle.md
+++ b/doc/dev/plans/perf-robustness/01-orderbook-snapshot-throttle.md
@@ -1,12 +1,12 @@
 ---
 plan: perf-robustness/01-orderbook-snapshot-throttle
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: true
 branch: fix/orderbook-snapshot-throttle
-pr: ""
+pr: "#XX"
 ---
 
 # Throttle order-book snapshot construction upstream (kills the 98 % CPU burn)


### PR DESCRIPTION
Leaf **01-orderbook-snapshot-throttle** of the `perf-robustness` plan tree — the root cause of the 2026-06-10 production incident (see #116).

## Problem
Every order-book WS adapter constructed the full book as pydantic objects (one `OrderBookLevel` per level, sorted) on **every delta frame**, while `operations.stream()` discarded all but one frame per `snapshot_interval` (60 s default). py-spy on the production collector (20 book jobs): **97.7 % CPU**, ~96 % of samples in `kraken.stream_orderbook` pydantic `__init__`. The starved event loop also serves the API — `/api/inventory` took 100 s, the remote UI was unusable.

## Changes
- `OrderBookLive.stream_orderbook(symbol, depth, *, min_interval=0.0)` — keyword-only, `0.0` = legacy per-frame behaviour.
- **Kraken / Bybit** (delta-maintained books): frames keep updating plain dicts; all pydantic construction is skipped until a capture is due; at emit the book is sorted once, the snapshot **truncated to the subscribed depth** and the state dicts pruned to the same top-N (WS truncation contract — stale levels bounded to one interval). Emitted snapshots are full state (`is_snapshot=True`).
- **Binance / OKX / BitMEX** (push-snapshot channels): frames dropped before parsing until the interval elapses.
- `operations.stream()` passes `snapshot_interval` down and saves every yielded snapshot (downstream throttle removed).
- New `test_orderbook_throttle.py` (12 tests): scripted Kraken/Bybit frame sequences with a fake clock — one snapshot per interval, zero `OrderBookLevel` constructed for skipped frames, truncation, qty-0 removal, `min_interval=0` regression guard.

## Verification on real data (isolated store)
- **Live Kraken BTC/USD, 60 s, `snapshot_interval=10`, depth 25** → exactly **6 snapshots** on disk, ≤ 25 levels/side, TS monotonic, never crossed (max bid < min ask on every snapshot).
- **2 Kraken + 1 Bybit live books for 2 min** → steady-state **2.0 % CPU** (10 `ps` samples, last 5 averaged). Production baseline with the old code: 97.7 % with one core saturated.
- 274 unit tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)