### PR TITLE
feat: remote-friendly UI transport — gzip, parallel fetches, saner polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remote-friendly UI transport: gzip on API/page responses (`/api/inventory`
+  measured 12 450 B → 460 B, 27×; SSE excluded and flushed immediately so
+  EventSource connects without waiting for the first event), dashboard fetches
+  parallelised (3×RTT → 1×RTT), Live re-fetches the inventory only on load and
+  stream-status changes instead of every 8 s, dashboard/storage poll cadences
+  relaxed (15 s / 30 s), and runs-store SQLite reads moved off the event loop.
+  UI smoke: 27/27 steps clean. (#XX)
+
 ### Fixed
 
+- A live stream whose WS generator ended on its own (no stop requested) was
+  recorded `cancelled`; it is now `failed` with an explicit
+  "stream ended unexpectedly" error, so Logs/Runs no longer claim someone
+  stopped a stream nobody touched. (#XX)
 - Order-book WS adapters built the full book as pydantic objects on **every**
   delta while the stream operation kept only one frame per `snapshot_interval` —
   97.7 % CPU on the production collector, starving the event loop and making

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parallelised (3×RTT → 1×RTT), Live re-fetches the inventory only on load and
   stream-status changes instead of every 8 s, dashboard/storage poll cadences
   relaxed (15 s / 30 s), and runs-store SQLite reads moved off the event loop.
-  UI smoke: 27/27 steps clean. (#XX)
+  UI smoke: 27/27 steps clean. (#121)
 
 ### Fixed
 
 - A live stream whose WS generator ended on its own (no stop requested) was
   recorded `cancelled`; it is now `failed` with an explicit
   "stream ended unexpectedly" error, so Logs/Runs no longer claim someone
-  stopped a stream nobody touched. (#XX)
+  stopped a stream nobody touched. (#121)
 - Order-book WS adapters built the full book as pydantic objects on **every**
   delta while the stream operation kept only one frame per `snapshot_interval` —
   97.7 % CPU on the production collector, starving the event loop and making

--- a/dccd/application/operations.py
+++ b/dccd/application/operations.py
@@ -479,10 +479,21 @@ async def stream(
     if batch:
         await asyncio.to_thread(store.save, ds, batch, Provenance(source=prov_src))
 
-    if events:
-        events.status("cancelled")
-    if runs_store:
-        runs_store.finish_run(run_id, "cancelled")
+    # `cancelled` only when a stop was actually requested. A WS generator that
+    # ends on its own (exhausted without stop) is a failure — recording it as
+    # `cancelled` made Logs/Runs claim someone stopped a stream nobody touched.
+    if stop_event and stop_event.is_set():
+        if events:
+            events.status("cancelled")
+        if runs_store:
+            runs_store.finish_run(run_id, "cancelled")
+    else:
+        msg = "stream ended unexpectedly"
+        if events:
+            events.log(msg, level="error")
+            events.status("failed")
+        if runs_store:
+            runs_store.finish_run(run_id, "failed", error=msg)
 
 
 def read(

--- a/dccd/interfaces/api/app.py
+++ b/dccd/interfaces/api/app.py
@@ -32,6 +32,7 @@ from urllib.parse import parse_qs
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -301,6 +302,11 @@ def create_app(
     # all; allowing every origin let any website's JS drive the local API
     # (reachable on 127.0.0.1 from the user's browser). Cross-origin access is
     # opt-in via settings.ui_allow_origins.
+    # Compress API/page responses for remote (Tailscale/TLS) clients — inventory
+    # and runs JSON shrink ~10×. Starlette excludes `text/event-stream` from
+    # compression by default, so the SSE stream at /api/events is untouched.
+    app.add_middleware(GZipMiddleware, minimum_size=1024)
+
     allow_origins = list(getattr(getattr(config, "settings", None), "ui_allow_origins", []) or [])
     if allow_origins:
         app.add_middleware(
@@ -485,7 +491,9 @@ def create_app(
         remotes = [r.remote for r in cfg.storage.remotes]
         configured = bool(remotes)
         interval = cfg.storage.sync_interval
-        runs = _runs(request).list_runs(spec_id="remote-sync", limit=1)
+        runs = await asyncio.to_thread(
+            lambda: _runs(request).list_runs(spec_id="remote-sync", limit=1)
+        )
         last = None
         next_eta = None
         if runs:
@@ -570,7 +578,7 @@ def create_app(
     @app.get("/api/backfill/{run_id}")
     async def get_backfill_status(run_id: str, request: Request) -> dict[str, Any]:
         """Get the status of a backfill run by ``run_id``."""
-        run = _runs(request).get_run(run_id)
+        run = await asyncio.to_thread(_runs(request).get_run, run_id)
         if not run:
             raise HTTPException(404, f"Run {run_id!r} not found")
         return _parse_run(run)
@@ -587,7 +595,8 @@ def create_app(
     @app.get("/api/runs")
     async def list_runs(request: Request, limit: int = 50) -> dict[str, Any]:
         """List recent job runs."""
-        return {"runs": [_parse_run(r) for r in _runs(request).list_runs(limit=limit)]}
+        runs = await asyncio.to_thread(lambda: _runs(request).list_runs(limit=limit))
+        return {"runs": [_parse_run(r) for r in runs]}
 
     # -----------------------------------------------------------------------
     # Stream control
@@ -789,6 +798,12 @@ def create_app(
 
         async def _generator():
             try:
+                # Flush an immediate comment: GZipMiddleware (even though it
+                # excludes text/event-stream from compression) buffers the
+                # response *start* until the first body chunk — without this,
+                # EventSource sits in "connecting" until the first event or
+                # the 30 s heartbeat.
+                yield ": connected\n\n"
                 while True:
                     if await request.is_disconnected():
                         break

--- a/dccd/interfaces/ui/templates/dashboard.html
+++ b/dccd/interfaces/ui/templates/dashboard.html
@@ -45,11 +45,13 @@ function kpi(label, value) {
 }
 
 async function load() {
-  // Fetch everything we need once.
-  let runs = [], streams = [], datasets = [];
-  try { runs = (await api('GET','/api/runs?limit=50')).runs || []; } catch (_) {}
-  try { streams = (await api('GET','/api/streams')).streams || []; } catch (_) {}
-  try { datasets = (await api('GET','/api/inventory')).datasets || []; } catch (_) {}
+  // Fetch everything we need once — in parallel: serial awaits cost 3×RTT,
+  // which is what a remote (Tailscale/TLS) client actually feels.
+  const [runsR, streamsR, invR] = await Promise.allSettled([
+    api('GET','/api/runs?limit=50'), api('GET','/api/streams'), api('GET','/api/inventory')]);
+  const runs = runsR.status === 'fulfilled' ? (runsR.value.runs || []) : [];
+  const streams = streamsR.status === 'fulfilled' ? (streamsR.value.streams || []) : [];
+  const datasets = invR.status === 'fulfilled' ? (invR.value.datasets || []) : [];
 
   const liveStreams = streams.filter(s => s.running);
   const activeRuns = runs.filter(r => r.state === 'running' || r.state === 'reconnecting');
@@ -118,6 +120,6 @@ async function load() {
 }
 
 load();
-setInterval(load, 8000);
+setInterval(load, 15000);
 </script>
 {% endblock %}

--- a/dccd/interfaces/ui/templates/live.html
+++ b/dccd/interfaces/ui/templates/live.html
@@ -40,17 +40,22 @@ function invFor(j) {
   return INV.find(d => d.exchange===j.exchange && d.pair===pair && d.data_type===j.data_type);
 }
 
-async function loadAll() {
+async function loadAll(withInventory) {
   try {
-    const [jr, sr, ir] = await Promise.all([
-      api('GET','/api/jobs'), api('GET','/api/streams'), api('GET','/api/inventory')]);
+    // Inventory only seeds liveness from disk — fetch it on initial load and
+    // on SSE status changes (a stream stopped/failed wrote its last point),
+    // not on every 8 s poll: it is the heaviest endpoint and live samples
+    // arrive over SSE anyway.
+    const reqs = [api('GET','/api/jobs'), api('GET','/api/streams')];
+    if (withInventory) reqs.push(api('GET','/api/inventory'));
+    const [jr, sr, ir] = await Promise.all(reqs);
     JOBS = (jr.jobs||[]).filter(j => j.operation === 'stream');
     RUNNING = {};
     for (const s of (sr.streams||[])) RUNNING[s.id] = s.running;
     // Seed liveness from what's on disk so a page refresh immediately reflects
     // the last stored data point (and its freshness) instead of "waiting…".
     // Real-time SSE samples (`live`) always win and are never overwritten here.
-    INV = ir.datasets || [];
+    if (ir) INV = ir.datasets || [];
     for (const j of JOBS) {
       if (samples[j.id] && samples[j.id].live) continue;
       const inv = invFor(j);
@@ -187,7 +192,7 @@ async function toggleStream(jobId) {
     await api('POST', running?'/api/streams/stop':'/api/streams/start', { spec_id: jobId });
     toast(running?'Stream stopped':'Stream started','ok');
     if (running) delete samples[jobId];
-    setTimeout(loadAll, 400);
+    setTimeout(() => loadAll(true), 400);
   } catch (e) { toast(e.message,'err'); btn.disabled = false; }
 }
 
@@ -290,7 +295,7 @@ function connectSSE() {
       samples[specId] = { value: ev.value, bid: ev.bid, ask: ev.ask, ts: ev.ts, live: true };
     } else if (ev.kind === 'status') {
       // a stream stopping/failing → refresh state soon
-      setTimeout(loadAll, 300);
+      setTimeout(() => loadAll(true), 300);
     }
   };
   es.onerror = () => {
@@ -300,7 +305,7 @@ function connectSSE() {
 }
 
 initTabs('#live-tabs');
-loadAll();
+loadAll(true);
 connectSSE();
 setInterval(refreshLiveness, 1000);
 setInterval(loadAll, 8000);

--- a/dccd/interfaces/ui/templates/storage.html
+++ b/dccd/interfaces/ui/templates/storage.html
@@ -103,6 +103,7 @@ async function loadInventory() {
 
 loadSync();
 loadInventory();
-setInterval(loadSync, 10000);
+// Status view: 30 s is plenty ("Sync now" already polls itself after a trigger).
+setInterval(loadSync, 30000);
 </script>
 {% endblock %}

--- a/dccd/tests/v3/test_api.py
+++ b/dccd/tests/v3/test_api.py
@@ -487,3 +487,31 @@ class TestMigrateEndpoint:
         # The v2→v3 migrate feature has been removed entirely.
         resp = client.post("/api/migrate", json={"dry_run": True})
         assert resp.status_code == 404
+
+
+class TestGzip:
+    def test_large_json_is_gzipped(self, client, app):
+        """API JSON above minimum_size is compressed when the client accepts gzip."""
+        from dccd.domain.dataset import DatasetId, Provenance
+        from dccd.domain.records import OHLCBar
+        from dccd.domain.symbol import Symbol
+        from dccd.domain.timeutils import NS
+        from dccd.domain.types import DataType
+
+        store = app.state.store
+        # Enough datasets that the inventory JSON exceeds minimum_size (1024 B).
+        for i in range(12):
+            ds = DatasetId(exchange="binance", symbol=Symbol.parse(f"T{i:02d}/USDT"),
+                           data_type=DataType.OHLC, span=3600)
+            bars = [OHLCBar(ts=(1_700_000_000 + j * 3600) * NS, open=1, high=2,
+                            low=0.5, close=1.5, volume=1.0) for j in range(5)]
+            store.save(ds, bars, Provenance(source="test"))
+        resp = client.get("/api/inventory", headers={"Accept-Encoding": "gzip"})
+        assert resp.status_code == 200
+        assert resp.headers.get("content-encoding") == "gzip"
+        assert len(resp.json()["datasets"]) == 12  # transparently decompressed
+
+    def test_small_json_not_gzipped(self, client):
+        resp = client.get("/health", headers={"Accept-Encoding": "gzip"})
+        assert resp.status_code == 200
+        assert resp.headers.get("content-encoding") != "gzip"

--- a/dccd/tests/v3/test_stream_end_state.py
+++ b/dccd/tests/v3/test_stream_end_state.py
@@ -1,0 +1,86 @@
+"""A live stream that ends on its own is `failed`, not `cancelled`.
+
+Regression for the mislabel where `stream()` finished every run as `cancelled`
+— including WS generators that ended unexpectedly with no stop requested — so
+Logs/Runs claimed someone stopped a stream nobody touched.
+"""
+
+import asyncio
+
+import pytest
+
+from dccd.application.jobs import JobParams, JobSpec, JobTarget, Trigger
+from dccd.application.operations import stream
+from dccd.domain.capability import Capability
+from dccd.domain.records import Trade
+from dccd.domain.symbol import Symbol
+from dccd.domain.timeutils import ns_now
+from dccd.domain.types import DataType
+from dccd.sources.base import TradesLive
+from dccd.storage.parquet import ParquetStore
+from dccd.storage.runs_sqlite import RunsStore
+
+
+class _FiniteTradesWS(TradesLive):
+    """A trades 'stream' whose generator ends after N records (no stop asked)."""
+
+    exchange = "fake"
+
+    def __init__(self, n: int = 3, forever: bool = False) -> None:
+        self._n = n
+        self._forever = forever
+
+    def capabilities(self) -> list[Capability]:
+        return [Capability(data_type=DataType.TRADES, transport="ws", mode="live")]
+
+    async def stream_trades(self, symbol):
+        for i in range(self._n):
+            yield Trade(ts=ns_now(), price=1.0 + i, amount=1.0, side="buy", tid=str(i))
+        while self._forever:
+            await asyncio.sleep(0.01)
+            yield Trade(ts=ns_now(), price=9.9, amount=1.0, side="buy", tid="loop")
+
+
+class _FakeReg:
+    def __init__(self, src):
+        self._s = src
+
+    def get(self, ex):
+        return self._s
+
+
+def _spec() -> JobSpec:
+    target = JobTarget(exchange="fake", symbol=Symbol.parse("BTC/USDT"),
+                       data_type=DataType.TRADES)
+    return JobSpec(id="stream:fake:BTC/USDT:trades", operation="stream",
+                   target=target, trigger=Trigger(kind="supervised"),
+                   params=JobParams(), origin="config")
+
+
+@pytest.mark.asyncio
+async def test_unexpected_end_is_failed(tmp_path):
+    store = ParquetStore(str(tmp_path / "data"))
+    runs = RunsStore(str(tmp_path / "runs.db"))
+    await stream(_spec(), registry=_FakeReg(_FiniteTradesWS(3)), store=store,
+                 runs_store=runs)
+    run = runs.list_runs(limit=1)[0]
+    assert run["state"] == "failed"
+    assert "unexpectedly" in (run["error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_requested_stop_is_cancelled(tmp_path):
+    store = ParquetStore(str(tmp_path / "data"))
+    runs = RunsStore(str(tmp_path / "runs.db"))
+    stop = asyncio.Event()
+
+    async def _stop_soon():
+        await asyncio.sleep(0.05)
+        stop.set()
+
+    asyncio.get_event_loop().create_task(_stop_soon())
+    await stream(_spec(), registry=_FakeReg(_FiniteTradesWS(3, forever=True)),
+                 store=store, runs_store=runs, stop_event=stop)
+    run = runs.list_runs(limit=1)[0]
+    assert run["state"] == "cancelled"
+    assert not run["error"]

--- a/doc/dev/plans/perf-robustness/00-plan.md
+++ b/doc/dev/plans/perf-robustness/00-plan.md
@@ -46,7 +46,7 @@ auto-memory `project-v33-perf-audit`.
 - [x] 02 inventory-footer-metadata — fix/inventory-footer-metadata — medium
 - [ ] 03 ws-subscription-honesty — fix/ws-subscription-honesty — medium (depends on 01)
 - [x] 04 scheduler-monitor-hygiene — fix/scheduler-monitor-hygiene — medium
-- [ ] 05 ui-transport-efficiency — feat/ui-transport-efficiency — medium (depends on 02)
+- [x] 05 ui-transport-efficiency — feat/ui-transport-efficiency — medium (depends on 02)
 
 ## Dependencies
 

--- a/doc/dev/plans/perf-robustness/05-ui-transport-efficiency.md
+++ b/doc/dev/plans/perf-robustness/05-ui-transport-efficiency.md
@@ -1,12 +1,12 @@
 ---
 plan: perf-robustness/05-ui-transport-efficiency
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: [02]
 parallel: false
 branch: feat/ui-transport-efficiency
-pr: ""
+pr: "#XX"
 ---
 
 # HTTP/UI transport efficiency: gzip, parallel fetches, saner polling, off-thread SQLite

--- a/doc/dev/plans/perf-robustness/05-ui-transport-efficiency.md
+++ b/doc/dev/plans/perf-robustness/05-ui-transport-efficiency.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: [02]
 parallel: false
 branch: feat/ui-transport-efficiency
-pr: "#XX"
+pr: "#121"
 ---
 
 # HTTP/UI transport efficiency: gzip, parallel fetches, saner polling, off-thread SQLite


### PR DESCRIPTION
Leaf **05-ui-transport-efficiency** of the `perf-robustness` plan tree (see #116). With #119/#120 fixing the server-side cost, this leaf fixes what a remote (Tailscale/TLS) client pays on the wire.

## Changes
- **GZip** on API/page responses (`minimum_size=1024`). Measured live: `/api/inventory` 12 450 B → **460 B (27×)**.
- **SSE kept correct under the middleware**: `text/event-stream` is excluded from compression (Starlette default), and the stream now flushes an immediate `: connected` comment — GZipMiddleware buffers the response *start* until the first body chunk, which would have left `EventSource` in "connecting" for up to 30 s (found during live verification).
- **Dashboard**: runs/streams/inventory fetched in parallel (`Promise.allSettled`, was 3 serial awaits = 3×RTT); poll 8 s → 15 s.
- **Live**: `/api/inventory` (the heaviest call, only used to seed liveness from disk) fetched on load and on stream-status changes only — no longer on every 8 s poll; live samples arrive over SSE.
- **Storage**: poll 10 s → 30 s.
- **RunsStore reads off-thread**: `/api/runs`, `/api/backfill/{run_id}`, `/api/storage/sync`.
- **Honest stream end-state**: a WS generator ending with no stop requested is recorded `failed` ("stream ended unexpectedly") instead of `cancelled`. New `test_stream_end_state.py` covers both paths.

## Verification
- Live isolated instance: gzip ratio above; SSE headers immediate with `Accept-Encoding: gzip` and no `content-encoding`; `ui_smoke.py` **27/27 steps, 0 console errors / JS exceptions / HTTP ≥ 400**.
- 278 unit tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)