### PR TITLE
docs: purge × sync data-loss risk + canonical-store architecture note

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -33,6 +33,17 @@ re-backfill — 46 528/46 528 bars, `missing_rows == 0` on all five pairs — an
 the boot orphan-sweep fix verified live, 20 stream runs `running` after
 restart)_
 
+**Data architecture (2026-06-12): the production collector is the canonical
+store.** The full deep history (OHLC 1m back to 2020, ~2 GB) was seeded onto
+the server (one-time `rclone copy` + a daemon-paused dedup merge of the
+colliding year files); the server is now the *single writer* of one continuous
+2020→present store (57 datasets), and the existing hourly mirror gives the
+main PC a complete off-box copy with no manual reconciliation. Legacy-only
+datasets (coinbase/bybit USDT pairs, early-June trades/order-book test
+captures) live on as static archive datasets. Caveat: the purge × destructive
+sync interaction is now a data-loss risk if `min_free_gb` is ever enabled —
+see the roadmap entry; purge stays off until fixed.
+
 ## Done & working (recent) — Epic D, performance & robustness (2026-06-10)
 
 A production audit (arthurserver, 50 jobs) found the daemon at 97.7 % CPU and

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -96,6 +96,19 @@ Small, well-scoped items surfaced while operating v3.5.0 in production.
   replicate a collector (e.g. arthurserver's 50 jobs) in one command. One
   leaf.
 
+- [ ] **Free-space purge can destroy the only copy (purge × destructive sync)**
+  — `RemoteStorage.sync_one` runs `rclone sync` (a *mirror*: it deletes remote
+  files absent locally), while the Epic C free-space purge deletes old
+  already-synced *local* files expecting the remote to keep them for
+  read-through restore. Purge a file, and the next hourly sync deletes it from
+  the remote too — the data is gone. Latent today (`min_free_gb: 0.0` in prod,
+  purge off) but armed the moment purge is enabled — and worse now that the
+  production store carries the full 2020→present history. Fix: make the
+  off-box copy non-destructive for purged files (`rclone copy`, or
+  `sync --backup-dir`, or exclude purge-tracked paths from deletion) + a test
+  that proves purge→sync→restore round-trips. One leaf. **Blocks ever setting
+  `min_free_gb > 0`.**
+
 P2 (append+compaction writes) and P3 (filename-based pruning in `load()`)
 stay parked as perf ideas until load demands them (see the audit doc).
 


### PR DESCRIPTION
## Summary
- **Roadmap (hardening backlog)**: `RemoteStorage.sync_one` uses `rclone sync` (destructive mirror) while the Epic C free-space purge expects the remote to retain purged local files for read-through restore — enabling `min_free_gb` would let the next hourly sync delete the only copy. Latent (`min_free_gb: 0.0` in prod) but must be fixed before purge is ever enabled. One leaf.
- **Status**: the production collector now holds the full 2020→present history (one-time seed of the 2 GB local archive + dedup merge of colliding year files) and is the single writer / canonical store; the hourly mirror gives the PC a complete copy with no manual reconciliation.

Docs only.