### PR TITLE
fix: package self-hosted UI fonts in the wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Self-hosted UI fonts are now actually packaged in the wheel: `package-data`
+  listed only `static/*` (top level), which excluded the `static/fonts/`
+  subdirectory added for the visual refresh — a pip-installed UI would 404 on
+  its `.woff2` and silently fall back to system fonts. Verified by inspecting
+  the built wheel (6 woff2 present). (#160)
 - The **Live** page no longer hangs on "Loading…" when no stream jobs are
   configured (a fresh install, or a backfill-only setup): the structure-change
   guard initialised `lastSig` to `''`, which equals the signature of an empty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,11 @@ Changelog = "https://github.com/ArthurBernard/Download_Crypto_Currencies_Data/bl
 include = ["dccd*"]
 
 [tool.setuptools.package-data]
-"dccd.interfaces.ui" = ["templates/*.html", "templates/partials/*.html", "static/*"]
-"dccd.daemon.ui" = ["templates/*.html", "templates/partials/*.html", "static/*"]
+# `static/*` matches only the top level — nested asset dirs (e.g. self-hosted
+# `static/fonts/*.woff2`) must be listed explicitly or the wheel ships without
+# them and the UI 404s on its fonts.
+"dccd.interfaces.ui" = ["templates/*.html", "templates/partials/*.html", "static/*", "static/fonts/*"]
+"dccd.daemon.ui" = ["templates/*.html", "templates/partials/*.html", "static/*", "static/fonts/*"]
 
 [tool.pytest.ini_options]
 addopts = "--exitfirst -vv --capture=no --ignore=doc --ignore=examples --ignore=env --cov=dccd --cov-report=term-missing -m 'not network'"


### PR DESCRIPTION
## Bug

PR #158 added self-hosted fonts under `dccd/interfaces/ui/static/fonts/`, but `[tool.setuptools.package-data]` only listed `static/*` — which matches the top level of `static/` and **not** the `fonts/` subdirectory. The built wheel therefore ships **without** the woff2, so a pip-installed UI 404s on every `/static/fonts/*.woff2` and silently falls back to system fonts (the instrument-panel typography is lost in production, though the UI still works).

## Fix

Add `static/fonts/*` to `package-data` for both `dccd.interfaces.ui` and `dccd.daemon.ui`.

## Verification

Built the wheel locally before and after:

- before: `woff2 count: 0`
- after:  `woff2 count: 6` (all of martian-mono-{600,700}, spline-sans-{400,500,600,700})

`pytest -m "not network"` → 479 passed; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)