### PR TITLE
docs: plan audit-fixes-2026-06-12

### DIFF
--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -99,6 +99,25 @@ Small, well-scoped items surfaced while operating v3.5.0 in production.
 P2 (append+compaction writes) and P3 (filename-based pruning in `load()`)
 stay parked as perf ideas until load demands them (see the audit doc).
 
+## Audit fixes (2026-06-12)
+
+Two bugs found auditing the production collector on 2026-06-12. Plan tree:
+`doc/dev/plans/audit-fixes-2026-06-12/`.
+
+- [ ] **OKX OHLC loses one bar per pagination page** — `fetch_ohlc_page` passes
+  `before = start_ms`, but OKX `before`/`after` cursors are *exclusive*: the bar
+  exactly at each 100-bar window start is dropped (431 one-minute gaps per OKX
+  pair on the server, spaced exactly 100 min, from the deep backfill). Fix
+  `before = start_ms - 1` + boundary regression test; repair server data with a
+  re-backfill after deploy. One leaf.
+- [ ] **`dccd start` boot race marks live stream runs stale** — `cmd_start`
+  starts the scheduler (streams create their `running` rows) *before* the
+  FastAPI lifespan calls `mark_stale_running()`, which sweeps the legit rows to
+  `stale` ("orphaned by daemon restart") a second after creation; Dashboard
+  "Active now" never shows streams under `dccd start`. Sweep orphans in
+  `cmd_start` before `scheduler.start()`; skip the lifespan sweep when a
+  scheduler is injected. One leaf.
+
 ## Deferred — M3 (post-3.0)
 
 Larger axes intentionally parked until after the 3.0 release. Not started; do not

--- a/doc/dev/plans/audit-fixes-2026-06-12/00-plan.md
+++ b/doc/dev/plans/audit-fixes-2026-06-12/00-plan.md
@@ -1,0 +1,57 @@
+---
+plan: audit-fixes-2026-06-12
+kind: global
+status: planning
+roadmap: "## Audit fixes (2026-06-12)"
+release_on_done: true
+---
+
+# Audit fixes — 2026-06-12 production audit
+
+## Goal
+
+Fix the two bugs found auditing the production collector (arthurserver) on
+2026-06-12. Both are small, independent, and verified root-caused:
+
+1. **OKX OHLC loses one bar per pagination page.** `fetch_ohlc_page` passes
+   `before = start_ms`, but OKX v5 `before`/`after` cursors are **exclusive** —
+   the bar exactly at each pagination-window start is never returned. Observed on
+   the server: 431 one-minute gaps per OKX pair, spaced exactly 100 minutes
+   (= the 100-bar page), all created by the 2026-06-10 deep backfill. It also
+   explains why hourly OKX runs write 60 rows where Binance writes 61.
+2. **`dccd start` boot race marks live stream runs stale.** `cmd_start` calls
+   `scheduler.start()` (each stream worker creates its `running` row in runs.db)
+   *before* `uvicorn` triggers the FastAPI lifespan, which then calls
+   `RunsStore.mark_stale_running()` and sweeps those legit rows to `stale`
+   ("orphaned by daemon restart") one second after creation. Observed on the
+   server: zero `running` rows while 20 streams collect; Dashboard "Active now"
+   never shows streams under `dccd start`.
+
+## Decomposition
+
+1. **okx-ohlc-inclusive-window-start** — make the OKX OHLC window start
+   inclusive (`before = start_ms - 1`) + boundary regression test.
+2. **boot-orphan-sweep-order** — sweep orphaned runs in `cmd_start` *before*
+   `scheduler.start()`; skip the sweep in the lifespan when a scheduler is
+   injected.
+
+## Leaf checklist
+
+- [ ] 01 okx-ohlc-inclusive-window-start — fix/okx-ohlc-boundary-bar — medium
+- [ ] 02 boot-orphan-sweep-order — fix/boot-orphan-sweep — medium
+
+## Dependencies
+
+- None — 01 and 02 are independent (disjoint files).
+
+## Done criteria
+
+- Both leaf PRs merged into `develop`; `pytest` green; invariants intact.
+- Leaf 01 verified on real data: an isolated OKX 1m backfill spanning several
+  100-bar page boundaries lands with `missing_rows == 0`.
+- Leaf 02 verified live: a locally started `dccd start` daemon shows its stream
+  run rows in state `running` (not `stale`) while alive.
+- **Ops follow-up (post-release/deploy, not a repo leaf):** re-backfill the five
+  OKX pairs on arthurserver from 2026-05-11 so the 431-gap-per-pair history is
+  repaired (dedup makes this safe); confirm inventory `missing_rows == 0` and
+  that a daemon restart leaves 20 `running` stream rows.

