### PR TITLE
docs: plan audit-fixes (Epic E — 2026-06-10 audit)

### DIFF
--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -54,6 +54,47 @@ from parquet footer stats + cache + off-thread, honest WS subscriptions
 gzip + saner UI polling. PRs #118–#121 + the last leaf; ADR journal has the
 rationale; see `06-status.md`._
 
+## Epic E — Audit 2026-06-10 fixes (correctness, perf, prod hygiene)
+
+Source: full-repo audit of 2026-06-10 (session doc `AUDIT-2026-06-10.md`, not
+committed). Ordered by priority; B6/B3 are confirmed in production
+(~350 zombie `running` runs in arthurserver's runs.db).
+
+- [ ] **B6 — stream `NoCapability` leaks zombie runs** — in
+  `operations.stream()` the capability check sits before `create_run`'s
+  `try` → the run row is inserted but never finished; and
+  `_StreamWorker._run_forever` retries a *permanent* error forever (60 s
+  loop). Move the check before `create_run` (or into the `try`) **and** make
+  the supervisor abandon on permanent errors.
+- [ ] **B3 — purge orphan `running` runs at daemon startup** — `RunsStore`
+  never marks runs left `running` after a crash as `stale`/`failed`;
+  `active_runs()` returns them forever.
+- [ ] **B2 — time-based flush for trades/OHLC streams** — streams only flush
+  every 1000 records; a quiet pair keeps hours of data in RAM (lost on
+  crash, invisible on disk). Add a time-based flush (e.g. 60 s).
+- [ ] **B5/P1 — RateLimiter fate + one HTTP pool per operation** —
+  `RateLimiter` is wired nowhere (doc says it is); each paginated page
+  currently opens/closes a fresh `httpx.AsyncClient` (1 TLS handshake per
+  page). Decide: wire the limiter into adapters or delete it + fix
+  CLAUDE.md; and hold the shared client open for the whole operation.
+- [ ] **Prod config — off-box backup + alerts + systemd limits** — no rclone
+  remote configured (prod data backed up nowhere), no alert webhook,
+  no `MemoryMax`/`TimeoutStopSec` in the unit (62 s stop vs 90 s default).
+  Ops + how-to doc, on arthurserver.
+- [ ] **UX — gap % counts empty minutes as missing** — illiquid pairs show
+  misleading "85 % missing" (exchanges emit no empty candles). Distinguish
+  true holes from trade-less minutes, or label it in the Data UI.
+- [ ] **Tests — CLI 0 %, adapter payload fixtures, stop/cancel path** — Typer
+  `CliRunner` suite; recorded REST/WS payload fixtures for adapters
+  (38–63 % coverage today, network-only); cover `_StreamWorker.stop()` and
+  the no-capability stream case (B6 regression test).
+- [ ] **Minor batch** — dynamic OpenAPI version (`3.0.0` hardcoded), CI job
+  for the Sphinx 0-warning rule, streams' `rows_written` always 0, restart
+  delay never resets after a healthy period, purge 21 merged local branches.
+
+P2 (append+compaction writes) and P3 (filename-based pruning in `load()`)
+stay parked below as perf ideas until load demands them.
+
 ## Deferred — M3 (post-3.0)
 
 Larger axes intentionally parked until after the 3.0 release. Not started; do not

--- a/doc/dev/plans/audit-fixes/00-plan.md
+++ b/doc/dev/plans/audit-fixes/00-plan.md
@@ -1,0 +1,82 @@
+---
+plan: audit-fixes
+kind: global
+status: planning
+roadmap: "Epic E — Audit 2026-06-10 fixes (correctness, perf, prod hygiene)"
+release_on_done: true
+---
+
+# Epic E — Audit 2026-06-10 fixes
+
+## Goal
+
+Close out the prioritized findings of the 2026-06-10 full-repo audit: two
+production-confirmed run-lifecycle bugs (B6 zombie runs on no-capability
+streams, B3 orphaned `running` rows after a crash), bounded data loss on
+quiet streams (B2), outbound HTTP discipline (P1 client churn, B5 unwired
+RateLimiter), production hardening on arthurserver (off-box backup, alerts,
+systemd limits), an honest gap metric in the Data UI, the two biggest test
+holes (CLI at 0 %, adapter parsing), and a small mechanical batch.
+
+Out of scope, deliberately parked: P2 (append+compaction writes), P3
+(filename pruning in `load()`), S1 (`/login` rate-limit), `run-all`
+concurrency cap, B1 residual cancel races. They stay in the audit notes /
+roadmap ideas until load or evidence demands them.
+
+## Decomposition
+
+1. **stream-nocapability-zombies** — B6: no run row before the capability
+   check; supervisor abandons permanent errors and resets its backoff after
+   a healthy period.
+2. **runs-stale-purge** — B3: mark orphaned `running` runs `stale` at daemon
+   boot (daemon boot only — not on CLI invocations).
+3. **stream-time-flush** — B2: flush stream batches on a time interval too,
+   and finally report real `rows_written` for stream runs.
+4. **http-client-lifetime** — P1/B4: one httpx pool per operation instead of
+   per page; make `Client.__aexit__` honest.
+5. **rate-limiter-fate** — B5: wire the RateLimiter into the request path or
+   delete it; either way the doc stops lying. ADR mandatory.
+6. **prod-hardening** — arthurserver: rclone remote, alert webhook,
+   `MemoryMax`/`TimeoutStopSec` in the unit; update the deploy how-tos.
+7. **gap-metric-context** — UX: stop presenting trade-less minutes of
+   illiquid pairs as "missing" data.
+8. **cli-tests** — Typer `CliRunner` suite for `interfaces/cli/main.py` (0 %).
+9. **adapter-fixtures** — recorded REST/WS payload fixtures for the
+   low-coverage adapters + ws reconnect + ratelimit unit tests.
+10. **minor-batch** — dynamic OpenAPI version, CI Sphinx job, local hygiene.
+
+## Leaf checklist
+
+- [ ] 01 stream-nocapability-zombies — fix/stream-nocapability-zombies — medium
+- [ ] 02 runs-stale-purge — fix/runs-stale-purge — medium
+- [ ] 03 stream-time-flush — fix/stream-time-flush — medium (depends on 01)
+- [ ] 04 http-client-lifetime — fix/http-client-lifetime — medium
+- [ ] 05 rate-limiter-fate — chore/rate-limiter-fate — high (depends on 04)
+- [ ] 06 prod-hardening — chore/prod-hardening — medium
+- [ ] 07 gap-metric-context — feat/gap-metric-context — medium
+- [ ] 08 cli-tests — chore/cli-tests — medium (parallel)
+- [ ] 09 adapter-fixtures — chore/adapter-fixtures — medium (parallel)
+- [ ] 10 minor-batch — chore/audit-minor-batch — low
+
+## Dependencies
+
+- 03 depends on 01 (same lines of `operations.stream()` — avoid conflicts).
+- 05 depends on 04 (limiter wiring sits on the corrected client lifetime).
+- Everything else is independent; 08 and 09 are test-only and may run in
+  parallel worktrees.
+
+## Done criteria
+
+- arthurserver runs.db: zero new zombie `running` rows after a simulated
+  no-capability stream job; existing ~350 zombies marked `stale` after one
+  daemon restart.
+- A quiet-pair trades stream shows data on disk within ~2× the flush
+  interval, and its run row reports non-zero `rows_written` after stop.
+- A 500-page backfill opens one HTTP pool, not 500 (log/metric evidence).
+- CLAUDE.md's transport description matches reality (RateLimiter wired or
+  gone).
+- Prod data syncs off-box on schedule; alert webhook fires on a forced
+  failure; unit has explicit `MemoryMax` + `TimeoutStopSec`.
+- Data UI no longer claims "85 % missing" for illiquid-but-complete pairs.
+- `interfaces/cli/main.py` coverage > 0 % → meaningful (target ≥ 70 %);
+  bitfinex/bitmex/coinbase adapters tested without network.

