### PR TITLE
docs: plan audit-fixes-20260620

### DIFF
--- a/doc/dev/plans/audit-fixes-20260620/00-plan.md
+++ b/doc/dev/plans/audit-fixes-20260620/00-plan.md
@@ -1,0 +1,46 @@
+---
+plan: audit-fixes-20260620
+kind: global
+status: planning
+roadmap: "none — surfaced by the 2026-06-20 arthurserver health audit (not a roadmap item)"
+release_on_done: true
+---
+
+# Audit fixes (2026-06-20 server audit)
+
+## Goal
+Two small, independent robustness fixes surfaced by the 2026-06-20 production
+audit of arthurserver. Both are real but low-frequency and self-healing; neither
+threatens data. "Done" = both shipped, a `3.6.3` patch released, and the server
+redeployed so the two error signatures stop appearing in the journal.
+
+The audit also produced **operational cleanup** (purge 7 orphan datasets with no
+feeding job; repopulate the empty UI-token convenience file) — that is server-side
+housekeeping, done directly out-of-band, *not* part of this code plan.
+
+## Decomposition
+1. **http-client-close-race** — `AsyncHTTPClient.__aexit__` awaits `aclose()`
+   *before* nulling `self._client`, so during that await a concurrent
+   `__aenter__` reuses the dying client → "Cannot send a request, as the client
+   has been closed." (~1 scheduled backfill failure/day, across binance/okx/kraken).
+2. **login-nonascii-token** — `POST /login` calls `secrets.compare_digest` on two
+   `str`s; a non-ASCII submitted token makes it raise `TypeError`, returning a 500
+   instead of a clean invalid-login (scanner/bot hits on the tailnet port).
+
+## Leaf checklist
+- [ ] 01 http-client-close-race — fix/http-client-close-race — medium
+- [ ] 02 login-nonascii-token — fix/login-nonascii-token — low
+
+## Dependencies
+- None. 01 and 02 touch disjoint files (`transport/http.py` vs
+  `interfaces/api/app.py`) and could run in parallel; executed serially here (safe
+  default).
+
+## Done criteria
+- `transport/http.py` nulls the shared client reference before awaiting `aclose()`;
+  a deterministic regression test reproduces the old race and passes with the fix.
+- `POST /login` no longer raises on a non-ASCII token (returns the login error
+  page); a TestClient regression test covers it.
+- `pytest` + `ruff check dccd/` green; both fixes shipped in `v3.6.3` and the
+  server redeployed (`pip install --no-deps --upgrade dccd==3.6.3`, polars-lts-cpu
+  preserved).

