### PR TITLE
chore: release v3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+## [3.6.2] - 2026-06-20
+
+### Fixed
+
 - Kraken adapter maps pairs by **altname** (`{base}{quote}`, with `BTC→XBT` and
   `DOGE→XDG`) instead of legacy X/Z-prefixed codes, so OHLC and trades for modern
   Kraken assets (TRX, DOT, BNB, …) and Dogecoin no longer fail with `Unknown asset
   pair`. Legacy pairs are unaffected — Kraken accepts altnames universally and the
   response is parsed by its code-key fallback. (#169)
-
-### Deprecated
-
-### Removed
 
 ## [3.6.1] - 2026-06-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dccd"
-version = "3.6.1"
+version = "3.6.2"
 description = "Download Crypto Currency Data — hexagonal architecture, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v3.6.2

Patch release — one fix.

### Fixed
- Kraken adapter maps pairs by **altname** (`{base}{quote}`, `BTC→XBT`, `DOGE→XDG`) instead of legacy X/Z-prefixed codes, so OHLC/trades for modern Kraken assets (TRX, DOT, BNB, …) and Dogecoin no longer fail with `Unknown asset pair`. (#169)

Bumps `pyproject.toml` to `3.6.2`.

## Test plan
- [x] `pytest` green on develop (post-#169)
- [ ] CI green on this branch