### PR TITLE
chore: release v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.5.0] - 2026-06-11
+
+### Added
+
 - Proactive per-exchange rate limiting on all REST fetches: the (previously
   unwired) token-bucket `RateLimiter` is now a process-wide singleton keyed
   by exchange, awaited before every outbound request — concurrent operations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.4.0"
+version = "3.5.0"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v3.5.0 — 2026-06-11

Freezes `[Unreleased]` (the full audit-fixes epic, PRs #126–#135) into `## [3.5.0]` and bumps `pyproject.toml` to 3.5.0.

### Added
- Proactive per-exchange rate limiting on all REST fetches (process-wide token bucket; verified live on Kraken, zero 429) (#130)
- CLI test suite — `interfaces/cli/main.py` 0 % → 97 % (#134)
- Offline adapter-parsing tests from 14 recorded live payloads + WS reconnect tests (adapters 67–77 %, `ws.py` 93 %) (#135)

### Changed
- Deploy template: explicit `TimeoutStopSec=120` + `MemoryMax` guidance; production checklist in the how-tos (#131)
- Data page: neutral "candle coverage" instead of misleading red "missing %" (#132)

### Fixed
- Real OpenAPI version + CI Sphinx `-W` docs gate (#133)
- Stream `NoCapability` zombie runs + permanent-error supervisor stop + backoff reset (#126)
- Crash-orphaned `running` runs marked `stale` at daemon boot (#127)
- Time-based stream flush (60 s) + real `rows_written` (#128)
- One HTTP pool per paginated operation; honest `Client` context manager (#129)

## Test plan
- [x] 459 tests green locally, coverage 89 %
- [x] ruff + mypy clean, Sphinx 0 warnings
- [ ] CI green