--- a/doc/dev/plans/audit-fixes-20260620/01-http-client-close-race.md
+++ b/doc/dev/plans/audit-fixes-20260620/01-http-client-close-race.md
@@ -1,0 +1,82 @@
+---
+plan: audit-fixes-20260620/01-http-client-close-race
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: true
+branch: fix/http-client-close-race
+pr: ""
+---
+
+# Close the shared-HTTP-client refcount race
+
+## Goal
+`AsyncHTTPClient.__aexit__` must not leave the dying client reachable while it is
+being closed. Null `self._client` (and reset depth) *before* awaiting `aclose()`,
+so a concurrent `__aenter__` during that await creates a fresh client instead of
+reusing the closing one.
+
+## Background (the race)
+`__aexit__` currently does, when depth hits 0:
+```python
+self._depth = 0
+await self._client.aclose()   # yields control
+self._client = None           # only nulled AFTER the await
+```
+While `aclose()` awaits, another scheduled job's `__aenter__` sees
+`self._client is not None`, skips creation, bumps depth to 1, and then `.get()`s a
+closing/closed client → `httpx` raises "Cannot send a request, as the client has
+been closed." Observed ~1×/day on arthurserver across binance/okx/kraken OHLC
+backfills (each backs off 3600 s and self-heals). The refcount was meant to make
+the shared client concurrency-safe (a documented invariant), but the
+null-after-await ordering leaves a hole.
+
+## Files to change
+- `dccd/transport/http.py` — in `__aexit__`, capture the client into a local,
+  null `self._client` and reset `self._depth = 0`, *then* `await client.aclose()`.
+  Update the inline comment to state the ordering matters (null-before-await closes
+  the re-entry window).
+
+## Steps
+1. Rewrite the `__aexit__` body to:
+   ```python
+   self._depth -= 1
+   if self._depth <= 0 and self._client is not None:
+       self._depth = 0
+       client = self._client
+       self._client = None      # null BEFORE awaiting: a concurrent __aenter__
+       await client.aclose()    # during aclose() then builds a FRESH client
+   ```
+2. Keep `__aenter__` unchanged (it already creates a client when `self._client is
+   None`).
+
+## Tests
+- `dccd/tests/v3/test_transport.py` — add an async regression test that
+  deterministically reproduces the race with a fake client whose `aclose()` yields
+  (`await asyncio.sleep(0)`/event) so a concurrent `__aenter__` interleaves:
+  - monkeypatch `httpx.AsyncClient` with a `FakeClient` that records `closed` and
+    whose `aclose()` awaits before setting `closed=True`;
+  - enter once (depth 1, client = fake1); start `__aexit__()` as a task; yield;
+    concurrently `__aenter__()` again;
+  - assert the client observed after the concurrent enter is **not None and not
+    closed** (i.e. a fresh client), and that fake1 still gets closed.
+  - With the old ordering this fails (concurrent enter reuses fake1, which is then
+    closed and nulled); with the fix it passes.
+
+## Verification on real data
+- After release + deploy: tail the server journal for ≥1 backfill cycle and
+  confirm no new `Cannot send a request, as the client has been closed.` lines
+  appear, and the previously-stale kraken DOGE-BTC OHLC resumes (fresh `max_ts`
+  within the hourly cadence). Pre-deploy, the deterministic unit test is the
+  primary evidence (the race is timing-dependent on live data).
+
+## Closeout
+- CHANGELOG (`Fixed`): "`AsyncHTTPClient.__aexit__` nulls the shared client
+  reference before awaiting `aclose()`, closing a refcount race where a concurrent
+  request reused the closing client (`Cannot send a request, as the client has
+  been closed`). (#NN)"
+- ADR: yes — record the null-before-await ordering as the chosen fix over
+  alternatives (a lock around enter/exit; never closing the client). Concurrency
+  invariant.
+- Status/roadmap: no roadmap line; deferred to last leaf (none to remove).

--- a/doc/dev/plans/audit-fixes-20260620/02-login-nonascii-token.md
+++ b/doc/dev/plans/audit-fixes-20260620/02-login-nonascii-token.md
@@ -1,0 +1,61 @@
+---
+plan: audit-fixes-20260620/02-login-nonascii-token
+kind: leaf
+status: planned
+complexity: low
+depends: []
+parallel: true
+branch: fix/login-nonascii-token
+pr: ""
+---
+
+# Make /login total on non-ASCII tokens
+
+## Goal
+`POST /login` must return the normal invalid-login response for a non-ASCII
+submitted token, not a 500. `secrets.compare_digest` raises
+`TypeError: comparing strings with non-ASCII characters is not supported` when
+given a `str` with non-ASCII bytes; compare on `bytes` instead.
+
+## Background
+`dccd/interfaces/api/app.py:921`:
+```python
+if not token or not secrets.compare_digest(submitted, token):
+```
+`submitted` comes from the urlencoded form (`decode("utf-8", "replace")`) so it can
+contain non-ASCII; `compare_digest(str, str)` then raises `TypeError` → unhandled →
+500 (observed 2×/7d on the tailnet port, fail-closed, no auth bypass — but a 500
+traceback instead of a clean rejection). `_valid_session` was checked and is **not**
+affected (it does `sid in app.state.sessions`, no `compare_digest`). Line 921 is the
+only `compare_digest` call.
+
+## Files to change
+- `dccd/interfaces/api/app.py` — line ~921: compare UTF-8 bytes:
+  ```python
+  if not token or not secrets.compare_digest(submitted.encode("utf-8"), token.encode("utf-8")):
+  ```
+  (`bytes` comparison is total; preserves constant-time semantics.)
+
+## Steps
+1. Encode both operands to `utf-8` bytes in the `compare_digest` call at the
+   `POST /login` handler. No other logic changes.
+
+## Tests
+- `dccd/tests/v3/test_api.py` — add a TestClient case: with `ui_auth_token`
+  configured, `POST /login` with `token=<non-ASCII string, e.g. "héllo€">` returns
+  **200 and the login error page** (or whatever the existing wrong-token case
+  asserts), **never 500**. Optionally assert the existing valid-token login still
+  sets the session cookie (no regression).
+
+## Verification on real data
+- After release + deploy: `curl -s -o /dev/null -w "%{http_code}" -X POST
+  --data 'token=hé€llo' http://127.0.0.1:8080/login` on the server returns 200 (not
+  500), and the journal shows no new `TypeError: comparing strings with non-ASCII`
+  ASGI exception.
+
+## Closeout
+- CHANGELOG (`Fixed`): "`POST /login` no longer returns 500 on a non-ASCII
+  submitted token — `secrets.compare_digest` is given UTF-8 bytes, so a malformed
+  token is rejected cleanly instead of raising `TypeError`. (#NN)"
+- ADR: none — mechanical robustness fix (bytes compare is the obvious total form).
+- Status/roadmap: no roadmap line; nothing to remove.


### PR DESCRIPTION
## Summary
Durable plan tree for the two robustness fixes surfaced by the 2026-06-20 arthurserver health audit.

## Goal
Two small, independent fixes; ship a `3.6.3` patch and redeploy so the two error signatures stop appearing in the journal.

## Leaf checklist
- [ ] 01 http-client-close-race — `fix/http-client-close-race` — medium — `AsyncHTTPClient.__aexit__` awaits `aclose()` before nulling `self._client`, so a concurrent `__aenter__` reuses the closing client → *"Cannot send a request, as the client has been closed"* (~1 backfill/day, binance/okx/kraken).
- [ ] 02 login-nonascii-token — `fix/login-nonascii-token` — low — `POST /login` calls `secrets.compare_digest` on `str`s; a non-ASCII token raises `TypeError` → 500 instead of a clean invalid-login.

Operational cleanup (purge 7 orphan datasets, repopulate the empty UI-token file) is done out-of-band on the server, not part of this code plan.

## Test plan
- [x] Plan files only (docs); no code changes
- [ ] CI green