--- a/doc/dev/plans/audit-fixes-2026-06-12/01-okx-ohlc-inclusive-window-start.md
+++ b/doc/dev/plans/audit-fixes-2026-06-12/01-okx-ohlc-inclusive-window-start.md
@@ -1,0 +1,78 @@
+---
+plan: audit-fixes-2026-06-12/01-okx-ohlc-inclusive-window-start
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/okx-ohlc-boundary-bar
+pr: ""
+---
+
+# OKX OHLC: make the pagination-window start inclusive
+
+## Goal
+
+OKX v5 `before`/`after` cursors are **exclusive** (`before`: records *newer than*
+ts; `after`: records *earlier than* ts). `fetch_ohlc_page` passes
+`before = start_ms`, so the bar exactly at every forward-pagination window start
+is silently dropped — one missing 1m bar per 100-bar page. Pass
+`before = start_ms - 1` so the requested window start is included.
+
+## Files to change
+
+- `dccd/sources/okx.py` — `OKX.fetch_ohlc_page` (~line 108): change
+  `"before": str(start_ns // 1_000_000)` to
+  `"before": str(start_ns // 1_000_000 - 1)`, with a one-line comment stating
+  that OKX `before`/`after` are exclusive and that without the `- 1` the bar at
+  every page boundary is lost. Do **not** touch `fetch_trades_page` — its
+  backward `after` cursor *relies* on exclusivity to not re-fetch the cursor row.
+- `dccd/tests/v3/test_sources.py` — new test class (see Tests).
+
+## Steps
+
+1. Apply the one-line param fix + comment in `fetch_ohlc_page`.
+2. Add the two tests below (stub the `self._http` context manager — an object
+   with `__aenter__`/`__aexit__` returning a recorder whose
+   `get(url, params)` captures `params` and returns canned OKX
+   `{"code":"0","data":[...]}` payloads).
+3. Run `pytest` (full suite) and `ruff check dccd/`.
+
+## Tests
+
+`dccd/tests/v3/test_sources.py`, new class `TestOKXOHLCWindowBoundary`:
+
+- `test_before_param_is_exclusive_adjusted` — call
+  `fetch_ohlc_page(Symbol("BTC","USDT"), 60, start_ns, end_ns, 100)` against the
+  recording stub; assert `params["before"] == str(start_ns // 1_000_000 - 1)`
+  and `params["after"] == str(end_ns // 1_000_000)`.
+- `test_no_bar_lost_at_page_boundary` — the regression guard. Fake `get`
+  emulates OKX exclusive semantics: from a synthetic continuous 1m series,
+  return (newest-first, max 100) the bars with
+  `before_ms < ts_ms < after_ms` — both bounds **strictly** exclusive. Drive
+  `paginate_ohlc` (via a closure over the adapter, per the paginator contract)
+  across a window of ≥ 150 minutes so at least one 100-bar page boundary is
+  crossed; assert the collected timestamps are exactly every minute of the
+  requested `[start, end]` window — no hole at the boundary, no duplicate.
+
+## Verification on real data
+
+`data-e2e` discipline, isolated store (`/tmp`), live OKX REST:
+
+- Run a real `backfill` of `okx BTC/USDT ohlc 1m` over a fixed ≥ 12 h window
+  (≥ 7 page boundaries).
+- Read the Parquet back: assert `rows == expected_rows` for the window
+  (i.e. inventory gap detection reports `missing_rows == 0`) and that the
+  previously-lost boundary minutes (`start + k·100min`) are present.
+
+## Closeout
+
+- CHANGELOG `Fixed`: "OKX OHLC pagination silently dropped the bar at every
+  100-bar page boundary — OKX `before`/`after` cursors are exclusive; the
+  window start is now passed as `start − 1 ms` so it is inclusive (#NN)"
+- ADR: none — mechanical off-by-one; the exclusivity note lives in the code
+  comment and the regression test.
+- Status/roadmap: remove the OKX bullet from `## Audit fixes (2026-06-12)` in
+  `doc/dev/07-roadmap.md`; note in `06-status.md` that arthurserver's OKX gaps
+  need the post-deploy re-backfill (ops step tracked in the epic's
+  `00-plan.md` Done criteria).

--- a/doc/dev/plans/audit-fixes-2026-06-12/02-boot-orphan-sweep-order.md
+++ b/doc/dev/plans/audit-fixes-2026-06-12/02-boot-orphan-sweep-order.md
@@ -1,0 +1,90 @@
+---
+plan: audit-fixes-2026-06-12/02-boot-orphan-sweep-order
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/boot-orphan-sweep
+pr: ""
+---
+
+# Sweep orphaned runs before the scheduler starts, not after
+
+## Goal
+
+Under `dccd start`, `cmd_start` awaits `scheduler.start()` (stream workers create
+their `running` rows in runs.db) before `uvicorn` triggers the FastAPI lifespan,
+which then calls `mark_stale_running()` and sweeps those legitimate rows to
+`stale` ("orphaned by daemon restart"). Move the sweep to `cmd_start` *before*
+the scheduler starts, and skip it in the lifespan when a scheduler is injected —
+exactly the misuse the `mark_stale_running` docstring warns about.
+
+## Files to change
+
+- `dccd/interfaces/cli/main.py` — `cmd_start`: immediately after
+  `runs_store = build_runs_store(...)`, call
+  `stale = runs_store.mark_stale_running()` and `typer.echo` a
+  "marked N orphaned run(s) stale (daemon restarted)" line when `stale > 0`.
+- `dccd/interfaces/api/app.py` — lifespan (~line 197): guard the existing
+  `mark_stale_running()` call with `if scheduler is None:` (standalone
+  `dccd ui` keeps the sweep); update the comment to say the `dccd start` path
+  sweeps in `cmd_start` *before* starting the scheduler, because sweeping here
+  would stale-out the stream runs the scheduler just created.
+- `dccd/storage/runs_sqlite.py` — `mark_stale_running` docstring Notes: the
+  call site is "the daemon boot path, before any new runs are started
+  (`cmd_start` for `dccd start`; the FastAPI lifespan for standalone
+  `dccd ui`)".
+- Tests — see below.
+
+## Steps
+
+1. Add the sweep + echo to `cmd_start` (before `Scheduler(...)`/
+   `scheduler.start()`; right after `build_runs_store` is the natural spot).
+2. Guard the lifespan call with `if scheduler is None:` and fix the comment.
+3. Update the `mark_stale_running` docstring Notes.
+4. Add the three tests; run `pytest` and `ruff check dccd/`.
+
+## Tests
+
+- `dccd/tests/v3/test_api.py` —
+  `test_lifespan_skips_orphan_sweep_when_scheduler_injected`: point
+  `cfg.settings.data_path` at `tmp_path`, pre-create
+  `RunsStore(tmp_path/".dccd"/"runs.db")` with one row left in `running`;
+  `create_app(config=cfg, scheduler=<Scheduler instance>)`; entering
+  `TestClient` must leave the row in state `running`.
+- `dccd/tests/v3/test_api.py` —
+  `test_lifespan_sweeps_orphans_standalone`: same setup with
+  `create_app(config=cfg)` (no scheduler); entering `TestClient` must
+  transition the row to `stale` (add only if no existing test already covers
+  the standalone sweep).
+- `dccd/tests/v3/test_cli.py` — `test_start_sweeps_orphans_before_scheduler`:
+  reuse the existing `cmd_start` wiring-test pattern
+  (`test_stream_jobs_present_starts_scheduler`, ~line 441): monkeypatch
+  `uvicorn.Server.serve` to return immediately, record call order of
+  `RunsStore.mark_stale_running` vs `Scheduler.start` (monkeypatched
+  recorders appending to one shared list); assert the sweep is called and
+  precedes `Scheduler.start`.
+
+## Verification on real data
+
+- Isolated config (`/tmp` store, free port) with one real stream job
+  (e.g. `binance BTC/USDT trades`); launch `dccd start`, wait ~15 s, query
+  runs.db: the stream's newest run row must be in state `running` with
+  `error IS NULL` while the daemon is alive (before the fix it is `stale` /
+  "orphaned by daemon restart" within a second of boot). Stop the daemon.
+- Restart the daemon once and repeat the check — the *old* row goes `stale`,
+  the *new* one stays `running`.
+
+## Closeout
+
+- CHANGELOG `Fixed`: "`dccd start` marked its own just-started stream runs
+  `stale` at boot (the orphan sweep ran in the FastAPI lifespan *after* the
+  scheduler had started); the sweep now runs in `cmd_start` before the
+  scheduler, and the lifespan only sweeps in standalone `dccd ui` (#NN)"
+- ADR: none — ordering fix; the constraint is recorded in the
+  `mark_stale_running` docstring.
+- Status/roadmap: remove the boot-race bullet from
+  `## Audit fixes (2026-06-12)` in `doc/dev/07-roadmap.md`; one line in
+  `06-status.md` (Dashboard "Active now" shows streams again under
+  `dccd start`).


### PR DESCRIPTION
Plan tree for the two bugs found auditing the production collector on 2026-06-12, plus their roadmap entries (new section **Audit fixes (2026-06-12)**).

## Goal

1. **OKX OHLC loses one bar per pagination page** — OKX `before`/`after` cursors are exclusive; `fetch_ohlc_page` passes `before = start_ms`, dropping the bar at every 100-bar window start (431 one-minute gaps per OKX pair on the server, spaced exactly 100 min).
2. **`dccd start` boot race marks live stream runs stale** — `cmd_start` starts the scheduler before the FastAPI lifespan runs `mark_stale_running()`, which sweeps the just-created `running` stream rows to `stale`; Dashboard "Active now" never shows streams.

## Leaf checklist

- [ ] 01 okx-ohlc-inclusive-window-start — fix/okx-ohlc-boundary-bar — medium
- [ ] 02 boot-orphan-sweep-order — fix/boot-orphan-sweep — medium

Leaves are independent (disjoint files). Post-deploy ops follow-up (OKX re-backfill on arthurserver) is tracked in the epic's Done criteria.