### PR TITLE
fix: Live page stuck on "Loading…" with zero stream jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The **Live** page no longer hangs on "Loading…" when no stream jobs are
+  configured (a fresh install, or a backfill-only setup): the structure-change
+  guard initialised `lastSig` to `''`, which equals the signature of an empty
+  job set, so the very first `load()` matched and returned before the panes
+  ever rendered their "No … streams yet" empty state. `lastSig` now starts at
+  `null` so the first render always runs. (#159)
+
 ### Deprecated
 
 ### Removed

--- a/dccd/interfaces/ui/templates/live.html
+++ b/dccd/interfaces/ui/templates/live.html
@@ -32,7 +32,11 @@ let JOBS = [], RUNNING = {}, INV = [], openExchanges = {};
 // spec_id -> { value|bid|ask, ts(ns), live }. `live` marks a real-time SSE
 // sample; entries without it are seeded from on-disk data (last stored point).
 const samples = {};
-let lastSig = '';
+// `null`, not '' — with zero stream jobs the structure signature is also '',
+// so an '' sentinel made the very first load() match and short-circuit before
+// renderPane ever ran, leaving both panes stuck on "Loading…". null guarantees
+// the first load always renders (then the real signature governs later polls).
+let lastSig = null;
 
 function sid(s){ return String(s).replace(/[^a-zA-Z0-9]/g,'_'); }
 function invFor(j) {


### PR DESCRIPTION
## Bug

Open **Live** with no stream jobs configured (a fresh install, or a backfill-only setup) and both data-type panes stay on **"Loading…"** forever — the "No … streams yet" empty state never appears. This is exactly the first-launch experience.

## Cause

`load()` skips re-rendering when the job structure hasn't changed, guarded by a signature compare:

```js
let lastSig = '';            // initial
const sig = JOBS.map(...).join('|');
if (sig === lastSig) { refreshLiveness(); return; }   // short-circuit
```

With zero stream jobs, `sig` is also `''` — so on the **very first** `load()` the guard matches and returns *before* `renderPane()` ever runs. The panes keep their initial "Loading…" placeholder.

## Fix

Initialise `lastSig = null`. A real signature is always a string (possibly `''`), so the first `load()` can never match `null` and always renders; later polls compare strings and short-circuit correctly as before. One-line change in `live.html`.

## Verification

- `pytest -m "not network"` → **479 passed**; `ruff` clean.
- Headless browser on a store with no stream jobs: the trades pane now reads *"No trades streams yet. Use ＋ Add above to create one."*, zero "Loading…" left on the page, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)