### PR TITLE
docs: prod ops complete (webhook live, server on v3.5.0)

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -80,8 +80,9 @@ ws-subscription-honesty):
   Tailscale (sftp, service-owned key under `/var/lib/dccd` because
   `ProtectHome=yes`; `.dccd/**` excluded — live SQLite WAL files can't be
   copied consistently mid-write), first cycle verified `succeeded`. Systemd
-  limits in place (`TimeoutStopSec=120`, `MemoryMax=1.5G`). **Still pending:
-  the alert webhook** (`alerts.webhook_url` null — user undecided).
+  limits in place (`TimeoutStopSec=120`, `MemoryMax=1.5G`). Alert webhook
+  live (ntfy.sh private topic, test delivered). Server upgraded to v3.5.0
+  on 2026-06-11; its first boot marked 491 crash-orphaned runs `stale`.
 
 ## Tooling & infra present in the repo
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -60,13 +60,10 @@ wired rate limiter, systemd limits, honest coverage metric, CLI + adapter test
 suites, OpenAPI version + CI docs gate. ADR journal has the rationale; see
 `06-status.md`._
 
-## Prod ops — pending user input
-
-- [ ] **arthurserver: configure the alert webhook** — `alerts.webhook_url` is
-  still null (user undecided on the target; ntfy.sh recommended). Off-box
-  backup is **done** (2026-06-11): hourly rclone sync to the main PC over
-  Tailscale (`~/data/arthurserver/`, service-owned key, `.dccd/**` excluded —
-  live SQLite), first cycle verified `succeeded`.
+_Prod ops: **complete** (2026-06-11). Off-box backup (hourly rclone sync to
+the main PC over Tailscale), ntfy alert webhook (test delivered), systemd
+limits, and the server upgraded to v3.5.0 — whose first boot marked 491
+orphaned runs `stale`. See `06-status.md`._
 
 P2 (append+compaction writes) and P3 (filename-based pruning in `load()`)
 stay parked as perf ideas until load demands them (see the audit doc).


### PR DESCRIPTION
Roadmap/status closeout: ntfy webhook configured and test-delivered, arthurserver upgraded to v3.5.0 (first boot purged 491 crash-orphaned runs to `stale` — B3 verified at production scale), off-box backup already live. The 'Prod ops — pending user input' roadmap section is resolved.