### PR TITLE
docs: record off-box backup live on arthurserver

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -75,11 +75,13 @@ ws-subscription-honesty):
   sync to stay above the floor, and **read-through restore** pulls a purged
   dataset back from the remote on read. **Epic C (tiered storage) is complete** —
   provisioning, restore and integrity are documented in
-  `doc/source/how-to/sync-remote.rst`. **Production caveat**: arthurserver has
-  **no rclone remote and no alert webhook configured yet** (pending the user's
-  choice of destination + webhook URL) — prod data is not backed up off-box.
-  The systemd unit limits are in place (`TimeoutStopSec=120`, `MemoryMax=1.5G`,
-  drop-in verified live 2026-06-11).
+  `doc/source/how-to/sync-remote.rst`. **Production (2026-06-11)**: off-box
+  backup is live — hourly rclone sync from arthurserver to the main PC over
+  Tailscale (sftp, service-owned key under `/var/lib/dccd` because
+  `ProtectHome=yes`; `.dccd/**` excluded — live SQLite WAL files can't be
+  copied consistently mid-write), first cycle verified `succeeded`. Systemd
+  limits in place (`TimeoutStopSec=120`, `MemoryMax=1.5G`). **Still pending:
+  the alert webhook** (`alerts.webhook_url` null — user undecided).
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -62,11 +62,11 @@ suites, OpenAPI version + CI docs gate. ADR journal has the rationale; see
 
 ## Prod ops — pending user input
 
-- [ ] **arthurserver: configure the rclone backup remote + alert webhook** —
-  everything else from the audit's prod hardening shipped (systemd limits
-  live, how-to checklist published); these two need the user's choice of
-  backup destination (provider + credentials) and webhook URL. Until then,
-  **prod data is not backed up off-box**.
+- [ ] **arthurserver: configure the alert webhook** — `alerts.webhook_url` is
+  still null (user undecided on the target; ntfy.sh recommended). Off-box
+  backup is **done** (2026-06-11): hourly rclone sync to the main PC over
+  Tailscale (`~/data/arthurserver/`, service-owned key, `.dccd/**` excluded —
+  live SQLite), first cycle verified `succeeded`.
 
 P2 (append+compaction writes) and P3 (filename-based pruning in `load()`)
 stay parked as perf ideas until load demands them (see the audit doc).


### PR DESCRIPTION
Roadmap + status update after configuring the production backup (2026-06-11): hourly rclone sync arthurserver → main PC over Tailscale, first cycle verified. Only the alert webhook remains pending user input.