### PR TITLE
chore: release v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.4.0] - 2026-06-10
+
+### Added
+
+### Changed
+
 - Remote-friendly UI transport: gzip on API/page responses (`/api/inventory`
   measured 12 450 B → 460 B, 27×; SSE excluded and flushed immediately so
   EventSource connects without waiting for the first event), dashboard fetches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.3.1"
+version = "3.4.0"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Freezes `[Unreleased]` into **3.4.0** and bumps `pyproject.toml` (only version source — `__version__` reads installed metadata).

## 3.4.0 — Epic D: performance & robustness (2026-06-10 production audit)

### Changed
- Remote-friendly UI transport: gzip (inventory 12 450 B → 460 B, 27×; SSE excluded + immediate flush), parallel dashboard fetches, saner poll cadences, runs-store reads off the event loop. (#121)

### Fixed
- Order-book depths declared per capability; invalid requests snap with a warning; WS subscription rejections surface as `failed` runs (production case: Kraken `depth: 20/50` silently wrote nothing). (#122)
- Stream ending on its own recorded `failed` ("stream ended unexpectedly"), not `cancelled`. (#121)
- Order-book snapshots built only at capture time — 97.7 % → 2.0 % CPU measured live; Kraken/Bybit books truncated to subscribed depth. (#120)
- `ParquetStore` metadata from parquet footer stats + mtime cache, off-thread API (value-identical, 13× warm). (#119)
- Scheduler failure backoff + startup jitter; HealthMonitor alert cooldown. (#118)

## Test plan
- CI (3.11/3.12/3.13 + lint) green on the branch.
- Every fix was verified on real exchange data before merge (details in each PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)