### PR TITLE
docs: plan hardening-backlog-2026-06

### DIFF
--- a/doc/dev/plans/hardening-backlog-2026-06/00-plan.md
+++ b/doc/dev/plans/hardening-backlog-2026-06/00-plan.md
@@ -1,0 +1,53 @@
+---
+plan: hardening-backlog-2026-06
+kind: global
+status: planning
+roadmap: "## Hardening backlog (post-audit follow-ups, 2026-06-11)"
+release_on_done: true
+---
+
+# Hardening backlog — purge×sync fix + small prod follow-ups
+
+## Goal
+
+Clear the bug-shaped items of the roadmap's **Hardening backlog**: the
+purge × destructive-sync data-loss risk (now critical — the production server
+carries the full 2020→present history and its hourly `rclone sync` would
+delete purged files from the only backup), the duplicate manual-run guard,
+runs.db retention, and ntfy-friendly alert formatting. The fifth backlog item
+(**config export/load**) is a feature, not a bug — it stays on the roadmap for
+a later epic.
+
+## Decomposition
+
+1. **remote-copy-not-sync** — make the off-box copy non-destructive
+   (`rclone copy`), so purged local files survive on the remote for
+   read-through restore. Unblocks `min_free_gb > 0`.
+2. **duplicate-run-guard** — manual backfill triggers return the existing
+   `run_id` instead of starting a concurrent duplicate for the same spec.
+3. **runs-db-retention** — boot-time deletion of old terminal runs
+   (configurable, default 90 days, `failed` kept) + `VACUUM`.
+4. **ntfy-alert-format** — plain-text alert body (+ `X-Title`/`X-Priority`)
+   for ntfy-style endpoints; JSON `{"text": …}` kept for Slack.
+
+## Leaf checklist
+
+- [ ] 01 remote-copy-not-sync — fix/remote-copy-not-sync — medium
+- [ ] 02 duplicate-run-guard — fix/duplicate-run-guard — medium
+- [ ] 03 runs-db-retention — feat/runs-db-retention — medium
+- [ ] 04 ntfy-alert-format — fix/ntfy-alert-format — medium
+
+## Dependencies
+
+- None — all four leaves touch disjoint files and may be executed in any
+  order; 01 first because it is the standing data-loss risk.
+
+## Done criteria
+
+- All four leaf PRs merged into `develop`; `pytest` green; invariants intact.
+- Leaf 01 proven by a purge→sync→restore round-trip test (and a live check
+  that a file deleted locally is *not* deleted from a real rclone remote).
+- The roadmap's Hardening backlog section reduced to the single
+  **config export/load** feature item.
+- `/release` suggested when the checklist is fully ticked (the purge fix
+  should reach the production server promptly).

