### PR TITLE
chore: release v3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+## [3.6.1] - 2026-06-19
+
+### Fixed
+
 - `ParquetStore.save()` now rejects rows whose timestamp is null or `<= 0` at the
   storage write boundary (one central guard for every adapter and data type), so a
   lost/epoch-0 timestamp can no longer be persisted or poison gap detection — a
   single `TS=0` bar otherwise dragged `inventory()` `min_ts` to `1970` and inflated
   `expected_rows`/`missing_rows` to a bogus ~89 %. Dropped rows are logged, not
-  raised, so one bad bar can't abort a good page. (#XX)
-
-### Deprecated
-
-### Removed
+  raised, so one bad bar can't abort a good page. (#165)
 
 ## [3.6.0] - 2026-06-13
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -120,7 +120,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-06-19 — Reject invalid timestamps (TS<=0) at the storage write boundary (PR #XX)  [accepted]
+### 2026-06-19 — Reject invalid timestamps (TS<=0) at the storage write boundary (PR #165)  [accepted]
 - **Choice**: guard against corrupt timestamps **centrally in `ParquetStore.save()`**,
   filtering out rows whose `TS` is null or `<= 0` for every data type, rather than
   validating per-adapter. Drop the rows and log a warning — do not raise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.6.0"
+version = "3.6.1"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v3.6.1

Patch release — one data-integrity fix.

### Fixed
- `ParquetStore.save()` now rejects rows whose timestamp is null or `<= 0` at the storage write boundary (one central guard for every adapter and data type), so a lost/epoch-0 timestamp can no longer be persisted or poison gap detection — a single `TS=0` bar otherwise dragged `inventory()` `min_ts` to `1970` and inflated `expected_rows`/`missing_rows` to a bogus ~89 %. Dropped rows are logged, not raised, so one bad bar can't abort a good page. (#165)

Also links the #165 CHANGELOG/ADR entries (placeholder `#XX` → `#165`) and bumps `pyproject.toml` to `3.6.1`.

## Test plan
- [x] `pytest` green on develop (post-#165 merge)
- [ ] CI green on this branch