### PR TITLE
docs: groom dev docs for v3.6.0

### DIFF
--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -17,12 +17,13 @@ Three ways to drive it, all over the same core:
 
 ## Current state (snapshot)
 
-- **Version `3.0.0`** (in `pyproject.toml`), living on `develop`. The v3 work is a
-  full hexagonal rewrite that replaced the v2 daemon. **Not yet tagged/released**
-  on `master` — last published tag is `v2.4.0`.
+- **Version `3.6.0`** (in `pyproject.toml`), released on `master` and published to
+  PyPI (2026-06-13). The v3 work is a full hexagonal rewrite that replaced the v2
+  daemon; the v3 line began at `v3.0.0` (2026-06-07). `develop` and `master` are
+  level.
 - **Python 3.11–3.13** (CI matrix). `mypy` runs under 3.12 semantics (see
   `CLAUDE.md`), strict on `domain/`.
-- **~191 unit tests** (+3 network E2E, opt-in) — green; `ruff` and `mypy` clean;
+- **~480 unit tests** (+3 network E2E, opt-in) — green; `ruff` and `mypy` clean;
   Sphinx builds with 0 warnings.
 - **Seven exchanges**: binance, coinbase, kraken, bybit, okx, bitfinex, bitmex.
 - The web UI was reworked (2026-06) into **Data / Historical / Live** pages with

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -10,7 +10,7 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, schema, regressions (~191 tests; network excluded) |
+| **Unit** | `pytest` | logic, schema, regressions (~480 tests; network excluded) |
 | **Network E2E** | `pytest -m network` | real exchange APIs: pagination drains, symbol mapping, round-trip |
 | **Type** | `mypy dccd/` | strict on `domain/`, lenient glue (Success = green) |
 | **Lint** | `ruff check dccd/` | style, dead imports |

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -16,22 +16,28 @@ an agent doesn't re-investigate settled ground or assume missing things are bugs
   **removed** — the data is migrated; new installs start on the v3 schema.
 - **Web UI** (PR #76 + polish): Data / Historical / Live / Dashboard / Logs /
   Config / Storage; inline job CRUD; SSE liveness; order-book best bid/ask +
-  cadence fixed across all WS adapters.
+  cadence fixed across all WS adapters. **v3.6.0 overhaul**: the Dashboard is now
+  a health-first operations view (status chips + a "Needs attention" panel for
+  failed runs and coverage gaps, with one-click Retry/Fill), and a global
+  "instrument panel" visual refresh ships **self-hosted** fonts (Martian Mono +
+  Spline Sans woff2 under `static/fonts/`, no external CDN) via `base.html`
+  tokens (#157–#160).
 - **Security**: Bearer auth on `/api/*` when `ui_auth_token` is set; non-wildcard
   CORS via `ui_allow_origins`.
-- **Quality gates**: ~191 unit tests + 3 network E2E (opt-in); `ruff` + `mypy`
+- **Quality gates**: ~480 unit tests + 3 network E2E (opt-in); `ruff` + `mypy`
   clean; Sphinx 0 warnings; CI matrix 3.11–3.13.
-- **Released**: `v3.0.0` tagged on `master` (2026-06-07), superseding `v2.4.0` —
-  GitHub Release published. `develop` and `master` are level; the next feature
-  merge into `develop` reopens the rolling release PR (`/release next-cycle`).
+- **Released**: `v3.6.0` tagged on `master` (2026-06-13) — the latest in the v3
+  line that began with `v3.0.0` (2026-06-07). GitHub Release + PyPI publish on
+  tag. `develop` and `master` are level; the next feature merge into `develop`
+  reopens the rolling release PR (`/release next-cycle`).
 
 ## Pending
 
-_(nothing pending — v3.5.1 released 2026-06-12 and deployed on the production
-collector; the 2026-06-12 audit is fully closed: OKX history repaired by
-re-backfill — 46 528/46 528 bars, `missing_rows == 0` on all five pairs — and
-the boot orphan-sweep fix verified live, 20 stream runs `running` after
-restart)_
+_(nothing pending — **v3.6.0 (UI overhaul) released 2026-06-13 and deployed on
+the production collector**: dashboard redesign + instrument-panel visual refresh
+with self-hosted fonts (#157–#160). Verified live on arthurserver — woff2 served
+`200 font/woff2`, new templates installed, `polars-lts-cpu` preserved via a
+`--no-deps` upgrade. The prior v3.5.x audits remain closed.)_
 
 **Data architecture (2026-06-12): the production collector is the canonical
 store.** The full deep history (OHLC 1m back to 2020, ~2 GB) was seeded onto


### PR DESCRIPTION
Status-doc refresh for the v3.6.0 release + a `/groom-docs` pass over `doc/dev/`.

## Status (`06-status.md`)
- "Pending" → v3.6.0 (UI overhaul) released 2026-06-13 and **deployed** on the production collector (verified live: woff2 served `200`, templates updated, `polars-lts-cpu` preserved via `--no-deps`).
- Web UI bullet now notes the health-first Dashboard + instrument-panel visual refresh with self-hosted fonts (#157–#160).
- "Released" line → `v3.6.0` (2026-06-13); test count `~191` → `~480`.

## Groom drift fixes
- `01-overview.md`: **`Version 3.0.0` → `3.6.0`**, and "Not yet tagged/released — last tag `v2.4.0`" → released on `master` + PyPI; test count `~191` → `~480`.
- `05-testing.md`: unit test count `~191` → `~480`.

## Groom — verified OK (no change)
- Roadmap (`07`) accurate: finished epics tombstoned, open work = Config export/load + the M3 deferred axes.
- All referenced artifacts exist (`scripts/repair_kraken_okx.py`, the three `how-to/*.rst`).
- No dead content to tombstone; `02`/`04`/`README` carry no stale version/feature claims.
- Decision journal (`03`) is append-only and current (the 2026-06-13 ADR revising #132's scope is already in `develop`).

Docs-only (`doc/dev/` agent brief, not Sphinx sources); `pytest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)