--- a/doc/dev/plans/hardening-backlog-2026-06/01-remote-copy-not-sync.md
+++ b/doc/dev/plans/hardening-backlog-2026-06/01-remote-copy-not-sync.md
@@ -1,0 +1,82 @@
+---
+plan: hardening-backlog-2026-06/01-remote-copy-not-sync
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/remote-copy-not-sync
+pr: ""
+---
+
+# Off-box copy must be non-destructive (purge × sync data loss)
+
+## Goal
+
+`RemoteStorage.sync_one` runs `rclone sync` — a *mirror* that deletes remote
+files absent locally — while `purge_to_free_space` deletes old already-synced
+local files expecting the remote to keep them for read-through restore
+(`RemoteStorage.restore`). Purge a file and the next hourly sync deletes the
+only remaining copy. Switch the upload to `rclone copy` (never deletes on the
+remote): local = hot tier, remote = complete archive. This is the tiered
+semantic Epic C intended, and it unblocks ever setting `min_free_gb > 0`.
+
+## Files to change
+
+- `dccd/storage/remote.py` — `sync_one`: `["rclone", "sync", …]` →
+  `["rclone", "copy", …]`. Update the module/class/method docstrings: the
+  remote is an *archive superset* of the local store, files are never deleted
+  remotely (deliberate — restore depends on it; remote cleanup is a manual
+  operation).
+- `dccd/tests/v3/test_remote_sync.py` — adjust assertions that expect the
+  `sync` verb; add the round-trip regression test (below).
+- `doc/source/how-to/sync-remote.rst` — wherever it describes mirror
+  semantics, state archive-superset semantics instead (grep for "sync"/
+  "mirror"/"deleted" and align; keep edits surgical).
+
+## Steps
+
+1. Change the rclone verb in `sync_one` and rewrite the touched docstrings.
+2. Fix existing tests that assert the command line (they monkeypatch
+   `subprocess.run` — check `test_remote_sync.py` for the pattern).
+3. Add `test_purge_then_sync_preserves_remote_copy` (below).
+4. `pytest` + `ruff check dccd/` until green.
+
+## Tests
+
+- `dccd/tests/v3/test_remote_sync.py::test_sync_one_uses_copy_verb` — the
+  subprocess command starts `rclone copy` (not `sync`).
+- `test_purge_then_sync_preserves_remote_copy` — the round-trip guard, all
+  local with a directory standing in for the remote: (a) store dir with two
+  parquet files, "remote" dir seeded with both (simulate a completed sync);
+  (b) `purge_to_free_space` with a `free_fn` forcing the deletion of the
+  oldest file; (c) run `sync_one` with `subprocess.run` replaced by a fake
+  that *applies* the rclone verb semantics to the dirs (copy = add/overwrite
+  only; sync = add/overwrite + delete extraneous) — with `copy` the purged
+  file must still exist on the "remote" afterwards, and `restore()` (same
+  fake, copy semantics) must bring it back locally. The fake's
+  sync-vs-copy behaviour is what would have caught the original bug.
+
+## Verification on real data
+
+- On a throwaway local rclone remote (e.g. `rclone config create tmploc
+  local` pointing at a /tmp dir — no network needed): create a small store,
+  `sync_all` it, delete one local parquet (simulating purge), `sync_all`
+  again, and verify the file **still exists** under the remote path; then
+  `restore()` it and verify content equality with the original. Run via the
+  repo venv against the real rclone binary.
+
+## Closeout
+
+- CHANGELOG `Fixed`: "off-box sync no longer mirrors deletions: `rclone
+  copy` replaces `rclone sync`, so locally purged files survive on the
+  remote for read-through restore — enabling `min_free_gb` no longer risks
+  deleting the only copy (#NN)"
+- ADR: yes — "Remote is an archive superset, not a mirror": choice
+  (`rclone copy`), why (purge+restore contract; full history now lives on
+  the production store), rejected alternatives (`sync --backup-dir`:
+  restores need a second path lookup; purge-aware exclude lists: stateful
+  and fragile). Note the accepted trade-off: deleting data from the remote
+  becomes a manual operation.
+- Status/roadmap: remove the purge×sync roadmap bullet (added 2026-06-12);
+  drop the "purge stays off until fixed" caveat from `06-status.md`.

--- a/doc/dev/plans/hardening-backlog-2026-06/02-duplicate-run-guard.md
+++ b/doc/dev/plans/hardening-backlog-2026-06/02-duplicate-run-guard.md
@@ -1,0 +1,85 @@
+---
+plan: hardening-backlog-2026-06/02-duplicate-run-guard
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/duplicate-run-guard
+pr: ""
+---
+
+# Manual triggers must not start duplicate concurrent runs
+
+## Goal
+
+`POST /api/backfill`, `/api/jobs/run` and `/api/jobs/run-all` happily start a
+second run for a spec that is already being backfilled. Benign for data
+(store locks + dedup; shared rate limiter) but it wastes exchange requests
+and confuses runs/progress. Make the trigger idempotent: when
+`active_runs()` already holds a run for the same spec id, return the
+existing `run_id` (HTTP 200, `status: "already-running"`) instead of
+starting a new one.
+
+## Files to change
+
+- `dccd/interfaces/api/app.py` — small helper near the endpoints, e.g.
+  `_active_run_for(request, spec_id) -> str | None`, wrapping
+  `await asyncio.to_thread(_runs(request).active_runs)` and returning the
+  `run_id` of the first row whose `spec_id` matches. Use it in:
+  - `start_backfill` (`POST /api/backfill`): after building `spec`, if an
+    active run exists → `{"run_id": <existing>, "status": "already-running"}`.
+  - `run_job_now` (`POST /api/jobs/run`): same check before
+    `_run_backfill_tracked` → add `"job_id"` to the response as today.
+  - `run_all_backfill_jobs` (`POST /api/jobs/run-all`): skip specs with an
+    active run; report them in a separate `"already_running"` list
+    (`[{run_id, job_id}, …]`) alongside the started ones, and count only the
+    actually-started in `"started"`.
+- `dccd/tests/v3/test_api.py` — see Tests.
+
+## Steps
+
+1. Add the helper + the three call sites (keep the responses backward
+   compatible: same keys as today plus the new `status`/`already_running`
+   fields).
+2. Tests below; `pytest` + `ruff check dccd/`.
+
+## Tests
+
+`dccd/tests/v3/test_api.py` (follow the existing TestClient + tmp data_path
+patterns; an "active" run = `runs_store.create_run(...)` without finishing,
+with `spec_id` equal to what `JobSpec.make_id("backfill", target)` yields for
+the request):
+
+- `test_backfill_duplicate_returns_existing_run` — pre-create a `running`
+  row for the spec id of the request; `POST /api/backfill` → 200,
+  `status == "already-running"`, `run_id` equals the pre-created one, and no
+  new run row was added.
+- `test_jobs_run_duplicate_returns_existing_run` — same through
+  `POST /api/jobs/run` with a configured job.
+- `test_run_all_skips_active_jobs` — two configured backfill jobs, one with
+  an active run: `POST /api/jobs/run-all` starts only the other
+  (`started == 1`) and lists the busy one under `already_running`.
+
+## Verification on real data
+
+- Isolated store + a real `dccd ui`/TestClient app wired to a slow real
+  backfill is overkill here; instead verify against the live server *after
+  deploy is not required*: locally run the API (TestClient) with a fake
+  adapter whose `fetch_ohlc_page` sleeps, `POST /api/backfill` twice for the
+  same spec, and confirm the second response returns the first `run_id`
+  while runs.db contains exactly one `running` row for the spec. (This is
+  an API-behaviour leaf, not a data-path leaf — the runs.db assertion *is*
+  the on-disk verification.)
+
+## Closeout
+
+- CHANGELOG `Fixed`: "manual backfill triggers (`POST /api/backfill`,
+  `/api/jobs/run`, `/api/jobs/run-all`) are idempotent: a spec already being
+  backfilled returns the existing `run_id` (`status: already-running`) /
+  is skipped by run-all, instead of starting a duplicate concurrent run
+  (#NN)"
+- ADR: none — behaviour choice is recorded in the roadmap line and the
+  response contract; mention "return existing id (not 409)" in the PR body.
+- Status/roadmap: remove the duplicate-run-guard bullet from the Hardening
+  backlog.

--- a/doc/dev/plans/hardening-backlog-2026-06/03-runs-db-retention.md
+++ b/doc/dev/plans/hardening-backlog-2026-06/03-runs-db-retention.md
@@ -1,0 +1,82 @@
+---
+plan: hardening-backlog-2026-06/03-runs-db-retention
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/runs-db-retention
+pr: ""
+---
+
+# runs.db boot-time retention
+
+## Goal
+
+The run history is append-only with no purge: ~800 runs/day in production ≈
+180 MB/year, unbounded. Add a boot-time retention sweep: delete terminal
+non-failed runs (`succeeded`/`stale`/`cancelled`) older than a configurable
+number of days (default 90; `failed` rows are kept as the long-term error
+journal), then `VACUUM`. Runs on the same boot paths as
+`mark_stale_running` — after it, so freshly-staled orphans age normally.
+
+## Files to change
+
+- `dccd/storage/runs_sqlite.py` — new method
+  `prune_old_runs(retention_days: int) -> int`: no-op returning 0 when
+  `retention_days <= 0`; else
+  `DELETE FROM runs WHERE state IN ('succeeded','stale','cancelled') AND
+  started_at < now_ns - days*86400*1e9`, then `VACUUM` (only when rows were
+  deleted), return the deleted count. numpydoc docstring mirroring
+  `mark_stale_running`'s (call sites: daemon boot, after the orphan sweep).
+- `dccd/application/config.py` — `SettingsConfig.runs_retention_days: int = 90`
+  with a `>= 0` validator (0 disables), documented in the class docstring.
+- `dccd/interfaces/cli/main.py` — `cmd_start`: after `mark_stale_running()`,
+  call `runs_store.prune_old_runs(cfg.settings.runs_retention_days)` and
+  `typer.echo` the count when > 0.
+- `dccd/interfaces/api/app.py` — lifespan, inside the existing
+  `if scheduler is None:` boot block: same call after `mark_stale_running()`,
+  `logger.info` the count when > 0.
+- Tests — see below.
+
+## Steps
+
+1. Implement `prune_old_runs` + the settings field (+ validator).
+2. Wire both boot paths (`cmd_start`, standalone lifespan) after the orphan
+   sweep.
+3. Tests; `pytest` + `ruff check dccd/`.
+
+## Tests
+
+- `dccd/tests/v3/test_storage.py` — `test_prune_old_runs`: rows older than
+  the cutoff in each terminal state + one old `failed` + one recent
+  `succeeded`; prune(90) deletes exactly the old terminal non-failed rows,
+  keeps old `failed` and everything recent; returns the count.
+  `test_prune_old_runs_disabled`: `prune_old_runs(0)` deletes nothing.
+- `dccd/tests/v3/test_api.py` — standalone lifespan prunes: pre-create an
+  old `succeeded` row (set `started_at` ~100 days back) in a tmp store,
+  enter `TestClient(create_app(config=cfg))`, row gone; with
+  `cfg.settings.runs_retention_days = 0`, row survives.
+- `dccd/tests/v3/test_cli.py` — extend the boot-order test pattern: under
+  `cmd_start`, `prune_old_runs` is called after `mark_stale_running` and
+  before `Scheduler.start` (same recorder-list technique as
+  `test_start_sweeps_orphans_before_scheduler`).
+
+## Verification on real data
+
+- On a copy of the **production runs.db** (scp from the server to /tmp —
+  read-only source, never mutate the live file): run `prune_old_runs(90)`
+  via the repo venv, then assert (a) every remaining non-failed terminal row
+  is younger than 90 days, (b) `failed` rows are all still there (compare
+  counts before/after), (c) the file shrank or stayed equal after VACUUM,
+  (d) `list_runs`/`active_runs` still work on the pruned DB.
+
+## Closeout
+
+- CHANGELOG `Added`: "boot-time runs.db retention
+  (`settings.runs_retention_days`, default 90, `0` disables): terminal
+  non-failed runs older than the window are deleted and the DB VACUUMed at
+  daemon start; `failed` runs are kept (#NN)"
+- ADR: none — parameters (90 days, keep failed, boot-time) come from the
+  roadmap line; note them in the PR body.
+- Status/roadmap: remove the runs.db-retention bullet.

--- a/doc/dev/plans/hardening-backlog-2026-06/04-ntfy-alert-format.md
+++ b/doc/dev/plans/hardening-backlog-2026-06/04-ntfy-alert-format.md
@@ -1,0 +1,75 @@
+---
+plan: hardening-backlog-2026-06/04-ntfy-alert-format
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: fix/ntfy-alert-format
+pr: ""
+---
+
+# ntfy-friendly alert formatting
+
+## Goal
+
+`HealthMonitor._alert` POSTs `{"text": msg}` as JSON; on ntfy the phone
+notification shows the raw JSON blob. Send a plain-text body (ntfy renders
+it as the message) with `X-Title: dccd` and `X-Priority: high` headers,
+keeping the JSON `{"text": …}` shape for Slack-compatible endpoints
+(detected by host: `hooks.slack.com`).
+
+## Files to change
+
+- `dccd/application/monitor.py` — extract the webhook send from `_alert`
+  into a small private helper, e.g. `_post_webhook(self, msg: str) -> None`:
+  parse `urllib.parse.urlsplit(self._webhook).hostname`; if it is
+  `hooks.slack.com` (or ends with it) → current JSON behaviour; otherwise →
+  `data = msg.encode()`, headers `{"Content-Type": "text/plain",
+  "X-Title": "dccd", "X-Priority": "high"}`. Keep the existing try/except +
+  send-failure cooldown exactly as is. Update the class docstring's webhook
+  paragraph.
+- `dccd/tests/v3/` — monitor tests: check whether a monitor test file
+  exists (`grep -rl HealthMonitor dccd/tests/v3/`); extend it, else create
+  `test_monitor_webhook.py`.
+
+## Steps
+
+1. Refactor the send into `_post_webhook` (behaviour-preserving first), then
+   add the host-based format switch.
+2. Tests below; `pytest` + `ruff check dccd/`.
+
+## Tests
+
+Monkeypatch `urllib.request.urlopen` to capture the `Request` object:
+
+- `test_webhook_plain_text_for_ntfy` — webhook `https://ntfy.sh/topic`:
+  body == the raw message bytes (no JSON), `Content-Type: text/plain`,
+  `X-Title` and `X-Priority` headers present.
+- `test_webhook_json_for_slack` — webhook
+  `https://hooks.slack.com/services/X/Y/Z`: body is JSON with `text` key,
+  `Content-Type: application/json` (today's behaviour preserved).
+- `test_webhook_send_failure_still_cooled_down` — keep/extend the existing
+  failure-cooldown coverage if it exists; otherwise assert a raising
+  urlopen doesn't propagate.
+
+## Verification on real data
+
+- One-shot script against the **real production ntfy topic** (the user's
+  phone — one test message is acceptable and proves the chain):
+  instantiate `HealthMonitor` with the prod `webhook_url` read from the
+  server config over ssh, call the private send helper with a clearly
+  labelled test message ("dccd format test — ignore"), and confirm HTTP 200.
+  Visually: the phone shows the plain message, not a JSON blob (note this
+  for the user to confirm; the 200 + correct headers is the automated
+  check).
+
+## Closeout
+
+- CHANGELOG `Fixed`: "webhook alerts send a plain-text body with
+  `X-Title`/`X-Priority` for ntfy-style endpoints (the phone showed a raw
+  JSON blob); Slack webhooks (`hooks.slack.com`) keep the JSON `{\"text\"}`
+  payload (#NN)"
+- ADR: none — formatting fix; host-based detection noted in the docstring.
+- Status/roadmap: remove the ntfy bullet; this empties the Hardening
+  backlog down to the config export/load feature item (leave that one).


### PR DESCRIPTION
Plan tree for the bug-shaped items of the roadmap's **Hardening backlog**. The fifth backlog item (config export/load) is a feature and stays on the roadmap for a later epic.

## Goal

1. **remote-copy-not-sync** — `rclone copy` instead of the destructive `rclone sync`, so locally purged files survive on the remote for read-through restore. Unblocks `min_free_gb > 0`; critical now that the production store carries the full 2020→present history.
2. **duplicate-run-guard** — manual backfill triggers return the existing `run_id` instead of starting a concurrent duplicate.
3. **runs-db-retention** — boot-time deletion of terminal non-failed runs older than `settings.runs_retention_days` (default 90) + VACUUM.
4. **ntfy-alert-format** — plain-text alert body + `X-Title`/`X-Priority` for ntfy; JSON kept for Slack.

## Leaf checklist

- [ ] 01 remote-copy-not-sync — fix/remote-copy-not-sync — medium
- [ ] 02 duplicate-run-guard — fix/duplicate-run-guard — medium
- [ ] 03 runs-db-retention — feat/runs-db-retention — medium
- [ ] 04 ntfy-alert-format — fix/ntfy-alert-format — medium

Leaves are independent (disjoint files); executed serially, 01 first (standing data-loss risk).