--- a/doc/dev/plans/audit-fixes/01-stream-nocapability-zombies.md
+++ b/doc/dev/plans/audit-fixes/01-stream-nocapability-zombies.md
@@ -1,0 +1,78 @@
+---
+plan: audit-fixes/01-stream-nocapability-zombies
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/stream-nocapability-zombies
+pr: ""
+---
+
+# B6 — stream `NoCapability` leaks zombie runs; supervisor retries forever
+
+## Goal
+
+A stream job whose adapter lacks the live capability must fail *cleanly*: no
+orphan `running` row in runs.db, and the supervising worker must stop instead
+of retrying a permanent error every 60 s. Confirmed in prod (~350 zombie rows
+from `stream:bitfinex:*:orderbook`).
+
+## Files to change
+
+- `dccd/application/operations.py` — in `stream()`, the
+  `adapter.capability_for(target.data_type, "ws", "live")` check (currently
+  ~line 421) runs *after* `runs_store.create_run(...)` (~line 384) and
+  *outside* the `try` → the row is inserted, `finish_run` never called.
+  Move the adapter lookup + capability check **before** `create_run`. The
+  three `isinstance` re-checks inside the `try` stay (they're already covered
+  by the failure path).
+- `dccd/application/scheduler.py` — `_StreamWorker._run_forever()`:
+  - catch `NoCapability` separately: log an error ("permanent, not
+    retrying"), emit `events.status("failed")` + an error log on the run
+    events, and `return` (worker stops; `is_running` becomes False).
+  - reset the backoff after a healthy run: record `time.monotonic()` before
+    `await stream(...)`; in the generic `except Exception` branch, if the
+    stream ran longer than e.g. 300 s before failing, reset `delay = 5.0`
+    before applying it (fixes "every restart waits 60 s after a few blips
+    over weeks").
+
+## Steps
+
+1. In `operations.stream()`, hoist `adapter = registry.get(...)` and the
+   `capability_for` check above the `runs_store.create_run` block, so
+   `NoCapability` propagates before any run row exists.
+2. In `_StreamWorker._run_forever`, import `NoCapability` from
+   `dccd.domain.errors`; add the dedicated except branch that abandons.
+3. Implement the backoff reset (healthy-duration threshold 300 s).
+4. Run `pytest`, `ruff check dccd/`, `mypy dccd/`.
+
+## Tests
+
+- `dccd/tests/v3/test_application.py` (or a new `test_scheduler_worker.py`):
+  - `stream()` with a registry whose adapter declares no live capability and
+    a real temp `RunsStore` → raises `NoCapability` AND `active_runs()` is
+    empty (regression for B6).
+  - `_StreamWorker` over a stub `stream` that raises `NoCapability` → after
+    `start()` + a short sleep, `is_running` is False and no unbounded retry
+    happened (count calls).
+  - Backoff reset: stub stream fails fast twice (delay grows), then runs
+    600 s (mock monotonic) and fails → next delay is 5 s again.
+
+## Verification on real data
+
+- Isolated store + config (`/tmp/dccd-b6`): add a stream job for a
+  combination with no WS capability (e.g. `bitfinex` orderbook, or bybit spot
+  trades history analogue for live), `dccd ui` it, wait 3 min: assert runs.db
+  contains **zero** `running` rows for that spec and the log shows a single
+  permanent-failure line, not one per minute.
+- Sanity: a valid stream (binance BTC/USDT trades) still starts, collects,
+  and stops cleanly.
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "Stream jobs without a live capability no longer leak
+  zombie `running` runs, and their supervisor stops retrying a permanent
+  error; stream restart backoff resets after a healthy period (#NN)"
+- ADR: permanent vs transient stream errors — supervisor semantics.
+- Status/roadmap: tick leaf in 00-plan; roadmap line stays until last leaf.

--- a/doc/dev/plans/audit-fixes/02-runs-stale-purge.md
+++ b/doc/dev/plans/audit-fixes/02-runs-stale-purge.md
@@ -1,0 +1,71 @@
+---
+plan: audit-fixes/02-runs-stale-purge
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/runs-stale-purge
+pr: ""
+---
+
+# B3 — purge orphaned `running` runs at daemon startup
+
+## Goal
+
+Runs left in state `running` after a daemon crash/SIGKILL currently pollute
+`active_runs()`, `dccd status` and the Dashboard forever (prod: ~350 rows).
+At daemon boot, mark them `stale` so the DB reflects reality.
+
+## Files to change
+
+- `dccd/storage/runs_sqlite.py` — new method
+  `RunsStore.mark_stale_running(self) -> int`:
+  `UPDATE runs SET state='stale', ended_at=<now ns>, error='orphaned by daemon restart' WHERE state='running'`,
+  return `rowcount`. Numpydoc docstring.
+- `dccd/interfaces/api/app.py` — call it once in the **lifespan startup**
+  (the daemon entry point used by both `dccd ui` and `dccd start`), log
+  "marked N orphaned runs stale" when N > 0.
+
+**Critical constraint**: the purge must run **only at daemon boot**, never
+from one-shot CLI commands (`dccd status`, `dccd backfill`, …) — a CLI call
+while a daemon is live would stale-out its legitimate active runs. So: do
+NOT put it in `service_factory.build_runs_store()`. Verify `dccd start`
+shares the FastAPI lifespan; if it has a separate boot path, call it there
+too (and only there).
+
+## Steps
+
+1. Add `mark_stale_running` to `RunsStore`.
+2. Call it in the API lifespan before the scheduler starts; check
+   `interfaces/cli/main.py` for any daemon boot path that bypasses
+   `create_app()` and cover it.
+3. Decide nothing about UI: `stale` rows simply stop appearing in
+   `active_runs()` (state filter is `WHERE state='running'`) and show as
+   `stale` in run history. Check the Logs/Dashboard templates don't choke on
+   the new state string (they render state as text/badge).
+4. `pytest`, `ruff`, `mypy`.
+
+## Tests
+
+- `dccd/tests/v3/test_storage.py` (or `test_application.py`): create 2
+  `running` + 1 `done` run in a temp `RunsStore`; `mark_stale_running()`
+  returns 2; `active_runs()` is empty; the rows have state `stale`,
+  non-null `ended_at`, and the orphan error message.
+- `dccd/tests/v3/test_api.py`: TestClient app boot over a runs DB seeded
+  with a `running` row → after startup, `/api/runs` shows it `stale`.
+
+## Verification on real data
+
+- Isolated store: start `dccd ui`, launch a long backfill, `kill -9` the
+  process mid-run; restart `dccd ui` → the interrupted run shows `stale` in
+  the Logs page and `dccd status` no longer lists it as active.
+- On arthurserver (after release lands there): one daemon restart clears the
+  ~350 historical zombies — note the count in the leaf report.
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "Runs orphaned in `running` state by a daemon crash
+  are marked `stale` at startup instead of polluting active runs forever (#NN)"
+- ADR: none — mechanical once the boot-only constraint is stated.
+- Status/roadmap: tick leaf in 00-plan.

--- a/doc/dev/plans/audit-fixes/03-stream-time-flush.md
+++ b/doc/dev/plans/audit-fixes/03-stream-time-flush.md
@@ -1,0 +1,65 @@
+---
+plan: audit-fixes/03-stream-time-flush
+kind: leaf
+status: planned
+complexity: medium
+depends: [01]
+parallel: false
+branch: fix/stream-time-flush
+pr: ""
+---
+
+# B2 — time-based flush for trades/OHLC streams + real `rows_written`
+
+## Goal
+
+Streams flush only every 1000 records: a quiet pair keeps hours of data in
+RAM — lost on crash, invisible to inventory/freshness. Flush on a time
+interval too. While touching every save site, count rows so stream runs stop
+reporting `rows_written=0`.
+
+## Files to change
+
+- `dccd/application/operations.py` — `stream()` only:
+  - module constant `_STREAM_FLUSH_INTERVAL_S = 60.0`.
+  - in the TRADES and OHLC loops, track `last_flush = time.monotonic()`;
+    flush when `len(batch) >= 1000` **or**
+    `batch and time.monotonic() - last_flush >= _STREAM_FLUSH_INTERVAL_S`;
+    update `last_flush` on every flush. (Note the check runs on record
+    arrival — that is fine: with zero records there is nothing in RAM, so
+    worst-case loss is bounded by the interval plus one inter-record gap.)
+  - accumulate `rows_written += n` from every `store.save(...)` return
+    (including the orderbook per-snapshot saves and the final flush) and
+    pass it to **both** `finish_run` calls (`cancelled` and `failed` paths
+    too — partial counts are still true counts).
+
+## Steps
+
+1. Refactor the two batched loops to a small local `maybe_flush()` closure
+   (count + time conditions) so the logic exists once.
+2. Thread the row counter through all finish paths.
+3. `pytest`, `ruff`, `mypy`.
+
+## Tests
+
+- `dccd/tests/v3/test_application.py`: a fake `TradesLive` adapter yielding
+  3 records then sleeping; with a mocked monotonic clock crossing the
+  interval, assert `store.save` was called before the 1000-record threshold.
+- Assert the finished run row's `rows_written` equals the records yielded
+  (stop via `stop_event` after N records).
+
+## Verification on real data
+
+- Isolated store: stream binance BTC/USDT trades for ~3 min, **without**
+  stopping it, and watch the dataset directory: the daily parquet must
+  appear/grow within ~2× the flush interval (audit baseline: nothing on disk
+  for 12 s+ until stop). Then stop; check the run row in runs.db reports a
+  `rows_written` matching `read()`'s row count for the window (± dedup).
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "Trades/OHLC streams flush to disk on a time interval
+  (60 s) as well as on batch size, bounding crash loss on quiet pairs; stream
+  runs now record their real `rows_written` (#NN)"
+- ADR: none — parameters follow the audit recommendation.
+- Status/roadmap: tick leaf in 00-plan.

--- a/doc/dev/plans/audit-fixes/04-http-client-lifetime.md
+++ b/doc/dev/plans/audit-fixes/04-http-client-lifetime.md
@@ -1,0 +1,75 @@
+---
+plan: audit-fixes/04-http-client-lifetime
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/http-client-lifetime
+pr: ""
+---
+
+# P1/B4 — one httpx pool per operation, honest `Client.__aexit__`
+
+## Goal
+
+Every `fetch_*_page` does `async with self._http:` and the ref-count
+(`_depth`) falls back to 0 between pages → a fresh `httpx.AsyncClient`
+(TCP pool + TLS handshake) **per page**; a 500-page backfill performs 500
+handshakes. Hold the client open for the whole operation. Also fix
+`Client.__aexit__` (currently `pass`) so the public API context manager
+keeps the pool alive across calls and closes it on exit, as its docstring
+already promises.
+
+## Files to change
+
+- `dccd/sources/base.py` (or wherever adapters expose their
+  `AsyncHTTPClient`) — expose a way to hold the transport open, e.g.
+  `adapter.http()` returning the `AsyncHTTPClient` (it is already an async
+  CM with ref-counting in `transport/http.py` `__aenter__`/`__aexit__`,
+  lines ~63–78).
+- `dccd/application/operations.py` — in `backfill()`, wrap the whole
+  paginated section in `async with <adapter's client>:` so `_depth` stays
+  ≥ 1 across pages; inner per-page `async with` become cheap ref-count
+  bumps. Same for the orderbook snapshot branch (single page — harmless).
+- `dccd/client.py` — `Client.__aenter__` enters the shared client(s) /
+  `__aexit__` exits them, so Python-API users get one pool per `async with
+  Client()` block. Audit found 2 prod runs failed with "Cannot send a
+  request, as the client has been closed" (3.3.x) — the ref-count must make
+  this impossible: add a concurrency test.
+
+## Steps
+
+1. Read `transport/http.py` fully; confirm the ref-count is asyncio-safe
+   (audit: it is, `test_transport.py` covers concurrency) and that holding
+   the context at operation level is the intended use.
+2. Wire the operation-level context in `backfill()` (and `stream()` is WS —
+   untouched).
+3. Fix `Client.__aenter__`/`__aexit__`; keep the lazy-open behavior for
+   non-context usage.
+4. `pytest`, `ruff`, `mypy`.
+
+## Tests
+
+- `dccd/tests/v3/test_transport.py`: instrument `AsyncHTTPClient` (count
+  `httpx.AsyncClient` constructions via monkeypatch) — a fake 5-page
+  paginated backfill constructs **one** client, not five.
+- Concurrent operations sharing one adapter still never see "client has
+  been closed" (overlapping `async with` blocks).
+- `Client` context: pool opened once on enter, closed on exit; reuse after
+  exit reopens cleanly.
+
+## Verification on real data
+
+- Isolated store: real backfill of ~10+ pages (e.g. coinbase 1h OHLC over a
+  long window — 300 candles/page) with httpx DEBUG logging or the
+  construction counter: exactly one pool for the operation, and the data on
+  disk matches the requested window (rows, bounds, no dup).
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "Paginated backfills reuse one HTTP connection pool
+  for the whole operation instead of opening a new TLS session per page;
+  `Client` context manager now actually manages the shared pool (#NN)"
+- ADR: none if the ref-count design holds; note one if semantics change.
+- Status/roadmap: tick leaf in 00-plan.

--- a/doc/dev/plans/audit-fixes/05-rate-limiter-fate.md
+++ b/doc/dev/plans/audit-fixes/05-rate-limiter-fate.md
@@ -1,0 +1,74 @@
+---
+plan: audit-fixes/05-rate-limiter-fate
+kind: leaf
+status: planned
+complexity: high
+depends: [04]
+parallel: false
+branch: chore/rate-limiter-fate
+pr: ""
+---
+
+# B5 — decide the RateLimiter's fate: wire it or delete it
+
+## Goal
+
+`transport/ratelimit.py` is exported but consumed nowhere; CLAUDE.md sells a
+"token-bucket per exchange" that does not run. Today the only throttle is
+reactive (429 + Retry-After in `http.py`), so a 50-job `run-all` hits every
+exchange at full speed. Decide — with an ADR — between (a) wiring the
+limiter into the outbound request path with sane per-exchange defaults, or
+(b) deleting the module and correcting the docs. This is a judgement leaf:
+investigate first, then implement the chosen option.
+
+## Files to change
+
+Option (a) — wire (the audit's lean, given `run-all` exists):
+- `dccd/transport/http.py` or `dccd/sources/base.py` — single choke point:
+  every adapter page fetch awaits `limiter.acquire(exchange)` before the
+  request. The limiter instance lives in `service_factory.build_registry()`
+  (one per process) so CLI/API/UI all inherit it.
+- defaults: conservative public-REST rates per exchange (binance ~10/s,
+  kraken ~1/s, coinbase ~3/s, others ~2/s — verify against current public
+  docs before committing numbers); overridable via `AppConfig` if trivial,
+  else hardcoded defaults + a follow-up roadmap line.
+- CLAUDE.md + `doc/dev/02-architecture` (if it exists): description matches.
+
+Option (b) — delete:
+- remove `dccd/transport/ratelimit.py` + export + its tests; fix CLAUDE.md
+  transport table; note in the ADR why reactive-only is acceptable.
+
+## Steps
+
+1. Re-read `transport/ratelimit.py`, `http.py` retry/429 handling, and how
+   adapters issue requests post-leaf-04 (the operation-level context).
+2. Check real 429 incidence on arthurserver logs (`ssh dccd-testbox`,
+   journalctl) — evidence for/against proactive limiting.
+3. Decide; write the ADR draft *first* (decision + why + rejected option).
+4. Implement the chosen option; keep the change surgical.
+5. `pytest`, `ruff`, `mypy`.
+
+## Tests
+
+- Option (a): unit test that two rapid `acquire("kraken")` calls space out
+  per the configured rate (mock clock), and an integration test that a
+  paginated fetch calls the limiter once per page.
+- Option (b): test suite simply stays green after removal; grep guards
+  nothing references `RateLimiter`.
+
+## Verification on real data
+
+- Option (a): isolated backfill against kraken (strictest public limits) of
+  20+ pages → zero 429 in logs and total duration consistent with the
+  configured rate. Then a small `run-all` style burst (3 concurrent
+  backfills, same exchange) → still no 429.
+- Option (b): n/a beyond the standard suite (document why in the report).
+
+## Closeout
+
+- CHANGELOG: option (a) `Added`: "Outbound token-bucket rate limiting per
+  exchange on all REST fetches (#NN)" / option (b) `Removed`: "Unwired
+  RateLimiter module; throttling remains reactive (429 + Retry-After) (#NN)"
+- ADR: **mandatory** — the decision and the evidence.
+- Status/roadmap: tick leaf in 00-plan; update CLAUDE.md transport row in
+  the same PR.

--- a/doc/dev/plans/audit-fixes/06-prod-hardening.md
+++ b/doc/dev/plans/audit-fixes/06-prod-hardening.md
@@ -1,0 +1,73 @@
+---
+plan: audit-fixes/06-prod-hardening
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: chore/prod-hardening
+pr: ""
+---
+
+# Prod — off-box backup, alert webhook, systemd limits on arthurserver
+
+## Goal
+
+Epic C shipped rclone sync but prod uses none of it: **the collected data is
+backed up nowhere**, the alert webhook is null (HealthMonitor alerts go into
+the void), and the systemd unit has no `MemoryMax`/`TimeoutStopSec` (62 s
+observed stop vs 90 s default before SIGKILL). Configure all three on
+arthurserver and align the repo's deploy templates/docs.
+
+**Needs user input before execution**: the rclone remote destination
+(provider + credentials) and the webhook target (ntfy/Discord/Slack/…).
+If unavailable when the leaf runs, do the repo-side template/doc work, apply
+the systemd limits, and report the two blocked items back instead of
+inventing endpoints.
+
+## Files to change
+
+- `deploy/dccd.service` — add `TimeoutStopSec=120` and a commented
+  `MemoryMax=` example (prod RSS observed ~830 MB; suggest 1.5G), short
+  comment on why.
+- `doc/source/how-to/deploy*` and `how-to/sync-remote*` — a "production
+  checklist" subsection: remote backup ON, webhook ON, memory/stop limits.
+- arthurserver (`ssh dccd-testbox`, ops — no repo diff): rclone remote in
+  the dccd config (`remotes:` + `sync_interval`), `alerts.webhook_url`,
+  systemd drop-in with the limits, `systemctl daemon-reload && restart`.
+
+## Steps
+
+1. Repo: service template + how-to edits (PR-able regardless of ops).
+2. Server: configure rclone remote (user-provided), run one manual sync
+   cycle, verify the coverage manifest lands on the remote.
+3. Server: set webhook, force a failure (e.g. temporary bogus job) or use
+   any test hook HealthMonitor offers, confirm delivery.
+4. Server: systemd drop-in (`TimeoutStopSec=120`, `MemoryMax=1.5G`),
+   restart, confirm clean stop < 120 s and steady RSS.
+5. `pytest` (repo side untouched logically, must stay green).
+
+## Tests
+
+- None beyond the suite (config/ops leaf). The how-to build must keep
+  Sphinx at 0 warnings (`cd doc && make html`).
+
+## Verification on real data
+
+- `rclone lsf <remote>` shows the synced tree growing after the scheduled
+  cycle; restore path: delete one local dataset dir on an **isolated copy**
+  (never prod data without backup-first) and confirm read-through restore.
+- Webhook: one delivered test alert visible in the receiving channel.
+- `systemctl show dccd | grep -E 'TimeoutStopSec|MemoryMax'` shows the
+  limits; journal shows a clean stop on restart.
+
+## Closeout
+
+- CHANGELOG (`Changed`): "Deploy template ships explicit
+  `TimeoutStopSec`/`MemoryMax` guidance; production checklist added to the
+  deploy/sync how-tos (#NN)"
+- ADR: none — ops + doc.
+- Status/roadmap: tick leaf; update `06-status.md` prod paragraph (backed
+  up off-box, alerts live).
+- Memory note: update `reference_test_server` memory (backup + webhook now
+  configured).

--- a/doc/dev/plans/audit-fixes/07-gap-metric-context.md
+++ b/doc/dev/plans/audit-fixes/07-gap-metric-context.md
@@ -1,0 +1,67 @@
+---
+plan: audit-fixes/07-gap-metric-context
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/gap-metric-context
+pr: ""
+---
+
+# UX — gap % must not call trade-less minutes "missing"
+
+## Goal
+
+`inventory()`'s OHLC gap detection (`expected_rows`/`missing_rows`,
+`storage/parquet.py` ~lines 430–465) divides elapsed time by the span:
+illiquid pairs on exchanges that emit no empty candles (bitfinex BTC-EUR 1m)
+show "85 % missing" when nothing is missing. Make the metric honest without
+breaking its real purpose (catching collection holes on liquid pairs —
+binance 1m showed 0 gaps over 44k bars).
+
+## Files to change
+
+- `dccd/storage/parquet.py` — keep the zero-extra-I/O constraint (footer
+  stats only). Cheap, honest option: also expose the **largest single gap**
+  (`max_gap_rows` derivable? footer stats give min/max/rowcount only — so
+  no; then the fix is presentational). Do NOT add per-file scans.
+- `dccd/interfaces/ui/templates/data.html` — rename the column/label from
+  "missing"/"gap %" to **"candle coverage"** with a tooltip: "Exchanges emit
+  no candle for minutes without trades — low coverage on quiet pairs is
+  normal, not data loss." Threshold styling (red dot) should key on
+  *exchange-relative* expectations if cheap, else drop the alarming color
+  below a documented floor.
+- `doc/source/` page documenting the inventory fields — same wording.
+
+## Steps
+
+1. Confirm with the footer-stats cache exactly what is computable for free;
+   if nothing structural is free, this is a presentation + naming fix (the
+   audit explicitly allows "or at least label it in the Data UI").
+2. Apply the rename + tooltip + de-alarming in `data.html` (and any API
+   field names left as-is for compatibility — UI label only).
+3. Sphinx page wording; `cd doc && make html` → 0 warnings.
+4. `pytest`, `ruff`; UI smoke (`doc/dev/ui_smoke.py`) against an isolated
+   `dccd ui`.
+
+## Tests
+
+- Existing storage tests stay green (no semantic change to the numbers).
+- If any computed field changes, `test_storage*.py` asserts the new shape.
+
+## Verification on real data
+
+- Isolated store: backfill a liquid pair (binance BTC/USDT 1m, a few days)
+  AND an illiquid one (bitfinex or kraken minor pair, 1m): the Data page
+  shows full coverage for the first and *non-alarming* coverage wording for
+  the second; a deliberately holed dataset (delete a middle file) still
+  surfaces visibly.
+
+## Closeout
+
+- CHANGELOG (`Changed`): "Data page presents OHLC completeness as 'candle
+  coverage' and explains trade-less minutes, instead of mislabeling quiet
+  pairs as missing data (#NN)"
+- ADR: short note — why presentational (footer-stats-only constraint).
+- Status/roadmap: tick leaf in 00-plan.

--- a/doc/dev/plans/audit-fixes/08-cli-tests.md
+++ b/doc/dev/plans/audit-fixes/08-cli-tests.md
@@ -1,0 +1,62 @@
+---
+plan: audit-fixes/08-cli-tests
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: chore/cli-tests
+pr: ""
+---
+
+# Tests — CLI suite (`interfaces/cli/main.py` is at 0 %)
+
+## Goal
+
+The Typer CLI (146 stmts) is tested nowhere; the audit's only dynamic check
+was manual. Add a `CliRunner`-based suite covering every command's happy
+path and the obvious failure modes, without network.
+
+## Files to change
+
+- `dccd/tests/v3/test_cli.py` (new) — `typer.testing.CliRunner` against
+  `dccd.interfaces.cli.main.app`.
+- Possibly tiny refactors in `interfaces/cli/main.py` ONLY if a command is
+  untestable as written (e.g. hardcoded paths) — keep them minimal and
+  behavior-preserving.
+
+## Steps
+
+1. Inventory the commands (`dccd --help` / reading `main.py`): expect
+   `validate`, `backfill`, `stream`, `read`/`status`, `inventory`, `ui`,
+   `start`, jobs-related, version.
+2. Fixtures: a tmp config YAML + tmp data dir; monkeypatch
+   `service_factory` builders to in-memory/tmp stores; stub the registry
+   with a fake adapter so `backfill` runs end-to-end offline (write real
+   rows through the real ParquetStore — the CLI→operation→store chain is
+   the point).
+3. Cover: exit codes (0 on success, non-zero on bad exchange/config),
+   `--help` for each command, `validate` on a bad YAML, `inventory` output
+   on a seeded store, `backfill` writing rows via the fake adapter.
+4. Do NOT spawn servers (`ui`/`start`): assert they're wired by checking
+   the command exists and bails correctly on a bad config (`--help` level),
+   not by binding ports.
+5. `pytest` (suite must stay < ~10 s), `ruff`, `mypy`.
+
+## Tests
+
+This leaf *is* tests. Target: `interfaces/cli/main.py` ≥ 70 % coverage
+(from 0 %), overall coverage strictly up.
+
+## Verification on real data
+
+- Not a data-path change. One manual sanity: `dccd backfill` real run
+  against binance on an isolated store still behaves identically (no CLI
+  refactor regression).
+
+## Closeout
+
+- CHANGELOG (`Added`): "CLI test suite (CliRunner) — commands covered
+  offline end-to-end (#NN)"
+- ADR: none — mechanical.
+- Status/roadmap: tick leaf; update test counts in `06-status.md`.

--- a/doc/dev/plans/audit-fixes/09-adapter-fixtures.md
+++ b/doc/dev/plans/audit-fixes/09-adapter-fixtures.md
@@ -1,0 +1,69 @@
+---
+plan: audit-fixes/09-adapter-fixtures
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: chore/adapter-fixtures
+pr: ""
+---
+
+# Tests — recorded payload fixtures for low-coverage adapters + transport units
+
+## Goal
+
+bitfinex (38 %), bitmex (39 %), coinbase (42 %), binance (50 %) parsing is
+only exercised by the 3 opt-in network tests — exchange format drift or a
+parsing regression ships silently. Record real REST/WS payloads as fixtures
+and test the parse paths offline. Also cover the two near-untested transport
+units: WS reconnect (49 %) and the token bucket (48 %).
+
+## Files to change
+
+- `dccd/tests/v3/fixtures/` (new) — JSON payload files, one per
+  exchange × endpoint (`bitfinex_ohlc_page.json`,
+  `bitfinex_ws_trade_msgs.json`, `bitmex_trades_page.json`,
+  `coinbase_candles_page.json`, `binance_klines_page.json`, …). Captured
+  from the live APIs **once, during this leaf**, with capture commands noted
+  in a fixtures README (so they can be re-recorded when drift is suspected).
+- `dccd/tests/v3/test_adapter_parsing.py` (new) — for each fixture: feed it
+  through the adapter's page-parse / WS-message-parse function and assert
+  record counts, ns timestamps, field mapping, ordering, and symbol
+  normalization (XBT→BTC for bitmex/kraken paths).
+- `dccd/tests/v3/test_transport.py` — add: `WebSocketBase.stream_raw()`
+  reconnects after a dropped connection (fake ws server or monkeypatched
+  `websockets.connect` yielding a failing then a working connection), with
+  exponential backoff observed; `ratelimit.py` token bucket spaces two
+  acquires (mock clock).
+
+## Steps
+
+1. Identify each adapter's parse seam (the function that turns a raw
+   payload into records). If parsing is inlined into the fetch coroutine,
+   extract a pure `_parse_*` helper — behavior-preserving, keeps domain
+   purity rules.
+2. Capture fixtures live (small pages, public endpoints, no keys) and
+   commit them with the capture commands in the README.
+3. Write the parsing tests; then the ws reconnect + ratelimit tests.
+4. `pytest` (no `network` mark on any new test), `ruff`, `mypy`.
+
+## Tests
+
+This leaf *is* tests. Target: bitfinex/bitmex/coinbase ≥ 65 % each,
+`transport/ws.py` and `ratelimit.py` ≥ 75 %.
+
+## Verification on real data
+
+- The fixture capture step itself is the real-data contact: each committed
+  fixture must be a verbatim live response (note capture date + URL in the
+  README). Cross-check one fixture per exchange against the corresponding
+  `pytest -m network` test to prove parser ↔ live agreement on capture day.
+
+## Closeout
+
+- CHANGELOG (`Added`): "Offline adapter parsing tests from recorded live
+  payloads; WS reconnect and rate-limiter unit tests (#NN)"
+- ADR: none — mechanical.
+- Status/roadmap: tick leaf; update coverage notes in `06-status.md`.
+- NB: if leaf 05 chose to delete the RateLimiter, drop that part here.

--- a/doc/dev/plans/audit-fixes/10-minor-batch.md
+++ b/doc/dev/plans/audit-fixes/10-minor-batch.md
@@ -1,0 +1,61 @@
+---
+plan: audit-fixes/10-minor-batch
+kind: leaf
+status: planned
+complexity: low
+depends: []
+parallel: false
+branch: chore/audit-minor-batch
+pr: ""
+---
+
+# Minor batch — dynamic OpenAPI version, CI Sphinx job, local hygiene
+
+## Goal
+
+Close the audit's mechanical leftovers in one small chore PR, plus two
+local-machine cleanups that need no PR.
+
+## Files to change
+
+- `dccd/interfaces/api/app.py` line ~232 — `FastAPI(title="dccd v3",
+  version="3.0.0", ...)` → use the package version
+  (`importlib.metadata.version("dccd")` or `dccd.__version__`), so /docs
+  stops claiming 3.0.0 forever.
+- `.github/workflows/` (the existing CI workflow) — add a docs job:
+  install `.[dev]` + docs deps, run `sphinx-build` and **fail on any
+  warning** (`-W` or grep, matching the repo's "0 warnings" rule). Keep it
+  a separate job so the test matrix is untouched.
+
+Local ops (no commit, run at closeout and report):
+- purge the 21 local branches already merged into develop
+  (`git branch --merged develop`, delete all but develop/master).
+- pyenv global 3.12.13: `pip uninstall dccd` (broken v2 ghost that shadows
+  the real install outside the project dir).
+- dccd_env: `pip install -e ".[dev]"` to refresh the stale 3.0.0 metadata.
+
+## Steps
+
+1. Version: single-line change + a test.
+2. CI: add the docs job; trigger it on the PR itself to prove it passes
+   (and that it *would* fail — locally verify `sphinx-build -W` catches an
+   injected warning, then revert the injection).
+3. Local ops; list what was deleted in the leaf report.
+4. `pytest`, `ruff`, `mypy`.
+
+## Tests
+
+- `dccd/tests/v3/test_api.py`: `app.version` (or `/openapi.json` `info.version`)
+  equals `importlib.metadata.version("dccd")` — never a hardcoded literal.
+
+## Verification on real data
+
+- n/a (no data path). CI run on the PR is the verification for the docs job.
+
+## Closeout
+
+- CHANGELOG (`Fixed`): "OpenAPI reports the real package version (#NN)";
+  (`Added`): "CI job enforcing the Sphinx 0-warning rule (#NN)"
+- ADR: none — mechanical.
+- Status/roadmap: tick leaf in 00-plan; this being the last leaf is fine —
+  whichever leaf closes last removes the Epic E roadmap section.


### PR DESCRIPTION
## Plan tree for Epic E — Audit 2026-06-10 fixes

Expands the new **Epic E** roadmap section (added in this PR) into a durable plan tree at `doc/dev/plans/audit-fixes/` — one global map + 10 leaves, one disposable PR each.

### Goal
Close the prioritized audit findings: two production-confirmed run-lifecycle bugs (B6 zombie runs, B3 orphaned `running` rows), bounded crash loss on quiet streams (B2), outbound HTTP discipline (P1 pool churn, B5 unwired RateLimiter), arthurserver hardening (off-box backup, alerts, systemd limits), an honest gap metric, the CLI/adapter test holes, and a mechanical batch.

### Leaf checklist
- [ ] 01 stream-nocapability-zombies — fix/stream-nocapability-zombies — medium
- [ ] 02 runs-stale-purge — fix/runs-stale-purge — medium
- [ ] 03 stream-time-flush — fix/stream-time-flush — medium (depends on 01)
- [ ] 04 http-client-lifetime — fix/http-client-lifetime — medium
- [ ] 05 rate-limiter-fate — chore/rate-limiter-fate — high (depends on 04)
- [ ] 06 prod-hardening — chore/prod-hardening — medium
- [ ] 07 gap-metric-context — feat/gap-metric-context — medium
- [ ] 08 cli-tests — chore/cli-tests — medium (parallel)
- [ ] 09 adapter-fixtures — chore/adapter-fixtures — medium (parallel)
- [ ] 10 minor-batch — chore/audit-minor-batch — low

Out of scope (parked): P2 append+compaction, P3 load() pruning, S1 /login rate-limit, run-all concurrency cap, B1 residual cancel races.