### PR TITLE
docs: document stale run state, proactive rate limiting, and stream time-flush

### DIFF
--- a/doc/source/architecture.rst
+++ b/doc/source/architecture.rst
@@ -94,3 +94,6 @@ Data flow — a backfill
    windows for OHLC, by cursor for trades (draining the full requested window).
 4. Records are flushed in batches to ``ParquetStore``, deduplicated on the
    natural key per data type, with progress emitted on the ``EventBus``.
+   Live streams flush both on batch size (1000 records) **and** on a 60 s
+   interval, so even a quiet pair shows fresh data on disk and a crash can
+   only lose the last interval's worth of records.

--- a/doc/source/http-api.rst
+++ b/doc/source/http-api.rst
@@ -59,6 +59,9 @@ Backfill
    * - ``GET``
      - ``/api/backfill/{run_id}``
      - Poll a run: ``state``, ``rows_written``, ``progress`` (time-based), ``log_tail``.
+       States: ``running``, ``succeeded``, ``failed``, ``cancelled``, and
+       ``stale`` — a run orphaned in ``running`` by a daemon crash, marked at
+       the next daemon boot (its ``error`` reads "orphaned by daemon restart").
    * - ``DELETE``
      - ``/api/backfill/{run_id}``
      - Cancel a running backfill (cooperative — stops at the next page, keeps collected rows).

--- a/doc/source/reference/transport.rst
+++ b/doc/source/reference/transport.rst
@@ -38,5 +38,16 @@ WebSocket base
 Rate limiter
 ============
 
+Rate limiting is **proactive**: a process-wide limiter keyed by exchange is
+awaited before every outbound REST request, so concurrent operations on the
+same exchange (e.g. "Run all" over many jobs) share one bucket and stay under
+the exchange's published rate. Conservative per-exchange defaults are built in
+(e.g. Kraken 1 req/s, Coinbase 3 req/s); reactive ``429``/``Retry-After``
+handling in the HTTP client remains as a backstop. The HTTP connection pool is
+held open for the whole paginated operation — one TLS session per backfill,
+not one per page.
+
 .. autoclass:: dccd.transport.ratelimit.RateLimiter
    :members:
+
+.. autofunction:: dccd.transport.ratelimit.shared_limiter


### PR DESCRIPTION
Closes the three user-facing doc gaps left by the audit-fixes epic: the `stale` run state (#127) was undocumented; the transport reference now states the rate limiter is proactively wired per exchange with its defaults (#130/#129); the architecture data-flow notes the 60 s stream flush (#128). Sphinx builds with 0 warnings.