### PR TITLE
chore: release v3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+## [3.5.1] - 2026-06-12
+
+### Fixed
+
 - `dccd start` marked its own just-started stream runs `stale` at boot: the
   orphan sweep (`mark_stale_running`) ran in the FastAPI lifespan *after*
   `cmd_start` had already started the scheduler's stream workers, so their
@@ -28,10 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test drives the paginator across a page boundary under faithful exclusive
   semantics. Verified live: a 12 h OKX 1m backfill lands with 0 gaps and
   all 7 boundary bars present. (#144)
-
-### Deprecated
-
-### Removed
 
 ## [3.5.0] - 2026-06-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.5.0"
+version = "3.5.1"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## [3.5.1] - 2026-06-12

### Fixed

- `dccd start` marked its own just-started stream runs `stale` at boot: the orphan sweep (`mark_stale_running`) ran in the FastAPI lifespan *after* `cmd_start` had already started the scheduler's stream workers, so their fresh `running` rows were swept as "orphaned by daemon restart" and the Dashboard "Active now" never showed streams. The sweep now runs in `cmd_start` before the scheduler starts; the lifespan only sweeps in standalone `dccd ui`. (#145)
- OKX OHLC pagination silently dropped the bar at every 100-bar page boundary: OKX `before`/`after` cursors are exclusive, so passing `before=start_ms` excluded the bar exactly at each window start (431 one-minute gaps per OKX pair in production). `fetch_ohlc_page` now sends `before=start_ms-1`. (#144)

## Test plan
- [x] Both fixes verified on real data before merge (see #144 / #145)
- [ ] CI green