### PR TITLE
chore: release v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [3.6.0] - 2026-06-13
+
+### Added
+
+### Changed
+
 - The web UI **Dashboard** is now a health-first operations view: a status-chip
   line (fresh `<24h` / coverage gaps / failures-24h / last-collection), a
   **Needs attention** panel that surfaces failed runs (with their error reason)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.5.2"
+version = "3.6.0"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v3.6.0** — UI overhaul.


### Added

### Changed

- The web UI **Dashboard** is now a health-first operations view: a status-chip
  line (fresh `<24h` / coverage gaps / failures-24h / last-collection), a
  **Needs attention** panel that surfaces failed runs (with their error reason)
  and datasets with coverage gaps — each with a one-click **Retry/Fill gaps**
  when a configured job matches, else a deep-link to Historical — plus a
  compact Active-now, recent runs, and a per-exchange Data summary with
  freshness dots. Client-side only (inventory + runs + jobs); no API change.
  The Needs-attention panel intentionally treats OHLC coverage gaps as
  actionable (revising the scope of #132 for the triage surface). (#157)
- Web UI visual refresh ("instrument panel" direction), all in `base.html`
  tokens so every page inherits it: **self-hosted** Martian Mono (wordmark +
  section labels) and Spline Sans (body) woff2 served from `/static/fonts`
  (latin subset) — no external font CDN, works fully offline and leaks nothing;
  tabular figures in tables/chips/totals, machined-panel card depth, a faint
  top glow, and one staggered page-load reveal (`prefers-reduced-motion`
  respected). (#158)

### Fixed

- Self-hosted UI fonts are now actually packaged in the wheel: `package-data`
  listed only `static/*` (top level), which excluded the `static/fonts/`
  subdirectory added for the visual refresh — a pip-installed UI would 404 on
  its `.woff2` and silently fall back to system fonts. Verified by inspecting
  the built wheel (6 woff2 present). (#160)
- The **Live** page no longer hangs on "Loading…" when no stream jobs are
  configured (a fresh install, or a backfill-only setup): the structure-change
  guard initialised `lastSig` to `''`, which equals the signature of an empty
  job set, so the very first `load()` matched and returned before the panes
  ever rendered their "No … streams yet" empty state. `lastSig` now starts at
  `null` so the first render always runs. (#159)

### Deprecated

### Removed

## Test plan
- CI green on `develop` (tests 3.11–3.13, docs, lint).
- Wheel build verified to include the 6 self-hosted woff2 (#160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)